### PR TITLE
Add: front depth camera to urdf

### DIFF
--- a/src/lunabot_description/urdf/lunabot.urdf.xacro
+++ b/src/lunabot_description/urdf/lunabot.urdf.xacro
@@ -52,4 +52,60 @@
         <visualize>false</visualize>
     </sensor>
     </gazebo>
+
+    <link name="camera_front_link">
+    <visual>
+      <geometry>
+        <cylinder length="0.05" radius="0.03"/>
+      </geometry>
+      <material name="dark_grey">
+        <color rgba="0.2 0.2 0.2 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <geometry>
+        <cylinder length="0.05" radius="0.03"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
+    </inertial>
+  </link>
+
+    <joint name="camera_front_joint" type="fixed">
+      <parent link="base_link"/>
+      <child link="camera_front_link"/>
+      <origin xyz="0.12 0.0 0.05" rpy="0 0.3 0"/>
+    </joint>
+
+    <link name="camera_front_optical_frame"/>
+    
+    <joint name="camera_front_optical_joint" type="fixed">
+      <parent link="camera_front_link"/>
+      <child link="camera_front_optical_frame"/>
+      <origin xyz="0 0 0" rpy="-${pi/2} 0.0 -${pi/2}"/>
+    </joint>
+
+      
+
+    <gazebo reference="camera_front_link">
+      <sensor name="camera_front" type="rgbd_camera">
+      <camera>
+        <horizontal_fov>1.57</horizontal_fov>
+        <image>
+          <width>640</width>
+          <height>480</height>
+        </image>
+        <clip>
+          <near>0.1</near>
+          <far>10</far>
+        </clip>
+      </camera>
+      <always_on>1</always_on>
+      <update_rate>5</update_rate>
+      <topic>camera_front</topic>
+        <gz_frame_id>camera_front_link</gz_frame_id>
+      </sensor>
+    </gazebo>
 </robot>

--- a/src/lunabot_simulation/launch/moon_yard.launch.py
+++ b/src/lunabot_simulation/launch/moon_yard.launch.py
@@ -81,18 +81,19 @@ def generate_launch_description():
             "/joint_states@sensor_msgs/msg/JointState[ignition.msgs.Model",
             "/camera/camera_info@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo",
             "/scan@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan",
+            "/camera_front/camera_info@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo",
+            "/camera_front/points@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked",
         ],
         output="screen",
     )
-    # camera feed taking up too many resources
 
-    # image_bridge = Node(
-    #     package="ros_gz_image",
-    #     executable="image_bridge",
-    #     name="image_bridge",
-    #     arguments=["/camera/image_raw"],
-    #     output="screen",
-    # )
+    image_bridge = Node(
+        package="ros_gz_image",
+        executable="image_bridge",
+        name="image_bridge",
+        arguments=["/camera_front/image", "/camera_front/depth_image"],
+        output="screen",
+    )
 
     return LaunchDescription(
         [
@@ -101,6 +102,6 @@ def generate_launch_description():
             spawn_robot,
             clock_bridge,
             robot_bridge,
-            # image_bridge,
+            image_bridge,
         ]
     )


### PR DESCRIPTION
When trying to use the cameras front optical frame in the gazebo frame ID, the depth scan rendered really weirdly. The camera itself worked fine.

Switching to camera_front_link fixed it.