### PR TITLE
add: official ros tooling ci tools

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-# Ignore purely stylistic rules that don't catch bugs:
-# - Q000: single vs double quotes preference
-# - I1xx: import ordering (let auto-formatters handle this)
-extend-ignore = Q000, I100, I101, I201, I202

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
       - '.rules/**'
       - 'LICENSE'
       - '.gitignore'
@@ -13,7 +13,7 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
       - '.rules/**'
       - 'LICENSE'
       - '.gitignore'
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build and test
-        uses: ros-tooling/action-ros-ci@v0.4
+        uses: ros-tooling/action-ros-ci@c8bee402c95e6b4a47c9bb5ce69de4c692128d3a # v0.4
         with:
           package-name: >
             lunabot_bringup

--- a/src/lunabot_bringup/setup.cfg
+++ b/src/lunabot_bringup/setup.cfg
@@ -2,3 +2,6 @@
 script_dir=$base/lib/lunabot_bringup
 [install]
 install_scripts=$base/lib/lunabot_bringup
+
+[flake8]
+extend-ignore = Q000, I100, I101, I201, I202

--- a/src/lunabot_control/setup.cfg
+++ b/src/lunabot_control/setup.cfg
@@ -2,3 +2,6 @@
 script_dir=$base/lib/lunabot_control
 [install]
 install_scripts=$base/lib/lunabot_control
+
+[flake8]
+extend-ignore = Q000, I100, I101, I201, I202

--- a/src/lunabot_localisation/setup.cfg
+++ b/src/lunabot_localisation/setup.cfg
@@ -2,3 +2,6 @@
 script_dir=$base/lib/lunabot_localisation
 [install]
 install_scripts=$base/lib/lunabot_localisation
+
+[flake8]
+extend-ignore = Q000, I100, I101, I201, I202

--- a/src/lunabot_navigation/setup.cfg
+++ b/src/lunabot_navigation/setup.cfg
@@ -2,3 +2,6 @@
 script_dir=$base/lib/lunabot_navigation
 [install]
 install_scripts=$base/lib/lunabot_navigation
+
+[flake8]
+extend-ignore = Q000, I100, I101, I201, I202

--- a/src/lunabot_perception/setup.cfg
+++ b/src/lunabot_perception/setup.cfg
@@ -2,3 +2,6 @@
 script_dir=$base/lib/lunabot_perception
 [install]
 install_scripts=$base/lib/lunabot_perception
+
+[flake8]
+extend-ignore = Q000, I100, I101, I201, I202

--- a/src/lunabot_simulation/.flake8
+++ b/src/lunabot_simulation/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+extend-ignore = Q000, I100, I101, I201, I202

--- a/src/lunabot_teleop/setup.cfg
+++ b/src/lunabot_teleop/setup.cfg
@@ -2,3 +2,6 @@
 script_dir=$base/lib/lunabot_teleop
 [install]
 install_scripts=$base/lib/lunabot_teleop
+
+[flake8]
+extend-ignore = Q000, I100, I101, I201, I202


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR integrates official ROS tooling into the CI/CD pipeline and standardizes code linting configuration across the project.

### Key Changes:

**CI/CD Pipeline Updates:**
- Replaced custom CI workflow with the official `ros-tooling/action-ros-ci` action for standardized ROS 2 build and test processes
- Updated container image to use the official ROS tooling setup image (`setup-ros-docker-ubuntu-jammy`)
- Expanded CI to test all lunabot_* packages (bringup, control, description, localisation, navigation, perception, simulation, teleop)
- Added path filters to ignore documentation and non-code files in CI triggers

**Code Linting Configuration:**
- Added Flake8 configuration to all ROS 2 packages to ignore specific linting codes (Q000, I100, I101, I201, I202) that conflict with standard code formatters like Black and isort
- Ensures consistent linting behavior across the codebase
<!-- end of auto-generated comment: release notes by coderabbit.ai -->