### PR TITLE
add: bootstrap mission BT shell for Nav2

### DIFF
--- a/src/lunabot_navigation/behavior_trees/mission_navigate_to_pose_bt.xml
+++ b/src/lunabot_navigation/behavior_trees/mission_navigate_to_pose_bt.xml
@@ -1,0 +1,65 @@
+<root BTCPP_format="4" main_tree_to_execute="MissionNavigateToPoseShell">
+  <BehaviorTree ID="MissionNavigateToPoseShell">
+    <Sequence name="MissionShellSequence">
+      <!-- TODO(issue#107): Replace this placeholder with a real readiness condition node/service check. -->
+      <AlwaysSuccess name="ReadinessPlaceholder"/>
+
+      <RecoveryNode number_of_retries="3" name="NavigateRecoveryShell">
+        <PipelineSequence name="NavigateWithReplanning">
+          <ControllerSelector
+            selected_controller="{selected_controller}"
+            default_controller="FollowPath"
+            topic_name="controller_selector"/>
+          <PlannerSelector
+            selected_planner="{selected_planner}"
+            default_planner="GridBased"
+            topic_name="planner_selector"/>
+
+          <RateController hz="1.0">
+            <RecoveryNode number_of_retries="1" name="ComputePathToPoseShell">
+              <ComputePathToPose
+                goal="{goal}"
+                path="{path}"
+                planner_id="{selected_planner}"
+                error_code_id="{compute_path_error_code}"
+                error_msg="{compute_path_error_msg}"/>
+              <ClearEntireCostmap
+                name="ClearGlobalCostmapContext"
+                service_name="global_costmap/clear_entirely_global_costmap"/>
+            </RecoveryNode>
+          </RateController>
+
+          <RecoveryNode number_of_retries="1" name="FollowPathShell">
+            <FollowPath
+              path="{path}"
+              controller_id="{selected_controller}"
+              error_code_id="{follow_path_error_code}"
+              error_msg="{follow_path_error_msg}"/>
+            <ClearEntireCostmap
+              name="ClearLocalCostmapContext"
+              service_name="local_costmap/clear_entirely_local_costmap"/>
+          </RecoveryNode>
+        </PipelineSequence>
+
+        <ReactiveFallback name="RecoveryFallbackShell">
+          <GoalUpdated/>
+          <RoundRobin name="RecoveryActionsShell">
+            <Sequence name="ClearCostmapsShell">
+              <ClearEntireCostmap
+                name="ClearLocalCostmapSubtree"
+                service_name="local_costmap/clear_entirely_local_costmap"/>
+              <ClearEntireCostmap
+                name="ClearGlobalCostmapSubtree"
+                service_name="global_costmap/clear_entirely_global_costmap"/>
+            </Sequence>
+            <Spin spin_dist="1.57"/>
+            <Wait wait_duration="3.0"/>
+            <BackUp backup_dist="0.20" backup_speed="0.10"/>
+          </RoundRobin>
+        </ReactiveFallback>
+      </RecoveryNode>
+
+      <!-- TODO(issue#107): Add mission-level branches (excavate/deposit/cycle) as BT subtrees. -->
+    </Sequence>
+  </BehaviorTree>
+</root>

--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -5,7 +5,9 @@
 bt_navigator:
   ros__parameters:
     use_sim_time: true
-    default_bt_xml_filename: "navigate_to_pose_w_replanning_and_recovery.xml"
+    # BT shell for mission orchestration bootstrap.
+    # TODO(issue#107, @junaid): evolve this tree with readiness check node + mission subtrees.
+    default_nav_to_pose_bt_xml: "$(find-pkg-share lunabot_navigation)/behavior_trees/mission_navigate_to_pose_bt.xml"
 
 # controller server with RPP
 controller_server:

--- a/src/lunabot_navigation/setup.py
+++ b/src/lunabot_navigation/setup.py
@@ -13,6 +13,10 @@ setup(
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         ("share/" + package_name, ["package.xml"]),
         (os.path.join("share", package_name, "config"), glob("config/*.yaml")),
+        (
+            os.path.join("share", package_name, "behavior_trees"),
+            glob("behavior_trees/*.xml"),
+        ),
     ],
     install_requires=["setuptools"],
     zip_safe=True,


### PR DESCRIPTION
## Summary
This PR adds a minimal, safe scaffold for BT-first mission orchestration so follow-up assignees can iterate in small PRs.

## What is included
- Adds BT shell XML: src/lunabot_navigation/behavior_trees/mission_navigate_to_pose_bt.xml
- Wires bt_navigator to this tree via default_nav_to_pose_bt_xml
- Installs BT XML files in navigation package setup
- Adds in-file TODO markers linked to issue #107 for handoff

## Intentionally not included
- No readiness implementation yet (placeholder only)
- No mission subtrees (excavate/deposit/cycle) yet

## Validation
- XML syntax parse check passed locally
- Changes scoped to navigation package only

## Tracking
- Epic issue: #107
- Handoff note posted and tagged in issue comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces a foundational behavior tree (BT) scaffold for Nav2 mission orchestration, enabling future navigation mission logic in smaller, incremental PRs.

## Changes

**New Behavior Tree Definition**
- Adds `mission_navigate_to_pose_bt.xml` as a minimal BT structure for mission-based navigation to pose with recovery capabilities. The tree includes placeholders for future mission subtrees (excavate, deposit, cycle) and TODO markers linked to issue #107.

**Configuration Updates**
- Updates Nav2 parameters in `nav2_params.yaml` to reference the new mission BT XML file, replacing the previous default behavior tree configuration.

**Package Setup**
- Extends `setup.py` to include BT XML files in package data, ensuring behavior tree definitions are installed alongside the navigation package.

## Scope & Validation

- Changes are isolated to the navigation package only
- XML syntax validated locally  
- Intentionally excludes mission-level implementations (readiness logic, mission subtrees) to keep the PR scope minimal and enable follow-up work

<!-- end of auto-generated comment: release notes by coderabbit.ai -->