### PR TITLE
add package-level READMEs for navigation stack orientation

### DIFF
--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -1,0 +1,25 @@
+# lunabot_bringup
+
+This package contains launch entrypoints that start integrated stack configurations.
+
+## What this package is responsible for
+
+`lunabot_bringup` is the operational entrypoint package. It composes localisation, perception, planning, and control-related nodes into runnable launch flows for testing and operation.
+
+## Typical usage
+
+Use bring-up launches when validating end-to-end behaviour. Avoid debugging subsystem-level issues from partial ad-hoc launches unless intentionally isolating one component.
+
+## Key files
+
+- `launch/`: stack launch entrypoints (navigation and related orchestration paths).
+
+## Common failure modes
+
+- Launch starts successfully but one critical node crashes shortly after (dependency mismatch).
+- Lifecycle nodes stay unconfigured due to invalid params in one server config.
+- Nodes appear alive but key topic links fail due to QoS incompatibility.
+
+## Where to read next
+
+- Wiki: [Operations](https://github.com/KJdotIO/innex1-rover/wiki/Operations), [SoftwareArchitecture](https://github.com/KJdotIO/innex1-rover/wiki/SoftwareArchitecture), [Autonomy-cycle-walkthrough](https://github.com/KJdotIO/innex1-rover/wiki/Autonomy-cycle-walkthrough), [Contracts](https://github.com/KJdotIO/innex1-rover/wiki/Contracts)

--- a/src/lunabot_localisation/README.md
+++ b/src/lunabot_localisation/README.md
@@ -1,0 +1,30 @@
+# lunabot_localisation
+
+This package contains localisation launch/config and localisation helper nodes for the rover stack.
+
+## What this package is responsible for
+
+`lunabot_localisation` provides fused localisation outputs consumed by planning and mapping components. It owns configuration around EKF-based local/global pose estimation and tag-based correction paths.
+
+## Core outputs
+
+- Local fused odometry for navigation smoothness.
+- Global correction path through tag-derived pose updates.
+- TF relationships required by planning components.
+
+## Key files
+
+- `config/ekf.yaml`: EKF fusion and frame configuration.
+- `launch/localisation.launch.py`: localisation bring-up path.
+- `lunabot_localisation/tag_pose_publisher.py`: bridge from tag detections to pose updates.
+
+## Common failure modes
+
+- Frame mismatch (`base_link` vs `base_footprint`) causing downstream planner instability.
+- Covariances set unrealistically low, making the filter overconfident.
+- Missing tag detections causing global drift to accumulate over longer runs.
+
+## Where to read next
+
+- Wiki: [Localisation](https://github.com/KJdotIO/innex1-rover/wiki/Localisation), [Extended Kalman Filtering Algorithm (EKF)](https://github.com/KJdotIO/innex1-rover/wiki/Extended-Kalman-Filtering-Algorithm-(EKF)), [Design-decisions](https://github.com/KJdotIO/innex1-rover/wiki/Design-decisions), [Contracts](https://github.com/KJdotIO/innex1-rover/wiki/Contracts)
+- External references: [robot_localization package overview](https://index.ros.org/p/robot_localization/), [robot_localization GPS integration notes](https://docs.ros.org/en/noetic/api/robot_localization/html/integrating_gps.html), [REP-105](https://www.ros.org/reps/rep-0105.html), [Nav2 odometry setup guide](https://docs.nav2.org/setup_guides/odom/setup_robot_localization.html)

--- a/src/lunabot_navigation/README.md
+++ b/src/lunabot_navigation/README.md
@@ -1,0 +1,36 @@
+# lunabot_navigation
+
+This package contains Nav2 configuration and mission navigation behaviour tree assets used by the rover navigation stack.
+
+## What this package is responsible for
+
+`lunabot_navigation` defines how Nav2 plans and follows paths in this project. It does not estimate localisation and it does not detect hazards directly. It consumes those outputs from localisation and perception.
+
+## Inputs this package depends on
+
+At runtime, navigation expects:
+- fused odometry from localisation (`/odometry/filtered`),
+- TF chain including `map`, `odom`, `base_footprint`,
+- hazard/depth observation sources used by costmaps,
+- configured mission or operator navigation goals.
+
+## Key files
+
+- `config/nav2_params.yaml`: Nav2 planners, controller, costmaps, and BT navigator config.
+- `behavior_trees/mission_navigate_to_pose_bt.xml`: current mission BT shell used for scaffolded orchestration.
+
+## Current status
+
+The BT configuration in this package is a shell intended for incremental development. It is designed to be safe, readable, and easy to extend in follow-up PRs.
+
+## Common failure modes
+
+- BT XML path configured but file not installed into share directory.
+- Costmaps not receiving expected observation topics.
+- TF mismatch between localisation outputs and Nav2 frame config.
+- Controller/planner parameters tuned for a different environment.
+
+## Where to read next
+
+- Wiki: [SoftwareArchitecture](https://github.com/KJdotIO/innex1-rover/wiki/SoftwareArchitecture), [Planning](https://github.com/KJdotIO/innex1-rover/wiki/Planning), [StateManagement](https://github.com/KJdotIO/innex1-rover/wiki/StateManagement), [Design-decisions](https://github.com/KJdotIO/innex1-rover/wiki/Design-decisions), [Contracts](https://github.com/KJdotIO/innex1-rover/wiki/Contracts)
+- Issue tracker epic for BT orchestration: https://github.com/KJdotIO/innex1-rover/issues/107

--- a/src/lunabot_perception/README.md
+++ b/src/lunabot_perception/README.md
@@ -1,0 +1,28 @@
+# lunabot_perception
+
+This package contains perception nodes that convert sensor streams into navigation-relevant observations.
+
+## What this package is responsible for
+
+`lunabot_perception` turns front depth inputs into hazard observations that Nav2 costmaps can consume. It does not perform global planning and it does not own mission sequencing.
+
+## Core responsibilities
+
+- Process depth point clouds into hazard outputs.
+- Publish obstacle observations with stable topics and frames.
+- Support tuning of hazard extraction behaviour for competition terrain.
+
+## Key files
+
+- `lunabot_perception/hazard_detection.py`: hazard extraction node.
+
+## Common failure modes
+
+- Missing runtime dependencies (for example `open3d` in environments still using the older implementation path).
+- QoS mismatch with upstream camera topics.
+- Frame mismatch causing hazards to appear in incorrect locations.
+
+## Where to read next
+
+- Wiki: [Perception](https://github.com/KJdotIO/innex1-rover/wiki/Perception), [Sensors](https://github.com/KJdotIO/innex1-rover/wiki/Sensors), [SoftwareArchitecture](https://github.com/KJdotIO/innex1-rover/wiki/SoftwareArchitecture), [Contracts](https://github.com/KJdotIO/innex1-rover/wiki/Contracts)
+- External reference: [ROS 2 QoS overview](https://docs.ros.org/en/humble/Concepts/Intermediate/About-Quality-of-Service-Settings.html)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds package-level README files for the navigation stack packages to improve documentation and user navigation:

- **lunabot_bringup**: Describes the operational entrypoint that composes localisation, perception, planning, and control nodes, including typical usage and recommended reading paths.
- **lunabot_localisation**: Documents the localisation package's purpose, core outputs, key files, and common failure modes.
- **lunabot_navigation**: Describes Nav2 planning and mission navigation capabilities, inputs, current status as an incremental development scaffold, and common failure modes.
- **lunabot_perception**: Documents the perception package's role in hazard detection from depth clouds, core responsibilities, key files, and dependency/configuration issues.

Each README includes common failure modes and references for further reading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->