### PR TITLE
Fix Nav2 default BT XML path

### DIFF
--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -5,7 +5,7 @@
 bt_navigator:
   ros__parameters:
     use_sim_time: true
-    default_nav_to_pose_bt_xml: "navigate_to_pose_w_replanning_and_recovery.xml"
+    default_nav_to_pose_bt_xml: "$(find-pkg-share nav2_bt_navigator)/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml"
 
 # controller server with RPP
 controller_server:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes the Nav2 behavior tree XML path configuration by providing the full qualified path to the behavior tree file instead of relying on just the filename.

## Changes
Updated the `default_nav_to_pose_bt_xml` parameter in the Nav2 configuration to use the full path with the `$(find-pkg-share)` substitution:
- Changed from: `"navigate_to_pose_w_replanning_and_recovery.xml"`
- Changed to: `"$(find-pkg-share nav2_bt_navigator)/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml"`

This ensures the behavior tree XML file is correctly located regardless of the ROS package installation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->