### PR TITLE
Adjust front camera geometry for sim testing

### DIFF
--- a/src/lunabot_description/urdf/lunabot.urdf.xacro
+++ b/src/lunabot_description/urdf/lunabot.urdf.xacro
@@ -107,7 +107,10 @@
     <joint name="camera_front_joint" type="fixed">
       <parent link="base_link" />
       <child link="camera_front_link" />
-      <origin xyz="0.12 0.0 0.05" rpy="0 0.3 0" />
+      <!-- Purdue-like geometry: farther forward, higher, and more downward
+           than the old low bumper-mounted view, while staying less extreme
+           than the much steeper COD-style front camera. -->
+      <origin xyz="0.22 0.0 0.22" rpy="0 0.5 0" />
     </joint>
 
     <link name="camera_front_rgb_link" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adjusts the front camera geometry in the robot's URDF description to optimize for simulation testing. The camera is repositioned to a "Purdue-like geometry" that places it farther forward, higher on the rover, and with increased downward tilt—balancing between a low bumper-mounted view and more extreme steeper camera configurations. This change improves camera viewpoint for better testing and perception in simulation environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->