### PR TITLE
nav2: tune obstacle robustness for sparse lidar

### DIFF
--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -11,22 +11,22 @@ bt_navigator:
 controller_server:
   ros__parameters:
     use_sim_time: true
-    controller_frequency: 20.0
+    controller_frequency: 12.0
     controller_plugins: ["FollowPath"]
 
     # choosing RPP
     FollowPath:
       plugin: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"
-      max_linear_vel: 0.18 # keep the robot inside the pointcloud refresh envelope
-      desired_linear_vel: 0.18 # fallback if max_linear_vel is ignored
-      max_angular_vel: 0.5 # prevents aggressive turning
-      lookahead_dist: 0.45
-      min_approach_linear_velocity: 0.08
+      max_linear_vel: 0.14 # stay inside the effective simulated lidar refresh envelope
+      desired_linear_vel: 0.14 # fallback if max_linear_vel is ignored
+      max_angular_vel: 0.4 # softer turning helps prevent drift-driven obstacle misses
+      lookahead_dist: 0.35
+      min_approach_linear_velocity: 0.05
       use_cost_regulated_linear_velocity_scaling: true
-      cost_scaling_dist: 0.30
+      cost_scaling_dist: 0.40
       cost_scaling_gain: 0.6
       inflation_cost_scaling_factor: 4.0
-      regulated_linear_scaling_min_speed: 0.12
+      regulated_linear_scaling_min_speed: 0.08
       max_allowed_time_to_collision_up_to_carrot: 0.75
 
 # planner server
@@ -83,7 +83,7 @@ global_costmap:
           observation_persistence: 0.0
           footprint_clearing_enabled: true
           tf_filter_tolerance: 0.2
-          min_obstacle_height: 0.10
+          min_obstacle_height: 0.05
           max_obstacle_height: 1.50
           obstacle_min_range: 0.0
           obstacle_max_range: 8.0
@@ -106,8 +106,8 @@ local_costmap:
       global_frame: odom
       robot_base_frame: base_footprint
       robot_radius: 0.25
-      update_frequency: 6.0
-      publish_frequency: 3.0
+      update_frequency: 4.0
+      publish_frequency: 2.0
       plugins: ["voxel_layer", "inflation_layer"]
 
       # rolling window
@@ -125,7 +125,7 @@ local_costmap:
           marking: true
           clearing: true
           expected_update_rate: 1.0
-          observation_persistence: 0.0
+          observation_persistence: 0.5
           footprint_clearing_enabled: true
           tf_filter_tolerance: 0.2
           origin_z: 0.0
@@ -134,17 +134,17 @@ local_costmap:
           unknown_threshold: 15
           combination_method: 1
           max_obstacle_height: 1.50
-          min_obstacle_height: 0.10
-          obstacle_max_range: 6.0
+          min_obstacle_height: 0.05
+          obstacle_max_range: 7.0
           obstacle_min_range: 0.0
-          raytrace_max_range: 8.0
+          raytrace_max_range: 9.0
           raytrace_min_range: 0.0
           mark_threshold: 0
 
       # config for inflation
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
-        inflation_radius: 0.30
+        inflation_radius: 0.35
         cost_scaling_factor: 4.0
 
       always_send_full_costmap: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR tunes the Nav2 navigation stack to improve obstacle robustness when operating with sparse lidar data. The changes optimize the balance between responsiveness and safety by:

**Motion Control:**
- Reduces controller frequency and linear/angular velocities to allow more stable obstacle detection and avoidance within the sparse lidar refresh envelope
- Decreases lookahead distance and approach velocity for more conservative path following

**Obstacle Detection:**
- Lowers the minimum obstacle height threshold from 0.10m to 0.05m in both global and local costmaps to detect smaller obstacles
- Increases the local costmap observation persistence to maintain awareness of detected obstacles longer
- Expands the sensing range for obstacle and raytrace detection

**Safety Margins:**
- Increases cost scaling distance to create larger safety buffers around detected obstacles
- Increases inflation radius for additional buffer space

**Update Rates:**
- Reduces local costmap update and publish frequencies to maintain performance efficiency while improving reliability

These parameter adjustments collectively address the challenges of sparse lidar data by making the navigation system more deliberate and conservative, reducing false negatives in obstacle detection while improving overall path safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->