### PR TITLE
teleop: add joystick control with twist mux

### DIFF
--- a/src/lunabot_bringup/config/twist_mux.yaml
+++ b/src/lunabot_bringup/config/twist_mux.yaml
@@ -1,0 +1,11 @@
+twist_mux:
+  ros__parameters:
+    topics:
+      joystick:
+        topic: cmd_vel_teleop
+        timeout: 0.5
+        priority: 100
+      navigation:
+        topic: cmd_vel_nav
+        timeout: 0.5
+        priority: 10

--- a/src/lunabot_bringup/launch/navigation.launch.py
+++ b/src/lunabot_bringup/launch/navigation.launch.py
@@ -5,12 +5,15 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.actions import GroupAction
 from launch.actions import IncludeLaunchDescription
 from launch.actions import TimerAction
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.conditions import IfCondition
+from launch.conditions import UnlessCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.actions import SetRemap
 
 
 def generate_launch_description():
@@ -20,22 +23,28 @@ def generate_launch_description():
     Start the blank map server, localisation include, and Nav2 navigation
     servers. The forwarded launch arguments keep the odom-only debug mode
     available while AprilTag global localisation remains the default path.
-    Optionally launch RViz with sim time enabled to avoid goal timestamp
-    mismatches during simulation testing.
+    Optionally launch RViz and joystick teleop, then arbitrate between
+    autonomous and manual velocity commands through a twist mux.
     """
     # Locate the configuration files
     pkg_bringup = get_package_share_directory("lunabot_bringup")
     pkg_nav = get_package_share_directory("lunabot_navigation")
     pkg_nav2_bringup = get_package_share_directory("nav2_bringup")
+    pkg_teleop = get_package_share_directory("lunabot_teleop")
 
     nav_params_path = os.path.join(pkg_nav, "config", "nav2_params.yaml")
     blank_map_path = os.path.join(pkg_nav, "maps", "moon_yard_blank.yaml")
     rviz_config_path = os.path.join(pkg_bringup, "rviz", "navigation.rviz")
+    twist_mux_params_path = os.path.join(
+        pkg_bringup, "config", "twist_mux.yaml"
+    )
     lidar_costmap_phase = LaunchConfiguration("lidar_costmap_phase")
     enable_visual_slam = LaunchConfiguration("enable_visual_slam")
     launch_rviz = LaunchConfiguration("launch_rviz")
     use_sim_time = LaunchConfiguration("use_sim_time")
     enable_apriltag_debug = LaunchConfiguration("enable_apriltag_debug")
+    enable_teleop = LaunchConfiguration("enable_teleop")
+    joy_device_id = LaunchConfiguration("joy_device_id")
 
     localisation_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
@@ -58,6 +67,17 @@ def generate_launch_description():
             "params_file": nav_params_path,
             "autostart": "true",
         }.items(),
+    )
+
+    teleop_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_teleop, "launch", "joystick_teleop.launch.py")
+        ),
+        launch_arguments={
+            "use_sim_time": use_sim_time,
+            "joy_device_id": joy_device_id,
+        }.items(),
+        condition=IfCondition(enable_teleop),
     )
 
     map_server = Node(
@@ -93,15 +113,46 @@ def generate_launch_description():
         condition=IfCondition(launch_rviz),
     )
 
+    twist_mux = Node(
+        package="twist_mux",
+        executable="twist_mux",
+        name="twist_mux",
+        output="screen",
+        remappings=[("cmd_vel_out", "cmd_vel")],
+        parameters=[twist_mux_params_path, {"use_sim_time": use_sim_time}],
+        condition=IfCondition(enable_teleop),
+    )
+
+    nav2_launch_group = GroupAction(
+        [
+            SetRemap(src="cmd_vel", dst="cmd_vel_nav"),
+            SetRemap(src="cmd_vel_smoothed", dst="cmd_vel_nav"),
+            nav2_launch,
+        ],
+        condition=IfCondition(enable_teleop),
+    )
+
     # Delay Nav2 startup slightly so sim time / TF / sensor streams can settle.
-    delayed_nav2_launch = TimerAction(period=5.0, actions=[nav2_launch])
+    delayed_nav2_launch = TimerAction(
+        period=5.0,
+        actions=[nav2_launch],
+        condition=UnlessCondition(enable_teleop),
+    )
+    delayed_muxed_nav2_launch = TimerAction(
+        period=5.0,
+        actions=[nav2_launch_group],
+        condition=IfCondition(enable_teleop),
+    )
 
     return LaunchDescription(
         [
             DeclareLaunchArgument(
                 "lidar_costmap_phase",
                 default_value="false",
-                description="Use odom-only debug localisation with an identity map->odom TF.",
+                description=(
+                    "Use odom-only debug localisation with an identity "
+                    "map->odom TF."
+                ),
             ),
             DeclareLaunchArgument(
                 "enable_visual_slam",
@@ -122,20 +173,39 @@ def generate_launch_description():
             DeclareLaunchArgument(
                 "use_sim_time",
                 default_value="true",
-                description="Use /clock instead of wall time for all launched nodes.",
+                description=(
+                    "Use /clock instead of wall time for all launched nodes."
+                ),
             ),
             DeclareLaunchArgument(
                 "enable_apriltag_debug",
                 default_value="false",
                 description=(
-                    "Launch the apriltag_draw overlay for annotated front camera "
-                    "debugging."
+                    "Launch the apriltag_draw overlay for annotated front "
+                    "camera debugging."
+                ),
+            ),
+            DeclareLaunchArgument(
+                "enable_teleop",
+                default_value="false",
+                description=(
+                    "Launch joystick teleoperation through twist_mux."
+                ),
+            ),
+            DeclareLaunchArgument(
+                "joy_device_id",
+                default_value="0",
+                description=(
+                    "SDL device index for the connected controller."
                 ),
             ),
             map_server,
             map_lifecycle_manager,
             localisation_launch,
+            teleop_launch,
+            twist_mux,
             delayed_nav2_launch,
+            delayed_muxed_nav2_launch,
             rviz,
         ]
     )

--- a/src/lunabot_bringup/package.xml
+++ b/src/lunabot_bringup/package.xml
@@ -4,7 +4,7 @@
   <name>lunabot_bringup</name>
   <version>0.1.0</version>
   <description>System level launch files and robot bringup</description>
-  <maintainer email="lunabotics@le.ac.uk">Leicester Lunabotics Team</maintainer>
+  <maintainer email="ko129@student.le.ac.uk">Leicester Lunabotics Team</maintainer>
   <license>Apache-2.0</license>
 
   <test_depend>ament_copyright</test_depend>
@@ -24,7 +24,9 @@
   <exec_depend>nav2_map_server</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>lunabot_navigation</exec_depend>
+  <exec_depend>lunabot_teleop</exec_depend>
   <exec_depend>lunabot_perception</exec_depend>
+  <exec_depend>twist_mux</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/src/lunabot_bringup/setup.py
+++ b/src/lunabot_bringup/setup.py
@@ -32,10 +32,10 @@ setup(
     ],
     install_requires=["setuptools"],
     zip_safe=True,
-    maintainer="drkwonk",
-    maintainer_email="drkwonk@todo.todo",
-    description="TODO: Package description",
-    license="TODO: License declaration",
+    maintainer="Leicester Lunabotics Team",
+    maintainer_email="ko129@student.le.ac.uk",
+    description="System bringup launch files and checks for Lunabot",
+    license="Apache-2.0",
     extras_require={
         "test": [
             "pytest",

--- a/src/lunabot_teleop/config/xbox_teleop.yaml
+++ b/src/lunabot_teleop/config/xbox_teleop.yaml
@@ -1,0 +1,20 @@
+teleop_twist_joy_node:
+  ros__parameters:
+    require_enable_button: true
+    enable_button: 9
+    enable_turbo_button: 10
+    inverted_reverse: true
+
+    axis_linear:
+      x: 1
+    scale_linear:
+      x: 0.35
+    scale_linear_turbo:
+      x: 0.6
+
+    axis_angular:
+      yaw: 2
+    scale_angular:
+      yaw: 0.45
+    scale_angular_turbo:
+      yaw: 0.8

--- a/src/lunabot_teleop/launch/joystick_teleop.launch.py
+++ b/src/lunabot_teleop/launch/joystick_teleop.launch.py
@@ -1,0 +1,68 @@
+"""Launch joystick teleoperation nodes for Lunabot."""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def generate_launch_description():
+    """
+    Generate a launch description for joystick teleoperation.
+
+    Start the SDL-backed game controller node and teleop_twist_joy with the
+    Lunabot Xbox-style mapping. Teleop commands are published on
+    /cmd_vel_teleop so a mux can arbitrate between manual and autonomous input.
+    """
+    pkg_share = get_package_share_directory("lunabot_teleop")
+    teleop_config = os.path.join(pkg_share, "config", "xbox_teleop.yaml")
+    use_sim_time = LaunchConfiguration("use_sim_time")
+    joy_device_id = LaunchConfiguration("joy_device_id")
+
+    game_controller = Node(
+        package="joy",
+        executable="game_controller_node",
+        name="game_controller_node",
+        output="screen",
+        parameters=[
+            {"use_sim_time": use_sim_time},
+            {"device_id": ParameterValue(joy_device_id, value_type=int)},
+            {"deadzone": 0.08},
+            {"autorepeat_rate": 20.0},
+            {"coalesce_interval_ms": 1},
+        ],
+    )
+
+    teleop_twist = Node(
+        package="teleop_twist_joy",
+        executable="teleop_node",
+        name="teleop_twist_joy_node",
+        output="screen",
+        parameters=[teleop_config, {"use_sim_time": use_sim_time}],
+        remappings=[("cmd_vel", "cmd_vel_teleop")],
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "use_sim_time",
+                default_value="false",
+                description=(
+                    "Use /clock instead of wall time for teleop nodes."
+                ),
+            ),
+            DeclareLaunchArgument(
+                "joy_device_id",
+                default_value="0",
+                description=(
+                    "SDL device index for the connected controller."
+                ),
+            ),
+            game_controller,
+            teleop_twist,
+        ]
+    )

--- a/src/lunabot_teleop/package.xml
+++ b/src/lunabot_teleop/package.xml
@@ -4,8 +4,11 @@
   <name>lunabot_teleop</name>
   <version>0.1.0</version>
   <description>Teleoperation and manual control interfaces</description>
-  <maintainer email="lunabotics@le.ac.uk">Leicester Lunabotics Team</maintainer>
+  <maintainer email="ko129@student.le.ac.uk">Leicester Lunabotics Team</maintainer>
   <license>Apache-2.0</license>
+
+  <exec_depend>joy</exec_depend>
+  <exec_depend>teleop_twist_joy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/src/lunabot_teleop/setup.py
+++ b/src/lunabot_teleop/setup.py
@@ -1,29 +1,41 @@
+import os
+from glob import glob
+
 from setuptools import find_packages, setup
 
-package_name = 'lunabot_teleop'
+package_name = "lunabot_teleop"
 
 setup(
     name=package_name,
-    version='0.0.0',
-    packages=find_packages(exclude=['test']),
+    version="0.0.0",
+    packages=find_packages(exclude=["test"]),
     data_files=[
-        ('share/ament_index/resource_index/packages',
-            ['resource/' + package_name]),
-        ('share/' + package_name, ['package.xml']),
+        (
+            "share/ament_index/resource_index/packages",
+            ["resource/" + package_name],
+        ),
+        ("share/" + package_name, ["package.xml"]),
+        (
+            os.path.join("share", package_name, "launch"),
+            glob("launch/*.launch.py"),
+        ),
+        (
+            os.path.join("share", package_name, "config"),
+            glob("config/*.yaml"),
+        ),
     ],
-    install_requires=['setuptools'],
+    install_requires=["setuptools"],
     zip_safe=True,
-    maintainer='drkwonk',
-    maintainer_email='drkwonk@todo.todo',
-    description='TODO: Package description',
-    license='TODO: License declaration',
+    maintainer="Leicester Lunabotics Team",
+    maintainer_email="ko129@student.le.ac.uk",
+    description="Joystick teleoperation launch files and configs",
+    license="Apache-2.0",
     extras_require={
-        'test': [
-            'pytest',
+        "test": [
+            "pytest",
         ],
     },
     entry_points={
-        'console_scripts': [
-        ],
+        "console_scripts": [],
     },
 )

--- a/src/lunabot_teleop/test/test_copyright.py
+++ b/src/lunabot_teleop/test/test_copyright.py
@@ -16,10 +16,12 @@ from ament_copyright.main import main
 import pytest
 
 
-# Remove the `skip` decorator once the source file(s) have a copyright header
-@pytest.mark.skip(reason='No copyright header has been placed in the generated source file.')
+# Remove the `skip` decorator once source files have copyright headers.
+@pytest.mark.skip(
+    reason="No copyright header has been placed in the generated source file."
+)
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found errors'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found errors"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds joystick teleoperation control to the Innex1 rover with integrated twist multiplexing to arbitrate between joystick and navigation velocity commands.

## Key Changes

### Teleoperation Infrastructure
- Added new `lunabot_teleop` package with joystick teleoperation launch and configuration
- Implemented Xbox controller support with configurable joystick axes, scaling factors, and button mapping
- Created launch file to initialize joy node and teleop_twist_joy node for joystick input

### Velocity Command Arbitration
- Introduced twist_mux configuration to manage competing velocity commands from joystick (`cmd_vel_teleop`) and navigation (`cmd_vel_nav`)
- Configured priority-based arbitration (joystick at priority 100, navigation at priority 10) with 0.5-second timeout on inputs
- Modified navigation launch to conditionally include twist_mux node when teleoperation is enabled

### Navigation Integration
- Updated `navigation.launch.py` to accept `enable_teleop` and `joy_device_id` launch arguments
- Remapped Nav2 velocity topics to `cmd_vel_nav` when teleoperation is active to allow twist_mux arbitration
- Adjusted Nav2 initialization timing based on whether teleoperation is enabled

### Package Updates
- Added runtime dependencies: `lunabot_teleop`, `twist_mux`, `joy`, and `teleop_twist_joy`
- Updated package metadata including maintainer email and descriptions for both `lunabot_bringup` and `lunabot_teleop` packages
- Configured setup.py to include launch and configuration files in package distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->