### PR TITLE
ci: mark workspace as safe for path filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Mark workspace as a safe git directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        shell: bash
+
       - name: Detect code-bearing changes
         id: changes
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
## Summary
- mark the checked-out workspace as a safe git directory before path filtering runs
- fix the failing main CI run introduced by the scoped CI change
- keep the docs-only skip behaviour intact

## Testing
- python3 YAML parse check for `.github/workflows/ci.yml`
- reviewed the workflow change with two review passes
- waiting on GitHub Actions for the container-specific validation
