### PR TITLE
ci: select ROS packages conservatively

### DIFF
--- a/.github/scripts/select_ci_packages.py
+++ b/.github/scripts/select_ci_packages.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Select a conservative ROS package set for CI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+BROAD_PATH_PREFIXES = (
+    ".github/workflows/",
+    ".github/actions/",
+    ".github/scripts/",
+    ".github/contracts/",
+)
+BROAD_PACKAGES = {
+    "lunabot_bringup",
+    "lunabot_control",
+    "lunabot_interfaces",
+    "lunabot_navigation",
+    "lunabot_simulation",
+}
+SAFE_SELECT_PACKAGES = {
+    "lunabot_excavation",
+    "lunabot_perception",
+    "lunabot_teleop",
+}
+DEPENDENCY_TAGS = {
+    "depend",
+    "build_depend",
+    "build_export_depend",
+    "exec_depend",
+    "test_depend",
+}
+
+
+@dataclass(frozen=True)
+class Selection:
+    mode: str
+    packages: tuple[str, ...]
+    reason: str
+
+
+def _git_changed_files(base_sha: str, head_sha: str) -> list[str]:
+    if not base_sha or set(base_sha) == {"0"}:
+        return []
+
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", base_sha, head_sha],
+            check=True,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"Falling back to full CI because git diff failed for {base_sha}..{head_sha}: "
+            f"{exc.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return []
+
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _discover_packages() -> tuple[dict[str, str], dict[str, set[str]]]:
+    package_roots: dict[str, str] = {}
+    dependencies: dict[str, set[str]] = {}
+
+    for package_xml in sorted(SRC_ROOT.rglob("package.xml")):
+        root = package_xml.parent
+        tree = ET.parse(package_xml)
+        package = tree.getroot()
+        name = package.findtext("name")
+        if not name:
+            continue
+
+        root_rel = root.relative_to(REPO_ROOT).as_posix()
+        package_roots[root_rel] = name
+        dependencies[name] = {
+            element.text.strip()
+            for element in package
+            if element.tag in DEPENDENCY_TAGS and element.text
+        }
+
+    return package_roots, dependencies
+
+
+def _owning_package(changed_file: str, package_roots: dict[str, str]) -> str | None:
+    matching_root = None
+    for root in package_roots:
+        prefix = f"{root}/"
+        if changed_file == root or changed_file.startswith(prefix):
+            if matching_root is None or len(root) > len(matching_root):
+                matching_root = root
+
+    if matching_root is None:
+        return None
+    return package_roots[matching_root]
+
+
+def _reverse_dependencies(
+    changed_packages: set[str],
+    dependencies: dict[str, set[str]],
+) -> set[str]:
+    selected = set(changed_packages)
+    added = True
+    while added:
+        added = False
+        for package, package_deps in dependencies.items():
+            if package in selected:
+                continue
+            if package_deps & selected:
+                selected.add(package)
+                added = True
+    return selected
+
+
+def _select(
+    changed_files: list[str],
+    package_roots: dict[str, str],
+    dependencies: dict[str, set[str]],
+) -> Selection:
+    if not changed_files:
+        return Selection("full", (), "No reliable diff range available")
+
+    if any(
+        any(path.startswith(prefix) for prefix in BROAD_PATH_PREFIXES)
+        for path in changed_files
+    ):
+        return Selection("full", (), "Shared CI or contract files changed")
+
+    changed_packages: set[str] = set()
+    for path in changed_files:
+        if not path.startswith("src/"):
+            return Selection("full", (), f"Top-level repo file changed: {path}")
+
+        package = _owning_package(path, package_roots)
+        if package is None:
+            return Selection("full", (), f"Unowned source path changed: {path}")
+
+        if package.startswith("leo_"):
+            return Selection("full", (), f"External package changed: {package}")
+
+        if package in BROAD_PACKAGES:
+            return Selection("full", (), f"Broad package changed: {package}")
+
+        if package not in SAFE_SELECT_PACKAGES:
+            return Selection("full", (), f"Package not whitelisted for selective CI: {package}")
+
+        changed_packages.add(package)
+
+    selected = _reverse_dependencies(changed_packages, dependencies)
+    return Selection(
+        "packages",
+        tuple(sorted(selected)),
+        "Selective CI is safe for this package set",
+    )
+
+
+def _write_github_output(path: Path, selection: Selection) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"mode={selection.mode}\n")
+        handle.write(f"packages={' '.join(selection.packages)}\n")
+        handle.write(f"reason={selection.reason}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--github-output")
+    args = parser.parse_args()
+
+    package_roots, dependencies = _discover_packages()
+    changed_files = _git_changed_files(args.base_sha, args.head_sha)
+    selection = _select(changed_files, package_roots, dependencies)
+
+    summary = {
+        "mode": selection.mode,
+        "packages": list(selection.packages),
+        "reason": selection.reason,
+        "changed_files": changed_files,
+    }
+    print(json.dumps(summary, indent=2))
+
+    if args.github_output:
+        _write_github_output(Path(args.github_output), selection)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_select_ci_packages.py
+++ b/.github/scripts/test_select_ci_packages.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Regression checks for CI package selection policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SELECTOR_PATH = REPO_ROOT / ".github/scripts/select_ci_packages.py"
+
+
+def _load_selector_module():
+    spec = importlib.util.spec_from_file_location("select_ci_packages", SELECTOR_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    selector = _load_selector_module()
+    package_roots, dependencies = selector._discover_packages()
+
+    scenarios = {
+        "empty_diff_forces_full": (
+            [],
+            ("full", ()),
+        ),
+        "excavation_safe_leaf": (
+            ["src/lunabot_excavation/lunabot_excavation/excavation_controller.py"],
+            ("packages", ("lunabot_control", "lunabot_excavation")),
+        ),
+        "leaf_package": (
+            ["src/lunabot_teleop/config/xbox_teleop.yaml"],
+            ("packages", ("lunabot_bringup", "lunabot_teleop")),
+        ),
+        "interfaces_force_full": (
+            ["src/lunabot_interfaces/msg/ExcavationStatus.msg"],
+            ("full", ()),
+        ),
+        "workflow_force_full": (
+            [".github/workflows/nightly-full-ci.yml"],
+            ("full", ()),
+        ),
+        "external_force_full": (
+            ["src/external/leo_common-ros2/leo_teleop/config/joy_config.yaml"],
+            ("full", ()),
+        ),
+        "localisation_force_full": (
+            ["src/lunabot_localisation/launch/localisation.launch.py"],
+            ("full", ()),
+        ),
+        "description_force_full": (
+            ["src/lunabot_description/urdf/lunabot.urdf.xacro"],
+            ("full", ()),
+        ),
+    }
+
+    failures: list[str] = []
+    for name, (changed_files, expected) in scenarios.items():
+        selection = selector._select(changed_files, package_roots, dependencies)
+        actual = (selection.mode, selection.packages)
+        if actual != expected:
+            failures.append(
+                f"{name}: expected {expected}, got {(selection.mode, selection.packages)}"
+            )
+
+    if failures:
+        print("CI package selector regression checks failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    invalid_diff = selector._git_changed_files(
+        "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        head_sha,
+    )
+    if invalid_diff != []:
+        print("CI package selector regression checks failed:")
+        print(f"- invalid_diff_range: expected [], got {invalid_diff}")
+        return 1
+
+    print("CI package selector regression checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,14 @@ jobs:
       pull-requests: read
     outputs:
       ros_ci: ${{ steps.changes.outputs.ros_ci }}
+      selection_mode: ${{ steps.selection.outputs.mode }}
+      selection_packages: ${{ steps.selection.outputs.packages }}
+      selection_reason: ${{ steps.selection.outputs.reason }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Mark workspace as a safe git directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -48,6 +53,29 @@ jobs:
         run: |
           python3 .github/scripts/run_preflight_checks.py
           python3 .github/scripts/check_interface_contracts.py
+          python3 .github/scripts/test_select_ci_packages.py
+        shell: bash
+
+      - name: Determine comparison range
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            echo "base_sha=$(git merge-base HEAD origin/${{ github.base_ref }})" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_sha=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "head_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Select ROS package scope
+        id: selection
+        if: steps.changes.outputs.ros_ci == 'true'
+        run: |
+          python3 .github/scripts/select_ci_packages.py \
+            --base-sha "${{ steps.range.outputs.base_sha }}" \
+            --head-sha "${{ steps.range.outputs.head_sha }}" \
+            --github-output "$GITHUB_OUTPUT"
         shell: bash
 
   build-and-test:
@@ -64,12 +92,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Explain selected ROS scope
+        run: |
+          echo "Selection mode: ${{ needs.preflight.outputs.selection_mode }}"
+          echo "Selection reason: ${{ needs.preflight.outputs.selection_reason }}"
+          echo "Selected packages: ${{ needs.preflight.outputs.selection_packages }}"
+        shell: bash
+
       - name: Cache apt packages
         uses: actions/cache@v4
         with:
           path: /var/cache/apt/archives
-          key: apt-${{ hashFiles('src/**/package.xml') }}
-          restore-keys: apt-
+          key: ${{ runner.os }}-apt-${{ hashFiles('src/**/package.xml') }}
+          restore-keys: ${{ runner.os }}-apt-
 
       - name: Cache colcon workspace
         uses: actions/cache@v4
@@ -77,8 +112,8 @@ jobs:
           path: |
             build/
             install/
-          key: colcon-${{ hashFiles('src/**/package.xml', 'src/**/CMakeLists.txt', 'src/**/setup.py') }}
-          restore-keys: colcon-
+          key: ${{ runner.os }}-colcon-${{ hashFiles('src/**/package.xml', 'src/**/CMakeLists.txt', 'src/**/setup.py') }}
+          restore-keys: ${{ runner.os }}-colcon-
 
       - name: Install dependencies
         run: |
@@ -90,15 +125,29 @@ jobs:
         shell: bash
 
       - name: Build
+        env:
+          SELECTION_MODE: ${{ needs.preflight.outputs.selection_mode }}
+          SELECTED_PACKAGES: ${{ needs.preflight.outputs.selection_packages }}
         run: |
           source /opt/ros/humble/setup.bash
-          colcon build
+          if [ "$SELECTION_MODE" = "packages" ]; then
+            colcon build --packages-up-to $SELECTED_PACKAGES
+          else
+            colcon build
+          fi
         shell: bash
 
       - name: Run tests
+        env:
+          SELECTION_MODE: ${{ needs.preflight.outputs.selection_mode }}
+          SELECTED_PACKAGES: ${{ needs.preflight.outputs.selection_packages }}
         run: |
           source /opt/ros/humble/setup.bash
-          colcon test
+          if [ "$SELECTION_MODE" = "packages" ]; then
+            colcon test --packages-select $SELECTED_PACKAGES
+          else
+            colcon test
+          fi
         shell: bash
 
       - name: Check test results


### PR DESCRIPTION
## Summary
- add a conservative ROS package selector for CI
- keep broad or ambiguous changes on the full workspace path
- add regression checks for selector policy and edge cases

## Testing
- local preflight script run
- local interface contract check
- local selector regression checks
- manual selector scenario checks for docs-only, leaf, broad, workflow, and external changes
- review-agent passes before commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR introduces a conservative ROS package selector for CI that enables intelligent, scoped package testing based on git changes. Rather than running the full workspace build/test suite on every change, the CI now identifies which packages are affected and can optionally test only those packages.

## Key Changes
- **New package selector script** (`select_ci_packages.py`): Analyzes git diffs between base and head commits to determine which ROS packages are affected by changes. Implements a conservative policy that falls back to full workspace testing for broad, ambiguous, or unsupported changes (e.g., workflow files, external packages, unowned paths).

- **Regression test suite** (`test_select_ci_packages.py`): Validates the package selector policy through scenario-based tests covering various change types (docs-only, leaf packages, broad changes, workflow changes, external packages).

- **Updated CI workflow** (`ci.yml`):
  - Preflight job now computes the comparison range (merge-base for PRs, otherwise using git event metadata)
  - Runs package selector to determine scope and exports selection results as job outputs
  - Build/test jobs now conditionally scope `colcon build` and `colcon test` to only affected packages when selection mode is "packages", otherwise runs full workspace
  - Improved caching strategy with OS-aware cache keys
  - Adds explanatory output to show which packages were selected and why

## Benefits
- Faster CI execution for changes affecting a subset of packages by avoiding unnecessary full-workspace builds
- Safety through conservative package selection: broad or unclear changes still trigger full workspace testing
- Regression test coverage to prevent future changes from breaking the selection policy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->