### PR TITLE
ci: add a dedicated ROS CI image build

### DIFF
--- a/.github/docker/ros-ci/Dockerfile
+++ b/.github/docker/ros-ci/Dockerfile
@@ -1,0 +1,13 @@
+FROM ros:humble-ros-base
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    python3-colcon-common-extensions \
+    python3-rosdep \
+    python3-vcstool \
+    python3-yaml \
+  && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/build-ros-ci-image.yml
+++ b/.github/workflows/build-ros-ci-image.yml
@@ -1,0 +1,114 @@
+name: Build ROS CI Image
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/docker/ros-ci/**'
+      - '.github/workflows/build-ros-ci-image.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/docker/ros-ci/**'
+      - '.github/workflows/build-ros-ci-image.yml'
+  workflow_dispatch:
+
+jobs:
+  build-and-smoke-test:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Derive image metadata
+        id: image
+        run: |
+          owner_lower=$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            cache_scope=ros-ci-image-pr
+          else
+            cache_scope=ros-ci-image-main
+          fi
+          echo "image=ghcr.io/${owner_lower}/innex1-rover-ci" >> "$GITHUB_OUTPUT"
+          echo "cache_scope=${cache_scope}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build ROS CI image for smoke testing
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/ros-ci/Dockerfile
+          load: true
+          tags: innex1-ros-ci:test
+          cache-from: type=gha,scope=${{ steps.image.outputs.cache_scope }}
+          cache-to: type=gha,mode=max,scope=${{ steps.image.outputs.cache_scope }}
+
+      - name: Build ROS CI image for smoke testing without cache export
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/ros-ci/Dockerfile
+          load: true
+          tags: innex1-ros-ci:test
+
+      - name: Smoke test the image
+        run: |
+          docker run --rm innex1-ros-ci:test bash -lc '
+            source /opt/ros/humble/setup.bash &&
+            if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then rosdep init; fi &&
+            rosdep update --rosdistro humble >/dev/null &&
+            colcon --help >/dev/null &&
+            rosdep --version >/dev/null &&
+            python3 -c "import yaml; print(yaml.__version__)"
+          '
+        shell: bash
+
+  publish:
+    runs-on: ubuntu-22.04
+    needs: build-and-smoke-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Derive image metadata
+        id: image
+        run: |
+          owner_lower=$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
+          echo "image=ghcr.io/${owner_lower}/innex1-rover-ci" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish ROS CI image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/ros-ci/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image }}:humble
+            ${{ steps.image.outputs.image }}:sha-${{ github.sha }}
+          cache-from: type=gha,scope=ros-ci-image-main
+          cache-to: type=gha,mode=max,scope=ros-ci-image-main


### PR DESCRIPTION
## Summary
- add a small ROS Humble CI image with the stable system tools preinstalled
- add a dedicated workflow that builds and smoke-tests the image on PRs
- publish the image to GHCR from main only so later CI can consume a trusted tag

## Testing
- python3 .github/scripts/run_preflight_checks.py
- python3 .github/scripts/check_interface_contracts.py
- workflow YAML parse
- GitHub image workflow builds and smoke-tests the image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds a dedicated CI infrastructure for building and distributing a ROS 2 Humble container image for use in downstream CI pipelines.

## Changes
- **New ROS CI base image**: Introduces a ROS 2 Humble–based Docker image with essential system tools and Python/ROS development packages preinstalled, designed for CI environments.
- **Automated image build workflow**: Adds a GitHub Actions workflow that builds and validates the image on pull requests and pushes to `main`. The workflow performs smoke tests to verify container functionality (rosdep initialization, colcon availability, Python dependencies).
- **GHCR publishing**: Configures the workflow to publish the image to GitHub Container Registry only on direct pushes to `main`, establishing a trusted image source for other CI jobs to consume.

## Testing
- Preflight checks and interface contract validation scripts executed
- Workflow YAML syntax validated
- Image build and smoke test verification completed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->