### PR TITLE
ci: consume the published ROS CI image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      packages: read
     outputs:
       image: ${{ steps.resolve.outputs.image }}
       prebuilt: ${{ steps.resolve.outputs.prebuilt }}
@@ -103,6 +104,8 @@ jobs:
             fi
           fi
 
+          echo "Published ROS CI image lookup failed; using ros:humble-ros-base instead."
+          cat /tmp/ci-image-inspect.err || true
           echo "image=ros:humble-ros-base" >> "$GITHUB_OUTPUT"
           echo "prebuilt=false" >> "$GITHUB_OUTPUT"
           echo "image_reason=Falling back because the published ROS CI image is unavailable" >> "$GITHUB_OUTPUT"
@@ -117,6 +120,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      packages: read
     container:
       image: ${{ needs.resolve-build-image.outputs.image }}
 

--- a/.github/workflows/nightly-full-ci.yml
+++ b/.github/workflows/nightly-full-ci.yml
@@ -91,6 +91,7 @@ jobs:
     if: needs.decide.outputs.should_run == 'true'
     permissions:
       contents: read
+      packages: read
     outputs:
       image: ${{ steps.resolve.outputs.image }}
       prebuilt: ${{ steps.resolve.outputs.prebuilt }}
@@ -114,6 +115,8 @@ jobs:
             fi
           fi
 
+          echo "Published ROS CI image lookup failed; using ros:humble-ros-base instead."
+          cat /tmp/ci-image-inspect.err || true
           echo "image=ros:humble-ros-base" >> "$GITHUB_OUTPUT"
           echo "prebuilt=false" >> "$GITHUB_OUTPUT"
           echo "image_reason=Falling back because the published ROS CI image is unavailable" >> "$GITHUB_OUTPUT"
@@ -127,6 +130,7 @@ jobs:
     if: needs.decide.outputs.should_run == 'true'
     permissions:
       contents: read
+      packages: read
     container:
       image: ${{ needs.resolve-build-image.outputs.image }}
     steps:


### PR DESCRIPTION
## Summary
- switch the heavy ROS CI jobs to the published GHCR image instead of reinstalling the same base tools every run
- resolve the image by digest when it is available, and fall back to ros:humble-ros-base if it is not
- keep rosdep install in place so dependency declarations are still checked honestly

## Testing
- python3 .github/scripts/run_preflight_checks.py
- python3 .github/scripts/check_interface_contracts.py
- python3 .github/scripts/test_select_ci_packages.py
- workflow YAML parse
- verified published image exists in GHCR with docker buildx imagetools inspect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR optimizes CI workflows by switching heavy ROS CI jobs to a published pre-built ROS CI image on GitHub Container Registry (GHCR), reducing redundant tool reinstallation while preserving dependency validation.

## What changed
- Modified workflows: .github/workflows/ci.yml and .github/workflows/nightly-full-ci.yml.
- Added image resolution flow: workflows now derive a GHCR image reference and attempt to resolve it to a digest; if successful the workflows use the digest-pinned GHCR image, otherwise they fall back to ros:humble-ros-base.
- Jobs updated to use the resolved container image via a new resolve-build-image job; build jobs now depend on image resolution.
- Adjusted dependency installation:
  - Always run apt-get update and rosdep to validate dependencies.
  - Conditionally install extra packaging/tools (e.g., python3-colcon-common-extensions, python3-rosdep) only when using the fallback image.
  - Run rosdep init only if the system sources file is missing.
- Removed the apt package cache step from CI since the pre-built image reduces package installs.
- Added explicit workflow job outputs exposing the computed CI image and resolution metadata.

## Benefits
- Faster CI runs by avoiding repeated installation of base ROS tooling.
- More reproducible builds when the GHCR image is resolved to a digest.
- Robust fallback to the official ROS base image if the published image is unavailable.
- Continues to validate project dependency declarations via rosdep.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->