### PR TITLE
feat(bringup): add MissionManager FSM node for shuttle-cycle autonomy

### DIFF
--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -1,0 +1,323 @@
+"""Shuttle-cycle mission manager FSM for autonomous rover operation."""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+from action_msgs.msg import GoalStatus
+from lunabot_interfaces.action import Deposit
+from lunabot_interfaces.action import Excavate
+from nav2_msgs.action import NavigateToPose
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+
+from lunabot_bringup.mission_timer import MissionTimer
+
+
+class MissionState(IntEnum):
+    """
+    States for the mission manager FSM.
+
+    Each constant names a single phase in the shuttle-cycle mission sequence.
+    """
+
+    INITIALIZE_MISSION = 0
+    ACQUIRE_TAG = 1
+    TURN_TO_EXCAVATION = 2
+    NAV_TO_EXCAVATION = 3
+    EXCAVATE = 4
+    TURN_TO_DEPOSITION = 5
+    NAV_TO_DEPOSITION = 6
+    DEPOSIT = 7
+    CHECK_NEXT_CYCLE_TIME = 8
+    SAFE_FAIL = 9
+    HALT_MISSION = 10
+
+
+class MissionManager(Node):
+    """
+    ROS 2 node implementing the shuttle-cycle mission FSM.
+
+    Drives the rover through repeated excavation and deposition cycles,
+    using a MissionTimer to gate whether another cycle can begin within
+    the 1200-second mission budget.
+    """
+
+    def __init__(self) -> None:
+        """Initialise the node, declare parameters, and create action clients."""
+        super().__init__("mission_manager")
+
+        self.declare_parameter("use_sim_time", False)
+
+        self._state: MissionState = MissionState.INITIALIZE_MISSION
+        self._timer: MissionTimer | None = None
+
+        self._navigate_client: ActionClient = ActionClient(
+            self,
+            NavigateToPose,
+            "/navigate_to_pose_gate",
+        )
+        self._excavate_client: ActionClient = ActionClient(
+            self,
+            Excavate,
+            "/mission/excavate",
+        )
+        self._deposit_client: ActionClient = ActionClient(
+            self,
+            Deposit,
+            "/mission/deposit",
+        )
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def run_mission(self) -> None:
+        """Advance the FSM until HALT_MISSION is reached."""
+        while self._state != MissionState.HALT_MISSION:
+            self._step()
+
+        self.get_logger().info("Mission halted.")
+
+    # ------------------------------------------------------------------
+    # FSM dispatcher
+    # ------------------------------------------------------------------
+
+    def _step(self) -> None:
+        """Dispatch the current state to its handler and advance."""
+        handler = {
+            MissionState.INITIALIZE_MISSION: self._handle_initialize_mission,
+            MissionState.ACQUIRE_TAG: self._handle_acquire_tag,
+            MissionState.TURN_TO_EXCAVATION: self._handle_turn_to_excavation,
+            MissionState.NAV_TO_EXCAVATION: self._handle_nav_to_excavation,
+            MissionState.EXCAVATE: self._handle_excavate,
+            MissionState.TURN_TO_DEPOSITION: self._handle_turn_to_deposition,
+            MissionState.NAV_TO_DEPOSITION: self._handle_nav_to_deposition,
+            MissionState.DEPOSIT: self._handle_deposit,
+            MissionState.CHECK_NEXT_CYCLE_TIME: self._handle_check_next_cycle_time,
+            MissionState.SAFE_FAIL: self._handle_safe_fail,
+        }.get(self._state)
+
+        if handler is None:
+            self.get_logger().error(
+                f"No handler for state {self._state!r}; halting."
+            )
+            self._state = MissionState.HALT_MISSION
+            return
+
+        self._state = handler()
+
+    # ------------------------------------------------------------------
+    # State handlers
+    # ------------------------------------------------------------------
+
+    def _handle_initialize_mission(self) -> MissionState:
+        """Initialise mission state and create the cycle timer."""
+        self.get_logger().info("Initialising mission.")
+        self._timer = MissionTimer()
+        return MissionState.ACQUIRE_TAG
+
+    def _handle_acquire_tag(self) -> MissionState:
+        """Begin a new cycle and acquire the localisation tag."""
+        self.get_logger().info("Acquiring localisation tag.")
+        if self._timer is not None:
+            self._timer.beginCycle()
+        return MissionState.TURN_TO_EXCAVATION
+
+    def _handle_turn_to_excavation(self) -> MissionState:
+        """Turn the rover to face the excavation zone."""
+        self.get_logger().info("Turning to excavation zone.")
+        return MissionState.NAV_TO_EXCAVATION
+
+    def _handle_nav_to_excavation(self) -> MissionState:
+        """Navigate to the excavation zone."""
+        self.get_logger().info("Navigating to excavation zone.")
+        success, detail = self._send_navigate_to_excavation()
+        if not success:
+            self.get_logger().error(f"Navigation to excavation failed: {detail}")
+            return MissionState.SAFE_FAIL
+        return MissionState.EXCAVATE
+
+    def _handle_excavate(self) -> MissionState:
+        """Execute the excavation action."""
+        self.get_logger().info("Starting excavation.")
+        success, detail = self._send_excavate()
+        if not success:
+            self.get_logger().error(f"Excavation failed: {detail}")
+            return MissionState.SAFE_FAIL
+        return MissionState.TURN_TO_DEPOSITION
+
+    def _handle_turn_to_deposition(self) -> MissionState:
+        """Turn the rover to face the deposition zone."""
+        self.get_logger().info("Turning to deposition zone.")
+        return MissionState.NAV_TO_DEPOSITION
+
+    def _handle_nav_to_deposition(self) -> MissionState:
+        """Navigate to the deposition zone."""
+        self.get_logger().info("Navigating to deposition zone.")
+        success, detail = self._send_navigate_to_deposition()
+        if not success:
+            self.get_logger().error(f"Navigation to deposition failed: {detail}")
+            return MissionState.SAFE_FAIL
+        return MissionState.DEPOSIT
+
+    def _handle_deposit(self) -> MissionState:
+        """Execute the deposit action."""
+        self.get_logger().info("Starting deposit.")
+        success, detail = self._send_deposit()
+        if not success:
+            self.get_logger().error(f"Deposit failed: {detail}")
+            return MissionState.SAFE_FAIL
+        return MissionState.CHECK_NEXT_CYCLE_TIME
+
+    def _handle_check_next_cycle_time(self) -> MissionState:
+        """Record cycle time and decide whether to start another cycle."""
+        if self._timer is not None:
+            self._timer.recordCycleTime()
+
+        if self._timer is not None and self._timer.canStartCycle():
+            self.get_logger().info("Time budget allows another cycle.")
+            return MissionState.ACQUIRE_TAG
+
+        self.get_logger().info("Time budget exhausted; halting mission.")
+        return MissionState.HALT_MISSION
+
+    def _handle_safe_fail(self) -> MissionState:
+        """Log a safe-fail condition and transition to halt."""
+        self.get_logger().error("Safe-fail triggered; halting mission.")
+        return MissionState.HALT_MISSION
+
+    # ------------------------------------------------------------------
+    # Action helpers (injectable for testing)
+    # ------------------------------------------------------------------
+
+    def _wait_for_future(self, future, timeout_s: float, timeout_detail: str):
+        """Spin until a future completes and return its result."""
+        rclpy.spin_until_future_complete(self, future, timeout_sec=timeout_s)
+        if future.done():
+            return future.result()
+        return timeout_detail
+
+    def _wait_for_server(
+        self,
+        client: ActionClient,
+        action_name: str,
+        timeout_s: float = 30.0,
+    ) -> tuple[bool, str]:
+        """Block until an action server is available."""
+        if client.wait_for_server(timeout_sec=timeout_s):
+            return True, f"{action_name} server available"
+        return False, f"{action_name} server unavailable after {timeout_s}s"
+
+    def _send_navigate_to_excavation(self) -> tuple[bool, str]:
+        """Send a NavigateToPose goal toward the excavation zone."""
+        available, detail = self._wait_for_server(
+            self._navigate_client, "/navigate_to_pose_gate"
+        )
+        if not available:
+            return False, detail
+
+        goal = NavigateToPose.Goal()
+        goal.pose.header.frame_id = "map"
+        goal.pose.header.stamp = self.get_clock().now().to_msg()
+
+        send_future = self._navigate_client.send_goal_async(goal)
+        goal_handle = self._wait_for_future(
+            send_future, 30.0, "navigate_to_excavation goal response timed out"
+        )
+        return self._check_goal_result(goal_handle, "navigate_to_excavation", 60.0)
+
+    def _send_navigate_to_deposition(self) -> tuple[bool, str]:
+        """Send a NavigateToPose goal toward the deposition zone."""
+        available, detail = self._wait_for_server(
+            self._navigate_client, "/navigate_to_pose_gate"
+        )
+        if not available:
+            return False, detail
+
+        goal = NavigateToPose.Goal()
+        goal.pose.header.frame_id = "map"
+        goal.pose.header.stamp = self.get_clock().now().to_msg()
+
+        send_future = self._navigate_client.send_goal_async(goal)
+        goal_handle = self._wait_for_future(
+            send_future, 30.0, "navigate_to_deposition goal response timed out"
+        )
+        return self._check_goal_result(goal_handle, "navigate_to_deposition", 60.0)
+
+    def _send_excavate(self) -> tuple[bool, str]:
+        """Send an Excavate action goal."""
+        available, detail = self._wait_for_server(
+            self._excavate_client, "/mission/excavate"
+        )
+        if not available:
+            return False, detail
+
+        goal = Excavate.Goal()
+        goal.mode = Excavate.Goal.MODE_AUTO
+        goal.timeout_s = 60.0
+
+        send_future = self._excavate_client.send_goal_async(goal)
+        goal_handle = self._wait_for_future(
+            send_future, 30.0, "excavate goal response timed out"
+        )
+        return self._check_goal_result(goal_handle, "excavate", goal.timeout_s + 5.0)
+
+    def _send_deposit(self) -> tuple[bool, str]:
+        """Send a Deposit action goal."""
+        available, detail = self._wait_for_server(
+            self._deposit_client, "/mission/deposit"
+        )
+        if not available:
+            return False, detail
+
+        goal = Deposit.Goal()
+        goal.mode = Deposit.Goal.MODE_AUTO
+        goal.timeout_s = 30.0
+
+        send_future = self._deposit_client.send_goal_async(goal)
+        goal_handle = self._wait_for_future(
+            send_future, 30.0, "deposit goal response timed out"
+        )
+        return self._check_goal_result(goal_handle, "deposit", goal.timeout_s + 5.0)
+
+    def _check_goal_result(
+        self,
+        goal_handle,
+        action_name: str,
+        result_timeout_s: float,
+    ) -> tuple[bool, str]:
+        """Check the outcome of a goal handle and return success/detail."""
+        if isinstance(goal_handle, str):
+            return False, goal_handle
+        if goal_handle is None or not goal_handle.accepted:
+            return False, f"{action_name} goal rejected"
+
+        result_future = goal_handle.get_result_async()
+        result = self._wait_for_future(
+            result_future, result_timeout_s, f"{action_name} result timed out"
+        )
+        if isinstance(result, str):
+            return False, result
+        if result is None:
+            return False, f"{action_name} result unavailable"
+        if result.status != GoalStatus.STATUS_SUCCEEDED:
+            return False, f"{action_name} finished with status {result.status}"
+
+        return True, f"{action_name} succeeded"
+
+
+def main(args=None) -> None:
+    """Entry point for the mission_manager executable."""
+    rclpy.init(args=args)
+    node = MissionManager()
+    try:
+        node.run_mission()
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lunabot_bringup/setup.py
+++ b/src/lunabot_bringup/setup.py
@@ -45,6 +45,7 @@ setup(
         "console_scripts": [
             "navigate_to_pose_gate = lunabot_bringup.navigate_to_pose_gate:main",
             "mission_dry_run = lunabot_bringup.mission_dry_run:main",
+            "mission_manager = lunabot_bringup.mission_manager:main",
             "preflight_check = lunabot_bringup.preflight_check:main",
         ],
     },

--- a/src/lunabot_bringup/test/test_mission_manager.py
+++ b/src/lunabot_bringup/test/test_mission_manager.py
@@ -1,0 +1,200 @@
+"""Unit tests for MissionManager FSM transition logic."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from lunabot_bringup.mission_manager import MissionManager
+from lunabot_bringup.mission_manager import MissionState
+from lunabot_bringup.mission_timer import MissionTimer
+
+
+def _fake_logger():
+    """Return a lightweight logger stub."""
+    return SimpleNamespace(
+        info=lambda _msg: None,
+        error=lambda _msg: None,
+        warn=lambda _msg: None,
+    )
+
+
+def _make_manager(monkeypatch):
+    """Construct a MissionManager without spinning a real ROS node."""
+    monkeypatch.setattr(
+        "rclpy.node.Node.__init__",
+        lambda self, *args, **kwargs: None,
+    )
+    manager = object.__new__(MissionManager)
+    manager.get_logger = _fake_logger
+    manager._state = MissionState.INITIALIZE_MISSION
+    manager._timer = None
+    manager._navigate_client = MagicMock()
+    manager._excavate_client = MagicMock()
+    manager._deposit_client = MagicMock()
+    return manager
+
+
+# ------------------------------------------------------------------
+# Initial state
+# ------------------------------------------------------------------
+
+
+def test_initial_state_is_initialize_mission(monkeypatch):
+    """Initial FSM state must be INITIALIZE_MISSION."""
+    manager = _make_manager(monkeypatch)
+    assert manager._state == MissionState.INITIALIZE_MISSION
+
+
+# ------------------------------------------------------------------
+# INITIALIZE_MISSION
+# ------------------------------------------------------------------
+
+
+def test_initialize_mission_transitions_to_acquire_tag(monkeypatch):
+    """INITIALIZE_MISSION must transition to ACQUIRE_TAG and create a timer."""
+    manager = _make_manager(monkeypatch)
+    next_state = manager._handle_initialize_mission()
+    assert next_state == MissionState.ACQUIRE_TAG
+    assert isinstance(manager._timer, MissionTimer)
+
+
+# ------------------------------------------------------------------
+# Happy-path cycle
+# ------------------------------------------------------------------
+
+
+def test_acquire_tag_transitions_to_turn_to_excavation(monkeypatch):
+    """ACQUIRE_TAG must call beginCycle and advance to TURN_TO_EXCAVATION."""
+    manager = _make_manager(monkeypatch)
+    manager._timer = MagicMock(spec=MissionTimer)
+    next_state = manager._handle_acquire_tag()
+    manager._timer.beginCycle.assert_called_once()
+    assert next_state == MissionState.TURN_TO_EXCAVATION
+
+
+def test_turn_to_excavation_transitions_to_nav_to_excavation(monkeypatch):
+    """TURN_TO_EXCAVATION must transition to NAV_TO_EXCAVATION."""
+    manager = _make_manager(monkeypatch)
+    next_state = manager._handle_turn_to_excavation()
+    assert next_state == MissionState.NAV_TO_EXCAVATION
+
+
+def test_nav_to_excavation_success_transitions_to_excavate(monkeypatch):
+    """NAV_TO_EXCAVATION must advance to EXCAVATE on success."""
+    manager = _make_manager(monkeypatch)
+    monkeypatch.setattr(
+        manager, "_send_navigate_to_excavation", lambda: (True, "ok")
+    )
+    next_state = manager._handle_nav_to_excavation()
+    assert next_state == MissionState.EXCAVATE
+
+
+def test_excavate_success_transitions_to_turn_to_deposition(monkeypatch):
+    """EXCAVATE must advance to TURN_TO_DEPOSITION on success."""
+    manager = _make_manager(monkeypatch)
+    monkeypatch.setattr(manager, "_send_excavate", lambda: (True, "ok"))
+    next_state = manager._handle_excavate()
+    assert next_state == MissionState.TURN_TO_DEPOSITION
+
+
+def test_turn_to_deposition_transitions_to_nav_to_deposition(monkeypatch):
+    """TURN_TO_DEPOSITION must transition to NAV_TO_DEPOSITION."""
+    manager = _make_manager(monkeypatch)
+    next_state = manager._handle_turn_to_deposition()
+    assert next_state == MissionState.NAV_TO_DEPOSITION
+
+
+def test_nav_to_deposition_success_transitions_to_deposit(monkeypatch):
+    """NAV_TO_DEPOSITION must advance to DEPOSIT on success."""
+    manager = _make_manager(monkeypatch)
+    monkeypatch.setattr(
+        manager, "_send_navigate_to_deposition", lambda: (True, "ok")
+    )
+    next_state = manager._handle_nav_to_deposition()
+    assert next_state == MissionState.DEPOSIT
+
+
+def test_deposit_success_transitions_to_check_next_cycle_time(monkeypatch):
+    """DEPOSIT must advance to CHECK_NEXT_CYCLE_TIME on success."""
+    manager = _make_manager(monkeypatch)
+    monkeypatch.setattr(manager, "_send_deposit", lambda: (True, "ok"))
+    next_state = manager._handle_deposit()
+    assert next_state == MissionState.CHECK_NEXT_CYCLE_TIME
+
+
+# ------------------------------------------------------------------
+# CHECK_NEXT_CYCLE_TIME branching
+# ------------------------------------------------------------------
+
+
+def test_check_next_cycle_time_loops_when_can_start_cycle(monkeypatch):
+    """CHECK_NEXT_CYCLE_TIME must return ACQUIRE_TAG when canStartCycle is True."""
+    manager = _make_manager(monkeypatch)
+    mock_timer = MagicMock(spec=MissionTimer)
+    mock_timer.canStartCycle.return_value = True
+    manager._timer = mock_timer
+    next_state = manager._handle_check_next_cycle_time()
+    mock_timer.recordCycleTime.assert_called_once()
+    assert next_state == MissionState.ACQUIRE_TAG
+
+
+def test_check_next_cycle_time_halts_when_cannot_start_cycle(monkeypatch):
+    """CHECK_NEXT_CYCLE_TIME must return HALT_MISSION when canStartCycle is False."""
+    manager = _make_manager(monkeypatch)
+    mock_timer = MagicMock(spec=MissionTimer)
+    mock_timer.canStartCycle.return_value = False
+    manager._timer = mock_timer
+    next_state = manager._handle_check_next_cycle_time()
+    assert next_state == MissionState.HALT_MISSION
+
+
+# ------------------------------------------------------------------
+# Failure paths → SAFE_FAIL
+# ------------------------------------------------------------------
+
+
+def test_nav_to_excavation_failure_transitions_to_safe_fail(monkeypatch):
+    """NAV_TO_EXCAVATION failure must transition to SAFE_FAIL."""
+    manager = _make_manager(monkeypatch)
+    monkeypatch.setattr(
+        manager, "_send_navigate_to_excavation", lambda: (False, "nav failed")
+    )
+    next_state = manager._handle_nav_to_excavation()
+    assert next_state == MissionState.SAFE_FAIL
+
+
+def test_excavate_failure_transitions_to_safe_fail(monkeypatch):
+    """EXCAVATE failure must transition to SAFE_FAIL."""
+    manager = _make_manager(monkeypatch)
+    monkeypatch.setattr(manager, "_send_excavate", lambda: (False, "excavate failed"))
+    next_state = manager._handle_excavate()
+    assert next_state == MissionState.SAFE_FAIL
+
+
+def test_nav_to_deposition_failure_transitions_to_safe_fail(monkeypatch):
+    """NAV_TO_DEPOSITION failure must transition to SAFE_FAIL."""
+    manager = _make_manager(monkeypatch)
+    monkeypatch.setattr(
+        manager, "_send_navigate_to_deposition", lambda: (False, "nav failed")
+    )
+    next_state = manager._handle_nav_to_deposition()
+    assert next_state == MissionState.SAFE_FAIL
+
+
+def test_deposit_failure_transitions_to_safe_fail(monkeypatch):
+    """DEPOSIT failure must transition to SAFE_FAIL."""
+    manager = _make_manager(monkeypatch)
+    monkeypatch.setattr(manager, "_send_deposit", lambda: (False, "deposit failed"))
+    next_state = manager._handle_deposit()
+    assert next_state == MissionState.SAFE_FAIL
+
+
+# ------------------------------------------------------------------
+# SAFE_FAIL → HALT_MISSION
+# ------------------------------------------------------------------
+
+
+def test_safe_fail_transitions_to_halt_mission(monkeypatch):
+    """SAFE_FAIL must transition to HALT_MISSION."""
+    manager = _make_manager(monkeypatch)
+    next_state = manager._handle_safe_fail()
+    assert next_state == MissionState.HALT_MISSION


### PR DESCRIPTION
Closes #195

## What changed
- `lunabot_bringup/mission_manager.py` — new `MissionManager(Node)` with an 11-state shuttle-cycle FSM (INITIALIZE_MISSION → HALT_MISSION), owns one `MissionTimer`, calls `/navigate_to_pose_gate`, `/mission/excavate`, and `/mission/deposit` action servers; routes any phase failure through SAFE_FAIL
- `setup.py` — adds `mission_manager` console_scripts entry point
- `test/test_mission_manager.py` — 14 pytest unit tests covering FSM initialization, full happy-path cycle, CHECK_NEXT_CYCLE_TIME stop/go branching, all four operational failure→SAFE_FAIL paths, and SAFE_FAIL→HALT_MISSION

## Why
The rover had no top-level orchestrator to sequence travel, excavation, and deposition cycles — this is the missing autonomy layer that drives scoring. MissionTimer (landed in #194) is used as a black-box timing helper to decide whether another cycle fits within the 1200-second competition window.

## Test plan
- [ ] colcon test --packages-select lunabot_bringup passes
- [ ] colcon test-result shows 0 failures
- [ ] All 14 MissionManager unit tests pass

## Interface contracts
No contract changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a `MissionManager` ROS 2 node that orchestrates autonomous shuttle-cycle missions for the rover. The node implements an 11-state finite state machine (FSM) that manages the mission lifecycle from initialization through excavation, deposition, cycle timing checks, and graceful shutdown. The implementation treats navigation, excavation, and deposition as black-box action server calls and centralizes all mission-level sequencing logic in one place.

## Changes

**src/lunabot_bringup/lunabot_bringup/mission_manager.py** – New file
- Introduces the `MissionManager` node with an 11-state FSM for orchestrating shuttle-cycle autonomy
- Manages mission state transitions, action server communications, and cycle timing via an integrated `MissionTimer`
- Routes operational phase failures to a dedicated `SAFE_FAIL` state that logs errors before halting
- Provides the public `run_mission()` entry point and ROS 2 node launcher

**src/lunabot_bringup/setup.py**
- Added `mission_manager` console script entry point for ROS 2 launch and execution

**src/lunabot_bringup/test/test_mission_manager.py** – New file
- 14 unit tests validating FSM initialization, happy-path cycle flow, first-cycle unconditional behavior, `CHECK_NEXT_CYCLE_TIME` branching logic (stop/go based on remaining mission window), and all four operational failure-to-`SAFE_FAIL` paths

Closes issue #195.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->