### PR TITLE
Mission Manager Launchfile (196)

### DIFF
--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -16,7 +16,26 @@ Use bring-up launches when validating end-to-end behaviour. Avoid debugging subs
 ## Key files
 
 - `launch/`: stack launch entrypoints (navigation and related orchestration paths).
+- `launch/mission_manager.launch.py`: starts the standalone mission supervisor node.
 - `launch/mission_dry_run.launch.py`: one-command sim dry run for travel, excavate, and deposit.
+
+## Mission Manager
+
+Start just the mission supervisor node with:
+
+```bash
+ros2 launch lunabot_bringup mission_manager.launch.py
+```
+
+For direct executable discovery without the launch wrapper, run:
+
+```bash
+ros2 run lunabot_bringup mission_manager
+```
+
+This launch path only starts the supervisor node itself. Navigation, excavation,
+and deposition servers remain in their existing bringup paths and are not
+implicitly started here.
 
 ## Mission Dry Run
 

--- a/src/lunabot_bringup/launch/mission_manager.launch.py
+++ b/src/lunabot_bringup/launch/mission_manager.launch.py
@@ -1,0 +1,33 @@
+"""Launch the standalone mission manager node."""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def generate_launch_description():
+    """Start the mission manager with an overridable sim-time setting."""
+    use_sim_time = LaunchConfiguration("use_sim_time")
+
+    mission_manager = Node(
+        package="lunabot_bringup",
+        executable="mission_manager",
+        name="mission_manager",
+        output="screen",
+        parameters=[
+            {"use_sim_time": ParameterValue(use_sim_time, value_type=bool)}
+        ],
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "use_sim_time",
+                default_value="false",
+                description="Use /clock instead of wall time for the mission manager.",
+            ),
+            mission_manager,
+        ]
+    )

--- a/src/lunabot_bringup/launch/mission_manager.launch.py
+++ b/src/lunabot_bringup/launch/mission_manager.launch.py
@@ -1,5 +1,3 @@
-"""Launch file for the mission manager."""
-
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
@@ -8,7 +6,6 @@ from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
-    """Generate a launch description for the mission manager."""
     use_sim_time = LaunchConfiguration("use_sim_time")
 
     # Start only the standalone mission manager; dependent action servers stay separate.

--- a/src/lunabot_bringup/launch/mission_manager.launch.py
+++ b/src/lunabot_bringup/launch/mission_manager.launch.py
@@ -1,4 +1,4 @@
-"""Launch the standalone mission manager node."""
+"""Launch file for the mission manager."""
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -8,13 +8,10 @@ from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
-    """
-    Generate a launch description for the mission manager.
-
-    Start the standalone mission manager node with an overridable sim-time setting.
-    """
+    """Generate a launch description for the mission manager."""
     use_sim_time = LaunchConfiguration("use_sim_time")
 
+    # Start only the standalone mission manager; dependent action servers stay separate.
     mission_manager = Node(
         package="lunabot_bringup",
         executable="mission_manager",

--- a/src/lunabot_bringup/launch/mission_manager.launch.py
+++ b/src/lunabot_bringup/launch/mission_manager.launch.py
@@ -8,7 +8,11 @@ from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
-    """Start the mission manager with an overridable sim-time setting."""
+    """
+    Generate a launch description for the mission manager.
+
+    Start the standalone mission manager node with an overridable sim-time setting.
+    """
     use_sim_time = LaunchConfiguration("use_sim_time")
 
     mission_manager = Node(

--- a/src/lunabot_bringup/package.xml
+++ b/src/lunabot_bringup/package.xml
@@ -7,6 +7,8 @@
   <maintainer email="ko129@student.le.ac.uk">Leicester Lunabotics Team</maintainer>
   <license>Apache-2.0</license>
 
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/src/lunabot_bringup/test/test_mission_manager_launch.py
+++ b/src/lunabot_bringup/test/test_mission_manager_launch.py
@@ -1,5 +1,3 @@
-"""Tests for the standalone mission manager launch entrypoint."""
-
 import importlib.util
 from pathlib import Path
 
@@ -10,7 +8,6 @@ from launch_ros.actions import Node
 
 
 def _load_launch_module():
-    """Import the mission manager launch file as a Python module."""
     launch_path = (
         Path(__file__).resolve().parents[1]
         / "launch"
@@ -26,8 +23,6 @@ def _load_launch_module():
 
 
 def test_mission_manager_launch_starts_one_supervisor_node(monkeypatch):
-    """Mission manager launch shape.
-    Verify the entrypoint declares `use_sim_time` and starts one mission_manager node."""
     module = _load_launch_module()
     description = module.generate_launch_description()
 

--- a/src/lunabot_bringup/test/test_mission_manager_launch.py
+++ b/src/lunabot_bringup/test/test_mission_manager_launch.py
@@ -26,7 +26,8 @@ def _load_launch_module():
 
 
 def test_mission_manager_launch_starts_one_supervisor_node(monkeypatch):
-    """Mission manager launch shape. Verify the entrypoint declares `use_sim_time` and starts one mission_manager node."""
+    """Mission manager launch shape.
+    Verify the entrypoint declares `use_sim_time` and starts one mission_manager node."""
     module = _load_launch_module()
     description = module.generate_launch_description()
 

--- a/src/lunabot_bringup/test/test_mission_manager_launch.py
+++ b/src/lunabot_bringup/test/test_mission_manager_launch.py
@@ -1,0 +1,46 @@
+"""Tests for the standalone mission manager launch entrypoint."""
+
+import importlib.util
+from pathlib import Path
+
+from launch.actions import DeclareLaunchArgument
+from launch_ros.actions import Node
+
+
+def _load_launch_module():
+    """Import the mission manager launch file as a Python module."""
+    launch_path = (
+        Path(__file__).resolve().parents[1]
+        / "launch"
+        / "mission_manager.launch.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "mission_manager_launch", launch_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mission_manager_launch_starts_one_supervisor_node():
+    """The launch entrypoint should expose a single mission_manager node."""
+    module = _load_launch_module()
+    launch_source = (
+        Path(__file__).resolve().parents[1]
+        / "launch"
+        / "mission_manager.launch.py"
+    ).read_text()
+    description = module.generate_launch_description()
+
+    nodes = [entity for entity in description.entities if isinstance(entity, Node)]
+    declared_arguments = [
+        entity.name
+        for entity in description.entities
+        if isinstance(entity, DeclareLaunchArgument)
+    ]
+
+    assert declared_arguments == ["use_sim_time"]
+    assert len(nodes) == 1
+    assert nodes[0].__dict__.get("_Node__node_name") == "mission_manager"
+    assert 'executable="mission_manager"' in launch_source

--- a/src/lunabot_bringup/test/test_mission_manager_launch.py
+++ b/src/lunabot_bringup/test/test_mission_manager_launch.py
@@ -46,4 +46,4 @@ def test_mission_manager_launch_starts_one_supervisor_node(monkeypatch):
     monkeypatch.setattr(ExecuteProcess, "execute", lambda self, context: None)
     nodes[0].execute(context)
 
-    assert nodes[0].node_name == "mission_manager"
+    assert nodes[0].node_name.rsplit("/", 1)[-1] == "mission_manager"

--- a/src/lunabot_bringup/test/test_mission_manager_launch.py
+++ b/src/lunabot_bringup/test/test_mission_manager_launch.py
@@ -26,7 +26,7 @@ def _load_launch_module():
 
 
 def test_mission_manager_launch_starts_one_supervisor_node(monkeypatch):
-    """The launch entrypoint should expose a single mission_manager node."""
+    """Mission manager launch shape. Verify the entrypoint declares `use_sim_time` and starts one mission_manager node."""
     module = _load_launch_module()
     description = module.generate_launch_description()
 

--- a/src/lunabot_bringup/test/test_mission_manager_launch.py
+++ b/src/lunabot_bringup/test/test_mission_manager_launch.py
@@ -42,5 +42,5 @@ def test_mission_manager_launch_starts_one_supervisor_node():
 
     assert declared_arguments == ["use_sim_time"]
     assert len(nodes) == 1
-    assert nodes[0].__dict__.get("_Node__node_name") == "mission_manager"
+    assert nodes[0].node_name == "mission_manager"
     assert 'executable="mission_manager"' in launch_source

--- a/src/lunabot_bringup/test/test_mission_manager_launch.py
+++ b/src/lunabot_bringup/test/test_mission_manager_launch.py
@@ -3,7 +3,9 @@
 import importlib.util
 from pathlib import Path
 
+from launch import LaunchContext
 from launch.actions import DeclareLaunchArgument
+from launch.actions import ExecuteProcess
 from launch_ros.actions import Node
 
 
@@ -23,14 +25,9 @@ def _load_launch_module():
     return module
 
 
-def test_mission_manager_launch_starts_one_supervisor_node():
+def test_mission_manager_launch_starts_one_supervisor_node(monkeypatch):
     """The launch entrypoint should expose a single mission_manager node."""
     module = _load_launch_module()
-    launch_source = (
-        Path(__file__).resolve().parents[1]
-        / "launch"
-        / "mission_manager.launch.py"
-    ).read_text()
     description = module.generate_launch_description()
 
     nodes = [entity for entity in description.entities if isinstance(entity, Node)]
@@ -42,5 +39,11 @@ def test_mission_manager_launch_starts_one_supervisor_node():
 
     assert declared_arguments == ["use_sim_time"]
     assert len(nodes) == 1
+    assert nodes[0].node_executable == "mission_manager"
+
+    context = LaunchContext()
+    context.launch_configurations["use_sim_time"] = "false"
+    monkeypatch.setattr(ExecuteProcess, "execute", lambda self, context: None)
+    nodes[0].execute(context)
+
     assert nodes[0].node_name == "mission_manager"
-    assert 'executable="mission_manager"' in launch_source


### PR DESCRIPTION
Integrated mission manager into lunabot_bringup with a launch file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds a launch entrypoint and documentation to run the Mission Manager supervisor standalone from lunabot_bringup.

## Changes
- New launch entrypoint: launch/mission_manager.launch.py — adds a launch description that declares a use_sim_time argument and starts the mission_manager node.
- Documentation: README updated to document the new launch entrypoint and clarify it only starts the supervisor (does not start navigation, excavation, or deposition servers).
- Package metadata: package.xml adds exec dependencies on launch and launch_ros.
- Tests: new test that loads the launch file, verifies the use_sim_time argument, ensures a single node uses the mission_manager executable, and exercises node execution in a launch context.

## Impact
- Runtime behavior: provides a supported bringup entrypoint for running the Mission Manager supervisor; no changes to the mission_manager node logic.
- Review effort: low (small launch and metadata additions, README update, and one launch test).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->