### PR TITLE
Add initial Python quality gates

### DIFF
--- a/.github/requirements-preflight.txt
+++ b/.github/requirements-preflight.txt
@@ -1,1 +1,6 @@
 PyYAML==6.0.2
+pyright>=1.1,<2
+radon>=6,<7
+ruff>=0.11,<0.12
+yamllint>=1.35,<2
+xenon>=0.9,<0.10

--- a/.github/scripts/run_preflight_checks.py
+++ b/.github/scripts/run_preflight_checks.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import py_compile
-import sys
 from pathlib import Path
 
 import yaml
@@ -43,7 +42,9 @@ def _check_python(files: list[Path]) -> list[str]:
         try:
             py_compile.compile(str(path), doraise=True)
         except py_compile.PyCompileError as exc:
-            errors.append(f"Python syntax error in {path.relative_to(REPO_ROOT)}: {exc.msg}")
+            errors.append(
+                f"Python syntax error in {path.relative_to(REPO_ROOT)}: {exc.msg}"
+            )
     return errors
 
 

--- a/.github/scripts/run_quality_checks.py
+++ b/.github/scripts/run_quality_checks.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Run repository quality checks for Python, YAML, and workflow files."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BLOCKING_PYTHON_TARGETS = [
+    ".github/scripts",
+]
+ADVISORY_PYTHON_TARGETS = [
+    ".github/scripts",
+    "tools",
+    "src/lunabot_bringup",
+    "src/lunabot_control",
+    "src/lunabot_excavation",
+    "src/lunabot_localisation",
+]
+BLOCKING_YAML_TARGETS = [
+    ".github",
+    ".pre-commit-config.yaml",
+    ".yamllint.yml",
+]
+COMPLEXITY_TARGETS = [
+    "tools",
+    "src/lunabot_bringup",
+    "src/lunabot_control",
+    "src/lunabot_excavation",
+    "src/lunabot_localisation",
+]
+
+
+def _run(command: list[str]) -> int:
+    result = subprocess.run(command, cwd=REPO_ROOT)
+    return result.returncode
+
+
+def _blocking_commands() -> list[list[str]]:
+    return [
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            *BLOCKING_PYTHON_TARGETS,
+            "--output-format",
+            "concise",
+            "--select",
+            "E,F,W",
+            "--ignore",
+            "E501",
+        ],
+        [sys.executable, "-m", "ruff", "format", "--check", *BLOCKING_PYTHON_TARGETS],
+        [sys.executable, "-m", "yamllint", *BLOCKING_YAML_TARGETS],
+    ]
+
+
+def _advisory_commands() -> list[list[str]]:
+    return [
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            *ADVISORY_PYTHON_TARGETS,
+            "--output-format",
+            "concise",
+            "--select",
+            "I,B,UP,SIM,RET,ARG,PTH,RUF,C4",
+            "--ignore",
+            "B008",
+        ],
+        [sys.executable, "-m", "pyright"],
+        [
+            sys.executable,
+            "-m",
+            "xenon",
+            "--max-absolute",
+            "C",
+            "--max-modules",
+            "B",
+            "--max-average",
+            "B",
+            *COMPLEXITY_TARGETS,
+        ],
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("blocking", "advisory"),
+        required=True,
+        help="Select the quality gate set to run.",
+    )
+    args = parser.parse_args()
+
+    commands = _blocking_commands() if args.mode == "blocking" else _advisory_commands()
+
+    failures = 0
+    for command in commands:
+        print(f"Running: {' '.join(command)}")
+        failures += _run(command)
+
+    if failures:
+        print(f"{args.mode.capitalize()} quality checks failed.")
+        return 1
+
+    print(f"{args.mode.capitalize()} quality checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/select_ci_packages.py
+++ b/.github/scripts/select_ci_packages.py
@@ -165,7 +165,9 @@ def _select(
             return Selection("full", (), f"Broad package changed: {package}")
 
         if package not in SAFE_SELECT_PACKAGES:
-            return Selection("full", (), f"Package not whitelisted for selective CI: {package}")
+            return Selection(
+                "full", (), f"Package not whitelisted for selective CI: {package}"
+            )
 
         changed_packages.add(package)
 
@@ -194,10 +196,14 @@ def main() -> int:
     package_roots, dependencies = _discover_packages()
     changed_files = _git_changed_files(args.base_sha, args.head_sha)
     ros_ci = requires_ros_ci(changed_files)
-    selection = _select(changed_files, package_roots, dependencies) if ros_ci else Selection(
-        "skip",
-        (),
-        "ROS build/test not needed for this change set",
+    selection = (
+        _select(changed_files, package_roots, dependencies)
+        if ros_ci
+        else Selection(
+            "skip",
+            (),
+            "ROS build/test not needed for this change set",
+        )
     )
 
     summary = {

--- a/.github/scripts/test_select_ci_packages.py
+++ b/.github/scripts/test_select_ci_packages.py
@@ -28,7 +28,10 @@ def main() -> int:
 
     ros_ci_scenarios = {
         "docs_only_skips_ros_ci": (["README.md"], False),
-        "src_change_needs_ros_ci": (["src/lunabot_teleop/config/xbox_teleop.yaml"], True),
+        "src_change_needs_ros_ci": (
+            ["src/lunabot_teleop/config/xbox_teleop.yaml"],
+            True,
+        ),
         "workflow_change_needs_ros_ci": ([".github/workflows/ci.yml"], True),
         "empty_diff_forces_ros_ci": ([], True),
     }
@@ -138,7 +141,9 @@ def main() -> int:
             "packages=",
             "reason=ROS build/test not needed for this change set",
         ]
-        missing = [fragment for fragment in expected_fragments if fragment not in output]
+        missing = [
+            fragment for fragment in expected_fragments if fragment not in output
+        ]
         if missing:
             print("CI package selector regression checks failed:")
             for fragment in missing:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,18 @@ jobs:
           python .github/scripts/test_select_ci_packages.py
         shell: bash
 
+      - name: Run blocking repository quality checks
+        run: python .github/scripts/run_quality_checks.py --mode blocking
+        shell: bash
+
+      - name: Lint GitHub Actions workflows
+        uses: rhysd/actionlint@v1
+
+      - name: Run advisory repository quality checks
+        continue-on-error: true
+        run: python .github/scripts/run_quality_checks.py --mode advisory
+        shell: bash
+
       - name: Determine comparison range
         id: range
         run: |

--- a/.github/workflows/nightly-full-ci.yml
+++ b/.github/workflows/nightly-full-ci.yml
@@ -173,6 +173,23 @@ jobs:
           python3 .github/scripts/check_interface_contracts.py
         shell: bash
 
+      - name: Install repository quality tools
+        run: |
+          python3 -m pip install --disable-pip-version-check -r .github/requirements-preflight.txt
+        shell: bash
+
+      - name: Run blocking repository quality checks
+        run: python3 .github/scripts/run_quality_checks.py --mode blocking
+        shell: bash
+
+      - name: Lint GitHub Actions workflows
+        uses: rhysd/actionlint@v1
+
+      - name: Run advisory repository quality checks
+        continue-on-error: true
+        run: python3 .github/scripts/run_quality_checks.py --mode advisory
+        shell: bash
+
       - name: Build
         run: |
           source /opt/ros/humble/setup.bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.13
+    hooks:
+      - id: ruff
+        args: [--select, E, F, W, --ignore, E501]
+      - id: ruff-format
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,16 @@
+extends: default
+
+ignore: |
+  build/
+  install/
+  log/
+  logs/
+  cache/
+  research/
+  src/external/
+
+rules:
+  document-start: disable
+  line-length: disable
+  comments-indentation: disable
+  truthy: disable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+extend-exclude = [
+  "build",
+  "install",
+  "log",
+  "logs",
+  "cache",
+  "research",
+  "src/external",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"
+

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,29 @@
+{
+  "include": [
+    ".github/scripts",
+    "tools",
+    "src/lunabot_bringup",
+    "src/lunabot_control",
+    "src/lunabot_excavation",
+    "src/lunabot_localisation"
+  ],
+  "exclude": [
+    "**/__pycache__",
+    "build",
+    "install",
+    "log",
+    "logs",
+    "cache",
+    "research",
+    "src/external"
+  ],
+  "typeCheckingMode": "basic",
+  "reportMissingImports": false,
+  "reportMissingModuleSource": false,
+  "reportUnknownVariableType": false,
+  "reportUnknownArgumentType": false,
+  "reportUnknownMemberType": false,
+  "reportUntypedFunctionDecorator": false,
+  "pythonVersion": "3.10"
+}
+


### PR DESCRIPTION
## Summary
Add the first phase of repo-level Python quality tooling and CI checks.

## What changed
- add Ruff, Pyright, Xenon, Yamllint and pre-commit configuration
- add a quality-check runner that separates blocking and advisory checks
- wire the blocking and advisory quality checks into CI and nightly CI
- keep the blocking scope deliberately modest so the branch remains mergeable while we burn down existing debt package by package

## Notes
- blocking checks pass locally
- advisory checks are expected to report existing debt in bringup, control, excavation, localisation and tools
- this is the infrastructure PR for the staged rollout, not the full clean-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Python Quality Gates Infrastructure

This PR establishes the foundational infrastructure for Python code quality checks across the repository. It introduces configurations and tooling for repository-level quality validation, separating concerns into blocking checks that enforce code standards and advisory checks that track technical debt.

### Key Additions

**Quality Tools & Configuration**
- Adds Ruff configuration for linting and formatting enforcement
- Adds Pyright configuration for Python static type checking
- Adds Yamllint configuration for YAML validation
- Introduces Xenon for code complexity analysis
- Configures pre-commit hooks to enforce quality checks locally

**Quality Check Runner**
- New `run_quality_checks.py` script that orchestrates quality checks with two modes:
  - **Blocking mode**: Runs restrictive Ruff lint rules, formatting checks, and YAML linting; currently passes locally
  - **Advisory mode**: Runs broader quality checks (Ruff, Pyright, Xenon) to report existing technical debt

**CI Integration**
- Updates main CI workflow to run blocking checks (must pass) and advisory checks (reported but non-blocking)
- Updates nightly CI job to include the same quality checks
- Adds GitHub Actions workflow linting via actionlint

### Scope & Strategy

The blocking scope is intentionally modest to allow the PR to merge while existing technical debt is addressed package-by-package. Advisory checks are expected to report issues in: bringup, control, excavation, localisation, and tools packages. This provides infrastructure for a staged rollout of quality standards across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->