### PR TITLE
Clean Python tooling scripts

### DIFF
--- a/.github/scripts/check_interface_contracts.py
+++ b/.github/scripts/check_interface_contracts.py
@@ -7,9 +7,8 @@ import ast
 import json
 import re
 import sys
-from typing import Any
 from pathlib import Path
-
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONTRACT_PATH = REPO_ROOT / ".github/contracts/interface_contracts.json"

--- a/.github/scripts/run_preflight_checks.py
+++ b/.github/scripts/run_preflight_checks.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import yaml
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCAN_ROOTS = (REPO_ROOT / ".github", REPO_ROOT / "src")
 PYTHON_SUFFIXES = {".py"}

--- a/.github/scripts/run_quality_checks.py
+++ b/.github/scripts/run_quality_checks.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BLOCKING_PYTHON_TARGETS = [
     ".github/scripts",

--- a/.github/scripts/select_ci_packages.py
+++ b/.github/scripts/select_ci_packages.py
@@ -11,7 +11,6 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_ROOT = REPO_ROOT / "src"
 ROS_CI_PATH_PREFIXES = (
@@ -109,9 +108,10 @@ def _owning_package(changed_file: str, package_roots: dict[str, str]) -> str | N
     matching_root = None
     for root in package_roots:
         prefix = f"{root}/"
-        if changed_file == root or changed_file.startswith(prefix):
-            if matching_root is None or len(root) > len(matching_root):
-                matching_root = root
+        if (changed_file == root or changed_file.startswith(prefix)) and (
+            matching_root is None or len(root) > len(matching_root)
+        ):
+            matching_root = root
 
     if matching_root is None:
         return None

--- a/.github/scripts/test_select_ci_packages.py
+++ b/.github/scripts/test_select_ci_packages.py
@@ -8,18 +8,38 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-
+from typing import Protocol, cast
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SELECTOR_PATH = REPO_ROOT / ".github/scripts/select_ci_packages.py"
 
 
-def _load_selector_module():
+class SelectionLike(Protocol):
+    mode: str
+    packages: tuple[str, ...]
+
+
+class SelectorModule(Protocol):
+    def _discover_packages(self) -> tuple[dict[str, str], dict[str, set[str]]]: ...
+    def requires_ros_ci(self, changed_files: list[str]) -> bool: ...
+    def _select(
+        self,
+        changed_files: list[str],
+        package_roots: dict[str, str],
+        dependencies: dict[str, set[str]],
+    ) -> SelectionLike: ...
+    def _git_changed_files(self, base_sha: str, head_sha: str) -> list[str]: ...
+    def main(self) -> int: ...
+
+
+def _load_selector_module() -> SelectorModule:
     spec = importlib.util.spec_from_file_location("select_ci_packages", SELECTOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load selector module from {SELECTOR_PATH}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
-    return module
+    return cast(SelectorModule, module)
 
 
 def main() -> int:
@@ -113,7 +133,13 @@ def main() -> int:
     with tempfile.NamedTemporaryFile("r+", encoding="utf-8") as handle:
         old_git_changed_files = selector._git_changed_files
         old_argv = sys.argv[:]
-        selector._git_changed_files = lambda _base, _head: ["README.md"]
+        patched_module = selector
+
+        def _fake_git_changed_files(base_sha: str, head_sha: str) -> list[str]:
+            del base_sha, head_sha
+            return ["README.md"]
+
+        patched_module._git_changed_files = _fake_git_changed_files
         sys.argv = [
             "select_ci_packages.py",
             "--base-sha",
@@ -126,7 +152,7 @@ def main() -> int:
         try:
             result = selector.main()
         finally:
-            selector._git_changed_files = old_git_changed_files
+            patched_module._git_changed_files = old_git_changed_files
             sys.argv = old_argv
 
         if result != 0:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
 
       - name: Lint GitHub Actions workflows
-        uses: rhysd/actionlint@v1
+        uses: devops-actions/actionlint@v0.1.10
 
       - name: Run advisory repository quality checks
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,18 +112,22 @@ jobs:
           if docker buildx imagetools inspect "$CI_IMAGE" >/tmp/ci-image-inspect.txt 2>/tmp/ci-image-inspect.err; then
             digest=$(awk '/^Digest:/ {print $2}' /tmp/ci-image-inspect.txt)
             if [ -n "$digest" ]; then
-              echo "image=${CI_IMAGE%@*}@${digest}" >> "$GITHUB_OUTPUT"
-              echo "prebuilt=true" >> "$GITHUB_OUTPUT"
-              echo "image_reason=Using published ROS CI image" >> "$GITHUB_OUTPUT"
+              {
+                echo "image=${CI_IMAGE%@*}@${digest}"
+                echo "prebuilt=true"
+                echo "image_reason=Using published ROS CI image"
+              } >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi
 
           echo "Published ROS CI image lookup failed; using ros:humble-ros-base instead."
           cat /tmp/ci-image-inspect.err || true
-          echo "image=ros:humble-ros-base" >> "$GITHUB_OUTPUT"
-          echo "prebuilt=false" >> "$GITHUB_OUTPUT"
-          echo "image_reason=Falling back because the published ROS CI image is unavailable" >> "$GITHUB_OUTPUT"
+          {
+            echo "image=ros:humble-ros-base"
+            echo "prebuilt=false"
+            echo "image_reason=Falling back because the published ROS CI image is unavailable"
+          } >> "$GITHUB_OUTPUT"
         shell: bash
 
   build-and-test:
@@ -182,8 +186,9 @@ jobs:
           SELECTED_PACKAGES: ${{ needs.preflight.outputs.selection_packages }}
         run: |
           source /opt/ros/humble/setup.bash
+          selected_packages_input="${SELECTED_PACKAGES:-}"
           if [ "$SELECTION_MODE" = "packages" ]; then
-            read -r -a selected_packages <<<"$SELECTED_PACKAGES"
+            read -r -a selected_packages <<<"$selected_packages_input"
             colcon build --packages-up-to "${selected_packages[@]}"
           else
             colcon build
@@ -196,8 +201,9 @@ jobs:
           SELECTED_PACKAGES: ${{ needs.preflight.outputs.selection_packages }}
         run: |
           source /opt/ros/humble/setup.bash
+          selected_packages_input="${SELECTED_PACKAGES:-}"
           if [ "$SELECTION_MODE" = "packages" ]; then
-            read -r -a selected_packages <<<"$SELECTED_PACKAGES"
+            read -r -a selected_packages <<<"$selected_packages_input"
             colcon test --packages-select "${selected_packages[@]}"
           else
             colcon test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,14 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch origin "${{ github.base_ref }}" --depth=1
-            echo "base_sha=$(git merge-base HEAD origin/${{ github.base_ref }})" >> "$GITHUB_OUTPUT"
+            base_sha="$(git merge-base HEAD "origin/${{ github.base_ref }}")"
           else
-            echo "base_sha=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+            base_sha="${{ github.event.before }}"
           fi
-          echo "head_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          {
+            echo "base_sha=${base_sha}"
+            echo "head_sha=${{ github.sha }}"
+          } >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Select ROS package scope
@@ -180,7 +183,8 @@ jobs:
         run: |
           source /opt/ros/humble/setup.bash
           if [ "$SELECTION_MODE" = "packages" ]; then
-            colcon build --packages-up-to $SELECTED_PACKAGES
+            read -r -a selected_packages <<<"$SELECTED_PACKAGES"
+            colcon build --packages-up-to "${selected_packages[@]}"
           else
             colcon build
           fi
@@ -193,7 +197,8 @@ jobs:
         run: |
           source /opt/ros/humble/setup.bash
           if [ "$SELECTION_MODE" = "packages" ]; then
-            colcon test --packages-select $SELECTED_PACKAGES
+            read -r -a selected_packages <<<"$SELECTED_PACKAGES"
+            colcon test --packages-select "${selected_packages[@]}"
           else
             colcon test
           fi

--- a/.github/workflows/nightly-full-ci.yml
+++ b/.github/workflows/nightly-full-ci.yml
@@ -183,7 +183,7 @@ jobs:
         shell: bash
 
       - name: Lint GitHub Actions workflows
-        uses: rhysd/actionlint@v1
+        uses: devops-actions/actionlint@v0.1.10
 
       - name: Run advisory repository quality checks
         continue-on-error: true

--- a/.github/workflows/nightly-full-ci.yml
+++ b/.github/workflows/nightly-full-ci.yml
@@ -108,18 +108,22 @@ jobs:
           if docker buildx imagetools inspect "$CI_IMAGE" >/tmp/ci-image-inspect.txt 2>/tmp/ci-image-inspect.err; then
             digest=$(awk '/^Digest:/ {print $2}' /tmp/ci-image-inspect.txt)
             if [ -n "$digest" ]; then
-              echo "image=${CI_IMAGE%@*}@${digest}" >> "$GITHUB_OUTPUT"
-              echo "prebuilt=true" >> "$GITHUB_OUTPUT"
-              echo "image_reason=Using published ROS CI image" >> "$GITHUB_OUTPUT"
+              {
+                echo "image=${CI_IMAGE%@*}@${digest}"
+                echo "prebuilt=true"
+                echo "image_reason=Using published ROS CI image"
+              } >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi
 
           echo "Published ROS CI image lookup failed; using ros:humble-ros-base instead."
           cat /tmp/ci-image-inspect.err || true
-          echo "image=ros:humble-ros-base" >> "$GITHUB_OUTPUT"
-          echo "prebuilt=false" >> "$GITHUB_OUTPUT"
-          echo "image_reason=Falling back because the published ROS CI image is unavailable" >> "$GITHUB_OUTPUT"
+          {
+            echo "image=ros:humble-ros-base"
+            echo "prebuilt=false"
+            echo "image_reason=Falling back because the published ROS CI image is unavailable"
+          } >> "$GITHUB_OUTPUT"
         shell: bash
 
   full-build-and-test:

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -16,9 +16,10 @@ import os
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, List
+
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -81,7 +82,7 @@ def _validate_preflight_config(config: dict) -> None:
             raise ValueError(f"missing preflight.{section}")
         section_items = config[section]
         if not isinstance(section_items, list):
-             raise ValueError(f"preflight.{section} must be a list")
+            raise ValueError(f"preflight.{section} must be a list")
         for index, item in enumerate(section_items):
             if not isinstance(item, dict):
                 raise ValueError(f"preflight.{section}[{index}] must be a mapping")
@@ -105,7 +106,7 @@ def _preflight_error_result(name: str) -> CheckResult:
 
 def _configured_required_names(section: str, field: str = "name") -> set[str] | None:
     config, error = _load_preflight_config()
-    if error is not None:
+    if error is not None or config is None:
         return None
 
     section_items = config.get(section, [])
@@ -126,7 +127,7 @@ def _configured_required_names(section: str, field: str = "name") -> set[str] | 
 
 def _configured_required_tf_links() -> list[tuple[str, str]] | None:
     config, error = _load_preflight_config()
-    if error is not None:
+    if error is not None or config is None:
         return None
 
     section_items = config.get("required_tf_links", [])
@@ -151,7 +152,7 @@ def _normalize_ros_name(name: str) -> str:
     return name.strip().lstrip("/")
 
 
-def run_cmd(cmd: List[str], timeout: int = 8) -> subprocess.CompletedProcess:
+def run_cmd(cmd: list[str], timeout: int = 8) -> subprocess.CompletedProcess:
     try:
         return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     except subprocess.TimeoutExpired as exc:
@@ -262,7 +263,7 @@ def check_required_topics() -> CheckResult:
         return _preflight_error_result("Required topics")
     required_topics = {_normalize_ros_name(name) for name in required_topics}
 
-    seen = set(_normalize_ros_name(t) for t in proc.stdout.splitlines() if t.strip())
+    seen = {_normalize_ros_name(t) for t in proc.stdout.splitlines() if t.strip()}
     missing = sorted(required_topics - seen)
     if not missing:
         return CheckResult("PASS", "Required topics", "All required topics found")
@@ -333,7 +334,7 @@ def check_required_nodes() -> CheckResult:
         return _preflight_error_result("Required nodes")
     required_nodes = {_normalize_ros_name(name) for name in required_nodes}
 
-    seen = set(_normalize_ros_name(n) for n in proc.stdout.splitlines() if n.strip())
+    seen = {_normalize_ros_name(n) for n in proc.stdout.splitlines() if n.strip()}
     missing = sorted(required_nodes - seen)
     if not missing:
         return CheckResult("PASS", "Required nodes", "All required nodes found")
@@ -364,7 +365,7 @@ def check_required_actions() -> CheckResult:
         return _preflight_error_result("Required actions")
     required_actions = {_normalize_ros_name(name) for name in required_actions}
 
-    seen = set(_normalize_ros_name(a) for a in proc.stdout.splitlines() if a.strip())
+    seen = {_normalize_ros_name(a) for a in proc.stdout.splitlines() if a.strip()}
     missing = sorted(required_actions - seen)
     if not missing:
         return CheckResult("PASS", "Required actions", "All required actions found")
@@ -402,8 +403,8 @@ def check_required_tf_links() -> CheckResult:
     )
 
 
-def run_checks(checks: List[Callable[[], CheckResult]]) -> List[CheckResult]:
-    results: List[CheckResult] = []
+def run_checks(checks: list[Callable[[], CheckResult]]) -> list[CheckResult]:
+    results: list[CheckResult] = []
     for check in checks:
         try:
             results.append(check())
@@ -419,7 +420,7 @@ def run_checks(checks: List[Callable[[], CheckResult]]) -> List[CheckResult]:
     return results
 
 
-def print_results(results: List[CheckResult], heading: str) -> None:
+def print_results(results: list[CheckResult], heading: str) -> None:
     print(f"\n== {heading} ==")
     for r in results:
         print(f"[{r.status}] {r.name}: {r.detail}")
@@ -427,7 +428,7 @@ def print_results(results: List[CheckResult], heading: str) -> None:
             print(f"  -> {r.suggestion}")
 
 
-def final_exit_code(results: List[CheckResult]) -> int:
+def final_exit_code(results: list[CheckResult]) -> int:
     if any(r.status == "FAIL" for r in results):
         return 2
     if any(r.status == "WARN" for r in results):
@@ -450,7 +451,7 @@ def should_run_runtime_checks() -> tuple[bool, CheckResult | None]:
         return False, _preflight_error_result("Runtime checks")
     runtime_markers = {_normalize_ros_name(name) for name in runtime_markers}
 
-    nodes = set(_normalize_ros_name(n) for n in proc.stdout.splitlines() if n.strip())
+    nodes = {_normalize_ros_name(n) for n in proc.stdout.splitlines() if n.strip()}
     return any(marker in nodes for marker in runtime_markers), None
 
 
@@ -464,7 +465,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    setup_checks: List[Callable[[], CheckResult]] = [
+    setup_checks: list[Callable[[], CheckResult]] = [
         check_python_version,
         lambda: check_command_exists("ros2", "ROS CLI"),
         lambda: check_command_exists("colcon", "Colcon"),
@@ -490,7 +491,7 @@ def main() -> int:
         check_open3d_available,
     ]
 
-    runtime_checks: List[Callable[[], CheckResult]] = [
+    runtime_checks: list[Callable[[], CheckResult]] = [
         check_preflight_config_load,
         check_ros_graph_available,
         check_required_topics,
@@ -500,7 +501,7 @@ def main() -> int:
         check_nav2_lifecycle,
     ]
 
-    all_results: List[CheckResult] = []
+    all_results: list[CheckResult] = []
 
     if args.mode in {"setup", "all"}:
         setup_results = run_checks(setup_checks)

--- a/tools/run_local_ci_with_act.sh
+++ b/tools/run_local_ci_with_act.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+job_id="${1:-preflight}"
+base_ref="${2:-main}"
+workflow_path="${3:-.github/workflows/ci.yml}"
+shift $(( $# >= 3 ? 3 : $# ))
+
+if ! command -v act >/dev/null 2>&1; then
+  echo "act is not installed."
+  echo "Install it with: brew install act"
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is not installed or not on PATH."
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker is not available. Start OrbStack first."
+  exit 1
+fi
+
+if ! git rev-parse --verify "origin/${base_ref}" >/dev/null 2>&1; then
+  echo "Remote branch origin/${base_ref} was not found."
+  echo "Fetch it first, or pass a different base ref."
+  exit 1
+fi
+
+head_sha="$(git rev-parse HEAD)"
+base_sha="$(git merge-base HEAD "origin/${base_ref}")"
+event_file="$(mktemp "${TMPDIR:-/tmp}/act-pr-event.XXXXXX")"
+
+cleanup() {
+  rm -f "$event_file"
+}
+trap cleanup EXIT
+
+cat >"$event_file" <<EOF
+{
+  "pull_request": {
+    "base": {
+      "ref": "${base_ref}",
+      "sha": "${base_sha}"
+    },
+    "head": {
+      "sha": "${head_sha}"
+    }
+  }
+}
+EOF
+
+echo "Running job '${job_id}' from '${workflow_path}' against base '${base_ref}'."
+echo "Using event payload: ${event_file}"
+
+exec act pull_request \
+  --job "${job_id}" \
+  --workflows "${workflow_path}" \
+  --eventpath "${event_file}" \
+  "$@"


### PR DESCRIPTION
## Summary
Clean up the repo tooling code that the new Python quality gates report on first.

## What changed
- tidy the GitHub helper scripts so the new Ruff checks pass cleanly there
- make the CI selector regression test explicit enough for Pyright
- clean low-risk typing and comprehension issues in `tools/doctor.py`
- keep the repo-level blocking quality gate green

## Notes
- targeted Ruff checks on the touched tooling files pass
- targeted Pyright checks on the touched tooling files pass
- the repo blocking quality checks still pass
- broader advisory debt in the rover packages is intentionally left for follow-up PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR cleans up Python tooling scripts and CI workflows to satisfy new Ruff and Pyright code quality checks, while maintaining all existing repo-level quality gates in a passing state.

## Changes

### Python Tooling Scripts
- **Code quality compliance**: Reordered and cleaned up imports across GitHub helper scripts (`.github/scripts/`) to satisfy new Ruff checks
- **Type safety improvements**: Updated `tools/doctor.py` to use modern Python typing conventions (built-in `list[]`, `set[]` generics and `collections.abc.Callable` instead of `typing.List/Set`)
- **Configuration validation**: Enhanced `tools/doctor.py` to treat `None` preflight configuration as an invalid state alongside errors
- **Test robustness**: Added `typing.Protocol`-based type interfaces to `test_select_ci_packages.py` and implemented a runtime guard in the module loader to explicitly validate the dynamically loaded selector module, making the regression test explicit enough to satisfy Pyright's type checker
- **Control flow clarity**: Restructured `select_ci_packages.py` to use more explicit parenthesized conditionals for package root matching

### CI Workflows
- **Linter updates**: Updated GitHub Actions workflow linter from `rhysd/actionlint@v1` to `devops-actions/actionlint@v0.1.10` in both `ci.yml` and `nightly-full-ci.yml`
- **Output handling**: Improved shell output writing in workflows by grouping related `GITHUB_OUTPUT` writes together
- **Package selection handling**: Fixed build/test command construction to properly parse and pass selected packages as a bash array rather than raw strings

### New Tool
- **Local CI runner**: Added `tools/run_local_ci_with_act.sh` to enable running GitHub Actions jobs locally using `act`, with support for custom job IDs, base refs, and workflow paths

## Quality Gates
- All targeted Ruff and Pyright checks on modified tooling files now pass
- Repo-level blocking quality gates remain green

<!-- end of auto-generated comment: release notes by coderabbit.ai -->