### PR TITLE
Refactor localisation runtime paths for quality gates

### DIFF
--- a/src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py
+++ b/src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py
@@ -3,28 +3,26 @@
 from __future__ import annotations
 
 import math
+from contextlib import suppress
 
-from geometry_msgs.msg import PoseWithCovarianceStamped
-from geometry_msgs.msg import Twist
-from lunabot_interfaces.msg import LocalisationStartZoneStatus
-from nav_msgs.msg import Odometry
 import rclpy
+import tf2_ros
+from geometry_msgs.msg import PoseWithCovarianceStamped, Twist
+from nav_msgs.msg import Odometry
 from rclpy.duration import Duration
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
-from rclpy.qos import DurabilityPolicy
-from rclpy.qos import HistoryPolicy
-from rclpy.qos import QoSProfile
-from rclpy.qos import ReliabilityPolicy
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
 from rclpy.time import Time
 from robot_localization.srv import SetPose
 from tf2_ros import Buffer, TransformListener
-import tf2_ros
 
-from lunabot_localisation.start_zone_logic import angle_delta
-from lunabot_localisation.start_zone_logic import PoseSample
-from lunabot_localisation.start_zone_logic import StableLockTracker
-
+from lunabot_interfaces.msg import LocalisationStartZoneStatus
+from lunabot_localisation.start_zone_logic import (
+    PoseSample,
+    StableLockTracker,
+    angle_delta,
+)
 
 STATE_IDLE = "idle"
 STATE_SEARCHING = "searching"
@@ -463,14 +461,113 @@ class StartZoneLocaliser(Node):
             self._stop_search_motion()
             return True
 
-        try:
+        with suppress(Exception):  # pragma: no cover - discarded result only
             self.discarded_set_pose_future.result()
-        except Exception:  # pragma: no cover - defensive path
-            pass
 
         self.discarded_set_pose_future = None
         self.discarded_set_pose_started_ns = None
         return True
+
+    def _clock_requires_reset(self, now_ns: int) -> bool:
+        """Return whether the localiser must reinitialise due to ROS time changes."""
+        return self.last_timer_now_ns is None or now_ns < self.last_timer_now_ns
+
+    def _handle_missing_tf(self, now_ns: int) -> bool:
+        """Handle the bounded wait for the required TF chain."""
+        if self._required_tf_available():
+            return False
+
+        assert self.search_started_ns is not None
+        self.set_pose_attempt_started_ns = None
+        tf_wait_elapsed_s = float(now_ns - self.search_started_ns) / 1e9
+        if (
+            self._should_fail_timeout(now_ns)
+            or tf_wait_elapsed_s >= self.tf_missing_timeout_s
+        ):
+            self._set_state(
+                STATE_FAILED,
+                REASON_TF_MISSING,
+                "Required TF for start-zone localisation never became available.",
+            )
+        else:
+            self._set_state(
+                STATE_SEARCHING,
+                REASON_TF_MISSING,
+                "Waiting for the map/tag or camera/base TF chain.",
+            )
+        self._stop_search_motion()
+        return True
+
+    def _handle_fresh_lock_window(self, now_ns: int) -> None:
+        """Track a candidate lock and start EKF seeding once it is stable."""
+        if self.state != STATE_CANDIDATE_LOCK:
+            self.candidate_entered_ns = now_ns
+        self._set_state(
+            STATE_CANDIDATE_LOCK,
+            REASON_UNSTABLE,
+            "Tag detected; waiting for a stable lock window.",
+        )
+        self._publish_search_cmd(
+            self.search_sign * self.candidate_alignment_angular_speed_rad_s
+        )
+
+        candidate_elapsed_ns = 0
+        if self.candidate_entered_ns is not None:
+            candidate_elapsed_ns = now_ns - self.candidate_entered_ns
+
+        if (
+            candidate_elapsed_ns >= int(self.candidate_settle_duration_s * 1e9)
+            and self.lock_tracker.has_stable_lock(
+                now_ns=now_ns,
+                window_ns=self.stable_window_ns,
+                min_samples=self.stable_window_min_samples,
+                max_gap_ns=self.max_sample_gap_ns,
+                max_translation_spread_m=self.max_lock_translation_spread_m,
+                max_yaw_spread_rad=self.max_lock_yaw_spread_rad,
+            )
+        ):
+            self._maybe_start_set_pose(now_ns)
+
+    def _handle_missing_lock_window(self, now_ns: int, latest_sample: PoseSample | None) -> None:
+        """Continue the bounded search when no fresh stable lock is available."""
+        self.candidate_entered_ns = None
+        self.set_pose_attempt_started_ns = None
+        if latest_sample is not None:
+            self._set_state(
+                STATE_SEARCHING,
+                REASON_STALE,
+                "Tag lock was lost before it became stable.",
+            )
+        else:
+            self._set_state(
+                STATE_SEARCHING,
+                REASON_SEARCHING,
+                "Searching for the start-zone AprilTag.",
+            )
+
+        if self._should_fail_timeout(now_ns):
+            self._set_state(
+                STATE_FAILED,
+                REASON_TIMEOUT,
+                "Timed out before a stable start-zone tag lock was achieved.",
+            )
+            self._stop_search_motion()
+            return
+
+        self._publish_search_cmd(self.search_sign * self.angular_speed_rad_s)
+
+    def _handle_lock_tracking(self, now_ns: int) -> None:
+        """Advance the candidate-lock state machine from accepted tag samples."""
+        self.lock_tracker.prune(now_ns - self.stable_window_ns)
+        self.lock_tracker.prune_future(now_ns)
+        latest_sample = self.lock_tracker.latest()
+        has_fresh_sample = self.lock_tracker.is_fresh(now_ns, self.max_sample_gap_ns)
+
+        if has_fresh_sample:
+            self._handle_fresh_lock_window(now_ns)
+            return
+
+        self._handle_missing_lock_window(now_ns, latest_sample)
 
     def _on_timer(self) -> None:
         """Run the bounded acquisition state machine and publish status."""
@@ -489,9 +586,7 @@ class StartZoneLocaliser(Node):
             self._publish_status(now_ns)
             return
 
-        if self.last_timer_now_ns is not None and now_ns < self.last_timer_now_ns:
-            self._reset_after_clock_jump(now_ns)
-        elif self.search_started_ns is None:
+        if self._clock_requires_reset(now_ns) or self.search_started_ns is None:
             self._reset_after_clock_jump(now_ns)
 
         self.last_timer_now_ns = now_ns
@@ -509,85 +604,11 @@ class StartZoneLocaliser(Node):
             self._publish_status(now_ns)
             return
 
-        if not self._required_tf_available():
-            self.set_pose_attempt_started_ns = None
-            if self._should_fail_timeout(now_ns) or (
-                float(now_ns - self.search_started_ns) / 1e9
-            ) >= self.tf_missing_timeout_s:
-                self._set_state(
-                    STATE_FAILED,
-                    REASON_TF_MISSING,
-                    "Required TF for start-zone localisation never became available.",
-                )
-            else:
-                self._set_state(
-                    STATE_SEARCHING,
-                    REASON_TF_MISSING,
-                    "Waiting for the map/tag or camera/base TF chain.",
-                )
-            self._stop_search_motion()
+        if self._handle_missing_tf(now_ns):
             self._publish_status(now_ns)
             return
 
-        self.lock_tracker.prune(now_ns - self.stable_window_ns)
-        self.lock_tracker.prune_future(now_ns)
-        latest_sample = self.lock_tracker.latest()
-        has_fresh_sample = self.lock_tracker.is_fresh(now_ns, self.max_sample_gap_ns)
-
-        if has_fresh_sample:
-            if self.state != STATE_CANDIDATE_LOCK:
-                self.candidate_entered_ns = now_ns
-            self._set_state(
-                STATE_CANDIDATE_LOCK,
-                REASON_UNSTABLE,
-                "Tag detected; waiting for a stable lock window.",
-            )
-            self._publish_search_cmd(
-                self.search_sign * self.candidate_alignment_angular_speed_rad_s
-            )
-
-            candidate_elapsed_ns = 0
-            if self.candidate_entered_ns is not None:
-                candidate_elapsed_ns = now_ns - self.candidate_entered_ns
-
-            if (
-                candidate_elapsed_ns >= int(self.candidate_settle_duration_s * 1e9)
-                and self.lock_tracker.has_stable_lock(
-                    now_ns=now_ns,
-                    window_ns=self.stable_window_ns,
-                    min_samples=self.stable_window_min_samples,
-                    max_gap_ns=self.max_sample_gap_ns,
-                    max_translation_spread_m=self.max_lock_translation_spread_m,
-                    max_yaw_spread_rad=self.max_lock_yaw_spread_rad,
-                )
-            ):
-                self._maybe_start_set_pose(now_ns)
-        else:
-            self.candidate_entered_ns = None
-            self.set_pose_attempt_started_ns = None
-            if latest_sample is not None:
-                self._set_state(
-                    STATE_SEARCHING,
-                    REASON_STALE,
-                    "Tag lock was lost before it became stable.",
-                )
-            else:
-                self._set_state(
-                    STATE_SEARCHING,
-                    REASON_SEARCHING,
-                    "Searching for the start-zone AprilTag.",
-                )
-
-            if self._should_fail_timeout(now_ns):
-                self._set_state(
-                    STATE_FAILED,
-                    REASON_TIMEOUT,
-                    "Timed out before a stable start-zone tag lock was achieved.",
-                )
-                self._stop_search_motion()
-            else:
-                self._publish_search_cmd(self.search_sign * self.angular_speed_rad_s)
-
+        self._handle_lock_tracking(now_ns)
         self._publish_status(now_ns)
 
 

--- a/src/lunabot_localisation/lunabot_localisation/start_zone_logic.py
+++ b/src/lunabot_localisation/lunabot_localisation/start_zone_logic.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import math
 from collections import deque
 from dataclasses import dataclass
-import math
 
 
 @dataclass(frozen=True)
@@ -93,10 +93,7 @@ class StableLockTracker:
         if self.translation_spread() > max_translation_spread_m:
             return False
 
-        if self.yaw_spread() > max_yaw_spread_rad:
-            return False
-
-        return True
+        return not self.yaw_spread() > max_yaw_spread_rad
 
     def translation_spread(self) -> float:
         """Return the maximum planar distance between tracked samples."""

--- a/src/lunabot_localisation/lunabot_localisation/tag_pose_publisher.py
+++ b/src/lunabot_localisation/lunabot_localisation/tag_pose_publisher.py
@@ -2,10 +2,10 @@
 
 import math
 
-from apriltag_msgs.msg import AprilTagDetectionArray
 import rclpy
-import tf2_ros
 import tf2_geometry_msgs
+import tf2_ros
+from apriltag_msgs.msg import AprilTagDetectionArray
 from geometry_msgs.msg import Pose, PoseWithCovarianceStamped, TransformStamped
 from rclpy.duration import Duration
 from rclpy.executors import MultiThreadedExecutor
@@ -90,6 +90,91 @@ class TagPosePublisher(Node):
 
         self.timer = self.create_timer(0.1, self.on_timer)
 
+    def _detection_metadata_ready(self) -> bool:
+        """Return whether the current TF sample has matching detection metadata."""
+        if self.latest_detection_stamp_ns is None:
+            self.get_logger().debug("Dropping tag detection without matching metadata")
+            return False
+        if self.latest_detection_hamming is None or self.latest_detection_margin is None:
+            self.get_logger().debug("Dropping tag detection with incomplete metadata")
+            return False
+        return True
+
+    def _metadata_allows_publication(self, detection_stamp_ns: int) -> bool:
+        """Return whether metadata and timing allow this tag sample to be used."""
+        if not self._detection_metadata_ready():
+            return False
+
+        detection_metadata_stamp_ns = self.latest_detection_stamp_ns
+        detection_hamming = self.latest_detection_hamming
+        detection_margin = self.latest_detection_margin
+        assert detection_metadata_stamp_ns is not None
+        assert detection_hamming is not None
+        assert detection_margin is not None
+
+        sync_error_sec = abs(detection_stamp_ns - detection_metadata_stamp_ns) / 1e9
+        if sync_error_sec > self.max_detection_sync_slop_sec:
+            self.get_logger().debug(
+                "Dropping unsynchronised tag detection "
+                f"(tf_vs_msg={sync_error_sec:.3f}s)"
+            )
+            return False
+
+        # Past this point the metadata and TF sample are aligned strongly enough
+        # that retries are no longer useful.
+        self.last_processed_stamp_ns = detection_stamp_ns
+
+        if detection_hamming > self.max_hamming:
+            self.get_logger().debug(
+                "Dropping low-quality tag detection "
+                f"(hamming={detection_hamming})"
+            )
+            return False
+
+        if detection_margin < self.min_decision_margin:
+            self.get_logger().debug(
+                "Dropping low-confidence tag detection "
+                f"(margin={detection_margin:.1f})"
+            )
+            return False
+
+        return True
+
+    def _age_allows_publication(self, detection_stamp_ns: int) -> bool:
+        """Return whether the tag sample is recent enough to trust."""
+        if detection_stamp_ns <= 0:
+            return True
+
+        now_ns = self.get_clock().now().nanoseconds
+        age_sec = (now_ns - detection_stamp_ns) / 1e9
+        if age_sec > self.max_detection_age_sec:
+            self.get_logger().debug(
+                f"Dropping stale tag detection (age={age_sec:.3f}s)"
+            )
+            return False
+        if age_sec < -0.05:
+            self.get_logger().debug(
+                f"Dropping future-dated tag detection (age={age_sec:.3f}s)"
+            )
+            return False
+        return True
+
+    def _should_log_correction(
+        self, pose_msg: PoseWithCovarianceStamped, yaw: float
+    ) -> bool:
+        """Return whether the current correction differs enough to report."""
+        if self.last_logged_pose is None:
+            return True
+
+        dx_log = pose_msg.pose.pose.position.x - self.last_logged_pose[0]
+        dy_log = pose_msg.pose.pose.position.y - self.last_logged_pose[1]
+        translation_delta = math.sqrt(dx_log * dx_log + dy_log * dy_log)
+        yaw_delta = abs(self._angle_delta(yaw, self.last_logged_pose[2]))
+        return (
+            translation_delta >= self.correction_log_min_translation_delta_m
+            or yaw_delta >= self.correction_log_min_yaw_delta_rad
+        )
+
     @staticmethod
     def _stamp_to_ns(stamp) -> int:
         return int(stamp.sec) * 1_000_000_000 + int(stamp.nanosec)
@@ -155,49 +240,11 @@ class TagPosePublisher(Node):
         if detection_stamp_ns == self.last_processed_stamp_ns:
             return
 
-        if self.latest_detection_stamp_ns is None:
-            self.get_logger().debug("Dropping tag detection without matching metadata")
+        if not self._metadata_allows_publication(detection_stamp_ns):
             return
 
-        sync_error_sec = abs(detection_stamp_ns - self.latest_detection_stamp_ns) / 1e9
-        if sync_error_sec > self.max_detection_sync_slop_sec:
-            self.get_logger().debug(
-                "Dropping unsynchronised tag detection "
-                f"(tf_vs_msg={sync_error_sec:.3f}s)"
-            )
+        if not self._age_allows_publication(detection_stamp_ns):
             return
-
-        # Past this point the metadata and TF sample are aligned strongly enough
-        # that retries are no longer useful.
-        self.last_processed_stamp_ns = detection_stamp_ns
-
-        if self.latest_detection_hamming > self.max_hamming:
-            self.get_logger().debug(
-                "Dropping low-quality tag detection "
-                f"(hamming={self.latest_detection_hamming})"
-            )
-            return
-
-        if self.latest_detection_margin < self.min_decision_margin:
-            self.get_logger().debug(
-                "Dropping low-confidence tag detection "
-                f"(margin={self.latest_detection_margin:.1f})"
-            )
-            return
-
-        if detection_stamp_ns > 0:
-            now_ns = self.get_clock().now().nanoseconds
-            age_sec = (now_ns - detection_stamp_ns) / 1e9
-            if age_sec > self.max_detection_age_sec:
-                self.get_logger().debug(
-                    f"Dropping stale tag detection (age={age_sec:.3f}s)"
-                )
-                return
-            if age_sec < -0.05:
-                self.get_logger().debug(
-                    f"Dropping future-dated tag detection (age={age_sec:.3f}s)"
-                )
-                return
 
         detected_tag_to_map = TransformStamped()
         detected_tag_to_map.header = map_to_tag.header
@@ -248,16 +295,7 @@ class TagPosePublisher(Node):
         self.pub.publish(msg)
         now_ns = self.get_clock().now().nanoseconds
         yaw = self._yaw_from_quaternion(msg.pose.pose.orientation)
-        should_log = self.last_logged_pose is None
-        if not should_log:
-            dx_log = msg.pose.pose.position.x - self.last_logged_pose[0]
-            dy_log = msg.pose.pose.position.y - self.last_logged_pose[1]
-            translation_delta = math.sqrt(dx_log * dx_log + dy_log * dy_log)
-            yaw_delta = abs(self._angle_delta(yaw, self.last_logged_pose[2]))
-            should_log = (
-                translation_delta >= self.correction_log_min_translation_delta_m
-                or yaw_delta >= self.correction_log_min_yaw_delta_rad
-            )
+        should_log = self._should_log_correction(msg, yaw)
 
         if (
             should_log


### PR DESCRIPTION
## Summary
- split the localisation runtime callbacks into smaller bounded helpers in the tag pose publisher and start-zone localiser
- fix optional-metadata handling in the tag pose bridge so stale or incomplete detection metadata is rejected explicitly
- simplify the start-zone stable-lock tracker and timeout/TF handling paths without changing the runtime state machine

## Verification
- `uv run --with ruff==0.11.13 ruff check src/lunabot_localisation/lunabot_localisation/tag_pose_publisher.py src/lunabot_localisation/lunabot_localisation/start_zone_logic.py src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py --output-format concise --select I,B,UP,SIM,RET,ARG,PTH,RUF,C4 --ignore B008`
- `uv run --with radon==6.0.1 radon cc -s -a src/lunabot_localisation/lunabot_localisation/tag_pose_publisher.py src/lunabot_localisation/lunabot_localisation/start_zone_logic.py src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py`
- `PYTHONPATH=src/lunabot_localisation uv run --with pytest pytest -q src/lunabot_localisation/test/test_start_zone_logic.py`
- `python3 -m compileall src/lunabot_localisation/lunabot_localisation/tag_pose_publisher.py src/lunabot_localisation/lunabot_localisation/start_zone_logic.py src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py`

## Notes
- Targeted Pyright on these files is reduced to the existing generated ROS message import symbol for `LocalisationStartZoneStatus`.
- I kept this PR scoped to the runtime localisation modules and did not pull in the broader launch/setup Path cleanups yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR refactors the localisation runtime modules to improve code quality and robustness. The changes focus on breaking down complex control-flow logic into smaller, bounded helper functions and strengthening validation of detection metadata.

## Changes

**tag_pose_publisher.py**
- Hardened metadata validation for tag detections by explicitly rejecting stale or incomplete detection metadata before processing
- Improved code clarity by extracting publication gating checks into dedicated helper methods while preserving the same validation logic

**start_zone_localiser.py**
- Refactored the main timer callback logic into smaller, focused helper methods for clock reset detection, TF availability handling, and lock-window tracking
- Simplified exception handling in the set-pose completion path
- Preserved the existing state-machine behavior and runtime outcomes

**start_zone_logic.py**
- Simplified the yaw-spread stability check logic

## Verification
All changes have been verified with:
- Ruff code quality checks (I, B, UP, SIM, RET, ARG, PTH, RUF, C4 rules)
- Cyclomatic complexity analysis
- pytest for start-zone logic tests
- Python bytecode compilation

## Impact
- No changes to public API or exported entities
- No changes to runtime state-machine behavior or motion/publishing side effects
- Improved code maintainability and readability
- Enhanced detection metadata validation for improved data quality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->