### PR TITLE
Harden bringup preflight QoS validation

### DIFF
--- a/src/lunabot_bringup/lunabot_bringup/preflight_check.py
+++ b/src/lunabot_bringup/lunabot_bringup/preflight_check.py
@@ -6,34 +6,34 @@ import argparse
 import json
 import sys
 import time
-from dataclasses import asdict
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from ament_index_python.packages import get_package_share_directory
-from lunabot_interfaces.action import Deposit
-from lunabot_interfaces.action import Excavate
-from nav2_msgs.action import NavigateToPose
 import rclpy
+import yaml
+from ament_index_python.packages import get_package_share_directory
+from nav2_msgs.action import NavigateToPose
 from rclpy.action import ActionClient
 from rclpy.node import Node
 from rclpy.parameter import Parameter
-from rclpy.qos import QoSDurabilityPolicy
-from rclpy.qos import QoSHistoryPolicy
-from rclpy.qos import QoSProfile
-from rclpy.qos import QoSReliabilityPolicy
+from rclpy.qos import (
+    QoSDurabilityPolicy,
+    QoSHistoryPolicy,
+    QoSProfile,
+    QoSReliabilityPolicy,
+)
 from rclpy.time import Time
 from rclpy.utilities import remove_ros_args
 from rosidl_runtime_py.utilities import get_message
-from tf2_ros import Buffer
-from tf2_ros import TransformListener
-import yaml
+from tf2_ros import Buffer, TransformListener
 
-from lunabot_bringup.preflight_profiles import filter_preflight_config
-from lunabot_bringup.preflight_profiles import PHASE_FULL
-from lunabot_bringup.preflight_profiles import VALID_PHASES
-
+from lunabot_bringup.preflight_profiles import (
+    PHASE_FULL,
+    VALID_PHASES,
+    filter_preflight_config,
+)
+from lunabot_interfaces.action import Deposit, Excavate
 
 EXIT_OK = 0
 EXIT_CRITICAL_FAILURE = 2
@@ -47,6 +47,14 @@ ACTION_TYPE_MAP: dict[str, type] = {
 
 TRUE_STRINGS = {"1", "true", "yes", "on"}
 FALSE_STRINGS = {"0", "false", "no", "off"}
+RELIABILITY_MAP = {
+    "best_effort": QoSReliabilityPolicy.BEST_EFFORT,
+    "reliable": QoSReliabilityPolicy.RELIABLE,
+}
+DURABILITY_MAP = {
+    "volatile": QoSDurabilityPolicy.VOLATILE,
+    "transient_local": QoSDurabilityPolicy.TRANSIENT_LOCAL,
+}
 
 
 @dataclass
@@ -73,6 +81,24 @@ def _repo_contract_path() -> Path:
     return Path.cwd() / ".github" / "contracts" / "interface_contracts.json"
 
 
+def _parse_qos_policy(
+    value: str,
+    mapping: dict[str, Any],
+    *,
+    field_name: str,
+) -> Any:
+    """Parse one named QoS policy and reject unknown configuration values."""
+    normalised = value.strip().lower()
+    try:
+        return mapping[normalised]
+    except KeyError as exc:
+        supported_values = ", ".join(sorted(mapping))
+        raise ValueError(
+            f"Unsupported {field_name} policy '{value}'. "
+            f"Expected one of: {supported_values}"
+        ) from exc
+
+
 def _merge_contract_requirements(config: dict[str, Any], logger) -> dict[str, Any]:
     """Merge contract-defined topics and TF checks into preflight config."""
     preflight = config.setdefault("preflight", {})
@@ -93,7 +119,7 @@ def _merge_contract_requirements(config: dict[str, Any], logger) -> dict[str, An
         return config
 
     topics = preflight.setdefault("required_topics", [])
-    topic_keys = {(item.get("name"), item.get("type")) for item in topics}
+    topic_keys = dict.fromkeys((item.get("name"), item.get("type")) for item in topics)
     for item in contract.get("topics", []):
         if not isinstance(item, dict):
             continue
@@ -112,10 +138,10 @@ def _merge_contract_requirements(config: dict[str, Any], logger) -> dict[str, An
             }
         )
         logger.info(f"Added contract topic check: {item.get('name')}")
-        topic_keys.add(key)
+        topic_keys[key] = None
 
     tf_links = preflight.setdefault("required_tf_links", [])
-    tf_keys = {(item.get("parent"), item.get("child")) for item in tf_links}
+    tf_keys = dict.fromkeys((item.get("parent"), item.get("child")) for item in tf_links)
     for item in contract.get("tf_links", []):
         if not isinstance(item, dict):
             continue
@@ -133,7 +159,7 @@ def _merge_contract_requirements(config: dict[str, Any], logger) -> dict[str, An
         parent = item.get("parent")
         child = item.get("child")
         logger.info(f"Added contract TF check: {parent}->{child}")
-        tf_keys.add(key)
+        tf_keys[key] = None
 
     return config
 
@@ -220,25 +246,77 @@ class PreflightChecker(Node):
 
     def _topic_types(self) -> dict[str, list[str]]:
         """Return discovered topic types keyed by topic name."""
-        return {name: types for name, types in self.get_topic_names_and_types()}
+        return dict(self.get_topic_names_and_types())
 
     @staticmethod
     def _parse_reliability(value: str) -> QoSReliabilityPolicy:
         """Return QoS reliability from config text."""
-        mapping = {
-            "best_effort": QoSReliabilityPolicy.BEST_EFFORT,
-            "reliable": QoSReliabilityPolicy.RELIABLE,
-        }
-        return mapping.get(value.lower(), QoSReliabilityPolicy.BEST_EFFORT)
+        return _parse_qos_policy(
+            value,
+            RELIABILITY_MAP,
+            field_name="reliability",
+        )
 
     @staticmethod
     def _parse_durability(value: str) -> QoSDurabilityPolicy:
         """Return QoS durability from config text."""
-        mapping = {
-            "volatile": QoSDurabilityPolicy.VOLATILE,
-            "transient_local": QoSDurabilityPolicy.TRANSIENT_LOCAL,
-        }
-        return mapping.get(value.lower(), QoSDurabilityPolicy.VOLATILE)
+        return _parse_qos_policy(
+            value,
+            DURABILITY_MAP,
+            field_name="durability",
+        )
+
+    def _wait_for_topic_discovery(
+        self,
+        topic_name: str,
+        *,
+        timeout_s: float,
+    ) -> list[str] | None:
+        """Wait until one topic appears on the graph and return its types."""
+        discovery_deadline = time.monotonic() + timeout_s
+        while time.monotonic() < discovery_deadline:
+            discovered_types = self._topic_types().get(topic_name)
+            if discovered_types:
+                return discovered_types
+            rclpy.spin_once(self, timeout_sec=0.1)
+        return None
+
+    def _wait_for_required_messages(
+        self,
+        topic_name: str,
+        message_type,
+        *,
+        min_messages: int,
+        timeout_s: float,
+        reliability: QoSReliabilityPolicy,
+        durability: QoSDurabilityPolicy,
+    ) -> int:
+        """Wait for the required message count on one topic."""
+        received = {"count": 0}
+        qos = QoSProfile(
+            history=QoSHistoryPolicy.KEEP_LAST,
+            depth=10,
+            reliability=reliability,
+            durability=durability,
+        )
+
+        subscription = self.create_subscription(
+            message_type,
+            topic_name,
+            lambda _msg, bucket=received: bucket.__setitem__(
+                "count", bucket["count"] + 1
+            ),
+            qos,
+        )
+
+        try:
+            deadline = time.monotonic() + timeout_s
+            while time.monotonic() < deadline and received["count"] < min_messages:
+                rclpy.spin_once(self, timeout_sec=0.1)
+        finally:
+            self.destroy_subscription(subscription)
+
+        return received["count"]
 
     def _check_required_topics(self) -> None:
         """Check required topics for type and message flow."""
@@ -254,21 +332,29 @@ class PreflightChecker(Node):
             expected_type = topic_cfg["type"]
             min_messages = int(topic_cfg.get("min_messages", 1))
             critical = bool(topic_cfg.get("critical", True))
-            reliability = self._parse_reliability(
-                str(topic_cfg.get("reliability", "best_effort"))
-            )
-            durability = self._parse_durability(
-                str(topic_cfg.get("durability", "volatile"))
-            )
             started = time.monotonic()
 
-            discovery_deadline = time.monotonic() + discovery_timeout_s
-            discovered_types: list[str] | None = None
-            while time.monotonic() < discovery_deadline:
-                discovered_types = self._topic_types().get(topic_name)
-                if discovered_types:
-                    break
-                rclpy.spin_once(self, timeout_sec=0.1)
+            try:
+                reliability = self._parse_reliability(
+                    str(topic_cfg.get("reliability", "best_effort"))
+                )
+                durability = self._parse_durability(
+                    str(topic_cfg.get("durability", "volatile"))
+                )
+            except ValueError as exc:
+                self._record(
+                    f"topic:{topic_name}",
+                    critical,
+                    False,
+                    str(exc),
+                    started,
+                )
+                continue
+
+            discovered_types = self._wait_for_topic_discovery(
+                topic_name,
+                timeout_s=discovery_timeout_s,
+            )
 
             if not discovered_types:
                 self._record(
@@ -293,40 +379,26 @@ class PreflightChecker(Node):
                 continue
 
             message_type = get_message(expected_type)
-            received = {"count": 0}
-            qos = QoSProfile(
-                history=QoSHistoryPolicy.KEEP_LAST,
-                depth=10,
+            received_count = self._wait_for_required_messages(
+                topic_name,
+                message_type,
+                min_messages=min_messages,
+                timeout_s=msg_timeout_s,
                 reliability=reliability,
                 durability=durability,
             )
 
-            subscription = self.create_subscription(
-                message_type,
-                topic_name,
-                lambda _msg, bucket=received: bucket.__setitem__(
-                    "count", bucket["count"] + 1
-                ),
-                qos,
-            )
-
-            deadline = time.monotonic() + msg_timeout_s
-            while time.monotonic() < deadline and received["count"] < min_messages:
-                rclpy.spin_once(self, timeout_sec=0.1)
-
-            self.destroy_subscription(subscription)
-
-            if received["count"] >= min_messages:
+            if received_count >= min_messages:
                 self._record(
                     f"topic:{topic_name}",
                     critical,
                     True,
-                    f"received {received['count']} msg(s)",
+                    f"received {received_count} msg(s)",
                     started,
                 )
                 continue
 
-            detail = f"received {received['count']} msg(s), "
+            detail = f"received {received_count} msg(s), "
             detail += f"expected >= {min_messages}"
             self._record(
                 f"topic:{topic_name}",

--- a/src/lunabot_bringup/lunabot_bringup/preflight_check.py
+++ b/src/lunabot_bringup/lunabot_bringup/preflight_check.py
@@ -119,7 +119,11 @@ def _merge_contract_requirements(config: dict[str, Any], logger) -> dict[str, An
         return config
 
     topics = preflight.setdefault("required_topics", [])
-    topic_keys = dict.fromkeys((item.get("name"), item.get("type")) for item in topics)
+    topic_keys = dict.fromkeys(
+        (item.get("name"), item.get("type"))
+        for item in topics
+        if isinstance(item, dict)
+    )
     for item in contract.get("topics", []):
         if not isinstance(item, dict):
             continue
@@ -141,7 +145,11 @@ def _merge_contract_requirements(config: dict[str, Any], logger) -> dict[str, An
         topic_keys[key] = None
 
     tf_links = preflight.setdefault("required_tf_links", [])
-    tf_keys = dict.fromkeys((item.get("parent"), item.get("child")) for item in tf_links)
+    tf_keys = dict.fromkeys(
+        (item.get("parent"), item.get("child"))
+        for item in tf_links
+        if isinstance(item, dict)
+    )
     for item in contract.get("tf_links", []):
         if not isinstance(item, dict):
             continue
@@ -295,7 +303,7 @@ class PreflightChecker(Node):
         received = {"count": 0}
         qos = QoSProfile(
             history=QoSHistoryPolicy.KEEP_LAST,
-            depth=10,
+            depth=max(10, min_messages),
             reliability=reliability,
             durability=durability,
         )

--- a/src/lunabot_bringup/test/test_mission_dry_run.py
+++ b/src/lunabot_bringup/test/test_mission_dry_run.py
@@ -3,10 +3,12 @@
 from types import SimpleNamespace
 
 from lunabot_bringup import mission_dry_run as dry_run_module
-from lunabot_bringup.mission_dry_run import dry_run_exit_code
-from lunabot_bringup.mission_dry_run import execute_dry_run
-from lunabot_bringup.mission_dry_run import MissionDryRunHarness
-from lunabot_bringup.mission_dry_run import summary_lines
+from lunabot_bringup.mission_dry_run import (
+    MissionDryRunHarness,
+    dry_run_exit_code,
+    execute_dry_run,
+    summary_lines,
+)
 
 
 def _fake_logger():
@@ -15,6 +17,11 @@ def _fake_logger():
         error=lambda _msg: None,
         warn=lambda _msg: None,
     )
+
+
+def _failed_runtime_preflight(self):
+    del self
+    return False, "runtime preflight failed"
 
 
 def test_execute_dry_run_runs_each_step_once_on_success():
@@ -123,7 +130,7 @@ def test_run_returns_non_zero_when_runtime_preflight_fails(monkeypatch):
     monkeypatch.setattr(
         dry_run_module.MissionDryRunHarness,
         "_run_runtime_preflight",
-        lambda self: (False, "runtime preflight failed"),
+        _failed_runtime_preflight,
     )
 
     status = MissionDryRunHarness.run(harness)
@@ -139,7 +146,7 @@ def test_run_prints_flat_summary_when_runtime_preflight_fails(
     monkeypatch.setattr(
         dry_run_module.MissionDryRunHarness,
         "_run_runtime_preflight",
-        lambda self: (False, "runtime preflight failed"),
+        _failed_runtime_preflight,
     )
 
     status = MissionDryRunHarness.run(harness)

--- a/src/lunabot_bringup/test/test_preflight_profiles.py
+++ b/src/lunabot_bringup/test/test_preflight_profiles.py
@@ -1,8 +1,10 @@
 """Unit tests for phase-scoped preflight filtering and CLI helpers."""
 
 import argparse
+import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -11,6 +13,7 @@ from lunabot_bringup.preflight_check import (
     ACTION_TYPE_MAP,
     DURABILITY_MAP,
     RELIABILITY_MAP,
+    _merge_contract_requirements,
     _parse_bool_text,
     _parse_qos_policy,
     _strip_ros_cli_args,
@@ -225,3 +228,62 @@ def test_parse_qos_policy_accepts_known_value():
         )
         == DURABILITY_MAP["transient_local"]
     )
+
+
+def test_parse_qos_policy_rejects_unknown_durability_value():
+    with pytest.raises(ValueError, match="Unsupported durability policy"):
+        _parse_qos_policy(
+            "persistent",
+            DURABILITY_MAP,
+            field_name="durability",
+        )
+
+
+def test_merge_contract_requirements_ignores_malformed_existing_entries(
+    tmp_path, monkeypatch
+):
+    contract_path = tmp_path / "contracts" / "interfaces.json"
+    contract_path.parent.mkdir(parents=True)
+    contract_path.write_text(
+        json.dumps(
+            {
+                "topics": [
+                    {
+                        "kind": "publisher",
+                        "name": "/imu/data_raw",
+                        "type": "sensor_msgs/msg/Imu",
+                    }
+                ],
+                "tf_links": [
+                    {
+                        "parent": "map",
+                        "child": "base_link",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = {
+        "preflight": {
+            "required_topics": ["bad-topic-entry"],
+            "required_tf_links": ["bad-tf-entry"],
+        }
+    }
+    logger = SimpleNamespace(info=lambda _msg: None, warning=lambda _msg: None)
+
+    monkeypatch.setattr(
+        "lunabot_bringup.preflight_check._repo_contract_path",
+        lambda: contract_path,
+    )
+
+    merged = _merge_contract_requirements(config, logger)
+
+    assert merged["preflight"]["required_topics"][1]["name"] == "/imu/data_raw"
+    assert merged["preflight"]["required_tf_links"][1] == {
+        "parent": "map",
+        "child": "base_link",
+        "critical": True,
+        "phases": None,
+    }

--- a/src/lunabot_bringup/test/test_preflight_profiles.py
+++ b/src/lunabot_bringup/test/test_preflight_profiles.py
@@ -1,16 +1,21 @@
 """Unit tests for phase-scoped preflight filtering and CLI helpers."""
 
+import argparse
 import sys
 from pathlib import Path
 
 import pytest
 import yaml
 
-from lunabot_bringup.preflight_check import ACTION_TYPE_MAP
-from lunabot_bringup.preflight_check import _parse_bool_text
-from lunabot_bringup.preflight_check import _strip_ros_cli_args
-from lunabot_bringup.preflight_profiles import filter_preflight_config
-from lunabot_bringup.preflight_profiles import validate_phase
+from lunabot_bringup.preflight_check import (
+    ACTION_TYPE_MAP,
+    DURABILITY_MAP,
+    RELIABILITY_MAP,
+    _parse_bool_text,
+    _parse_qos_policy,
+    _strip_ros_cli_args,
+)
+from lunabot_bringup.preflight_profiles import filter_preflight_config, validate_phase
 
 
 def test_filter_preflight_config_keeps_all_checks_in_full_phase():
@@ -198,5 +203,25 @@ def test_parse_bool_text_accepts_common_launch_values(text, expected):
 
 
 def test_parse_bool_text_rejects_invalid_value():
-    with pytest.raises(Exception):
+    with pytest.raises(argparse.ArgumentTypeError):
         _parse_bool_text("maybe")
+
+
+def test_parse_qos_policy_rejects_unknown_value():
+    with pytest.raises(ValueError, match="Unsupported reliability policy"):
+        _parse_qos_policy(
+            "eventual",
+            RELIABILITY_MAP,
+            field_name="reliability",
+        )
+
+
+def test_parse_qos_policy_accepts_known_value():
+    assert (
+        _parse_qos_policy(
+            "transient_local",
+            DURABILITY_MAP,
+            field_name="durability",
+        )
+        == DURABILITY_MAP["transient_local"]
+    )


### PR DESCRIPTION
## Summary
- make bringup preflight QoS parsing fail closed on unsupported reliability and durability values instead of silently falling back
- split topic discovery and message waiting into smaller helpers so the required-topic check is easier to reason about
- add unit coverage for the new QoS parsing behaviour and clean the local dry-run test monkeypatch helpers

## Verification
- `uv run --with ruff==0.11.13 ruff check src/lunabot_bringup/lunabot_bringup/preflight_check.py src/lunabot_bringup/test/test_preflight_profiles.py src/lunabot_bringup/test/test_mission_dry_run.py --output-format concise --select I,B,UP,SIM,RET,ARG,PTH,RUF,C4 --ignore B008`
- `uv run --with radon==6.0.1 radon cc -s -a src/lunabot_bringup/lunabot_bringup/preflight_check.py`
- `python3 -m compileall src/lunabot_bringup/lunabot_bringup/preflight_check.py src/lunabot_bringup/test/test_preflight_profiles.py src/lunabot_bringup/test/test_mission_dry_run.py`

## Notes
- I could not run the bringup tests end to end in this environment because ROS Python dependencies such as `ament_index_python` are not installed here.
- This PR stays scoped to preflight and directly related tests; it does not pull in the broader bringup launch and setup-file cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## QoS Validation Hardening and Preflight Check Refactoring

### Key Changes

**QoS Validation Hardening**
- Bringup preflight QoS parsing now fails closed on unsupported reliability and durability values, raising `ValueError` exceptions instead of silently falling back to defaults. This prevents misconfiguration from going undetected during bringup.

**Code Organization Improvements**
- Refactored topic discovery and message-waiting logic into dedicated helper functions (`_wait_for_topic_discovery()` and `_wait_for_required_messages()`) to improve code clarity and testability. This makes the required-topic checks easier to reason about.
- Consolidated and cleaned up test helper functions across the test suite, reducing duplication and improving test maintainability.

**Test Coverage Expansion**
- Added unit tests for QoS policy parsing to verify that unsupported reliability and durability values are properly rejected.
- Tightened validation of existing tests to expect more specific exception types.

### Verification
All code quality checks passed (ruff linting, cyclomatic complexity analysis, and Python compilation). End-to-end ROS-dependent tests were not available in the verification environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->