### PR TITLE
Refactor material action control runtime paths

### DIFF
--- a/src/lunabot_control/lunabot_control/material_action_server.py
+++ b/src/lunabot_control/lunabot_control/material_action_server.py
@@ -58,9 +58,7 @@ class MaterialActionServer(Node):
             return False
         if not isfinite(dump_duration_s):
             return False
-        if dump_duration_s < 0.0:
-            return False
-        return True
+        return not dump_duration_s < 0.0
 
     def goal_callback(self, goal_request):
         """Accept only deposit goals that match the supported contract."""
@@ -95,88 +93,94 @@ class MaterialActionServer(Node):
         result.duration_s = float(duration_s)
         return result
 
-    def execute_deposit(self, goal_handle):
-        """Run deposition stub with success, timeout, and failure paths."""
+    def _deposit_nominal_duration(self, goal_handle):
+        """Return the simulated deposit duration for this goal."""
         nominal_duration = float(self.get_parameter("deposit_nominal_duration_s").value)
         dump_duration = float(goal_handle.request.dump_duration_s)
         if dump_duration > 0.0:
-            nominal_duration = max(nominal_duration, dump_duration + 2.0)
+            return max(nominal_duration, dump_duration + 2.0)
+        return nominal_duration
 
-        timeout_s = float(goal_handle.request.timeout_s)
-        start = monotonic()
+    @staticmethod
+    def _deposit_phase(progress):
+        """Map progress to the current deposit feedback phase."""
+        if progress < 0.2:
+            return Deposit.Feedback.PHASE_PRECHECK
+        if progress < 0.45:
+            return Deposit.Feedback.PHASE_OPENING
+        if progress < 0.65:
+            return Deposit.Feedback.PHASE_RAISING
+        if progress < 0.85:
+            return Deposit.Feedback.PHASE_DUMPING
+        return Deposit.Feedback.PHASE_CLOSING
 
-        while rclpy.ok():
-            elapsed = monotonic() - start
+    def _publish_deposit_feedback(self, goal_handle, elapsed, nominal_duration):
+        """Publish one bounded deposit feedback update and return progress."""
+        progress = min(elapsed / max(nominal_duration, 0.1), 1.0)
 
-            if goal_handle.is_cancel_requested:
-                goal_handle.canceled()
-                return self._deposit_result(
-                    False,
-                    Deposit.Result.REASON_CANCELED,
-                    "Deposit goal canceled by client",
-                    1.0,
-                    elapsed,
-                )
+        feedback = Deposit.Feedback()
+        feedback.phase = self._deposit_phase(progress)
+        feedback.elapsed_s = float(elapsed)
+        feedback.actuator_current_a = float(3.5 + 2.5 * progress)
+        feedback.door_open = feedback.phase in (
+            Deposit.Feedback.PHASE_OPENING,
+            Deposit.Feedback.PHASE_RAISING,
+            Deposit.Feedback.PHASE_DUMPING,
+        )
+        feedback.bed_raised = feedback.phase in (
+            Deposit.Feedback.PHASE_RAISING,
+            Deposit.Feedback.PHASE_DUMPING,
+        )
+        feedback.estop_active = False
+        goal_handle.publish_feedback(feedback)
+        return progress
 
-            if timeout_s > 0.0 and elapsed >= timeout_s:
-                goal_handle.abort()
-                return self._deposit_result(
-                    False,
-                    Deposit.Result.REASON_TIMEOUT,
-                    "Deposition timeout reached",
-                    1.0,
-                    elapsed,
-                )
+    def _canceled_deposit_result(self, goal_handle, elapsed):
+        """Cancel the active goal and return the matching result."""
+        goal_handle.canceled()
+        return self._deposit_result(
+            False,
+            Deposit.Result.REASON_CANCELED,
+            "Deposit goal canceled by client",
+            1.0,
+            elapsed,
+        )
 
-            if self._should_force_failure("deposit"):
-                goal_handle.abort()
-                return self._deposit_result(
-                    False,
-                    Deposit.Result.REASON_FORCED_FAILURE,
-                    "Forced failure for bench testing",
-                    1.0,
-                    elapsed,
-                )
+    def _timeout_deposit_result(self, goal_handle, elapsed):
+        """Abort the active goal after a deposit timeout."""
+        goal_handle.abort()
+        return self._deposit_result(
+            False,
+            Deposit.Result.REASON_TIMEOUT,
+            "Deposition timeout reached",
+            1.0,
+            elapsed,
+        )
 
-            progress = min(elapsed / max(nominal_duration, 0.1), 1.0)
+    def _forced_failure_result(self, goal_handle, elapsed):
+        """Abort the goal when the bench is configured to force failure."""
+        goal_handle.abort()
+        return self._deposit_result(
+            False,
+            Deposit.Result.REASON_FORCED_FAILURE,
+            "Forced failure for bench testing",
+            1.0,
+            elapsed,
+        )
 
-            feedback = Deposit.Feedback()
-            if progress < 0.2:
-                feedback.phase = Deposit.Feedback.PHASE_PRECHECK
-            elif progress < 0.45:
-                feedback.phase = Deposit.Feedback.PHASE_OPENING
-            elif progress < 0.65:
-                feedback.phase = Deposit.Feedback.PHASE_RAISING
-            elif progress < 0.85:
-                feedback.phase = Deposit.Feedback.PHASE_DUMPING
-            else:
-                feedback.phase = Deposit.Feedback.PHASE_CLOSING
-            feedback.elapsed_s = float(elapsed)
-            feedback.actuator_current_a = float(3.5 + 2.5 * progress)
-            feedback.door_open = feedback.phase in (
-                Deposit.Feedback.PHASE_OPENING,
-                Deposit.Feedback.PHASE_RAISING,
-                Deposit.Feedback.PHASE_DUMPING,
-            )
-            feedback.bed_raised = feedback.phase in (
-                Deposit.Feedback.PHASE_RAISING,
-                Deposit.Feedback.PHASE_DUMPING,
-            )
-            feedback.estop_active = False
-            goal_handle.publish_feedback(feedback)
+    def _succeeded_deposit_result(self, goal_handle, elapsed):
+        """Mark the goal successful and return the result."""
+        goal_handle.succeed()
+        return self._deposit_result(
+            True,
+            Deposit.Result.REASON_SUCCESS,
+            "",
+            0.05,
+            elapsed,
+        )
 
-            if progress >= 1.0:
-                goal_handle.succeed()
-                return self._deposit_result(
-                    True,
-                    Deposit.Result.REASON_SUCCESS,
-                    "",
-                    0.05,
-                    elapsed,
-                )
-
-            sleep(self.loop_period_s)
-
+    def _shutdown_deposit_result(self, goal_handle, start):
+        """Abort active work during shutdown and report a bounded result."""
         if goal_handle.is_active:
             goal_handle.abort()
         return self._deposit_result(
@@ -186,6 +190,40 @@ class MaterialActionServer(Node):
             1.0,
             monotonic() - start,
         )
+
+    def _terminal_deposit_result(self, goal_handle, elapsed, timeout_s):
+        """Return a terminal result when the deposit loop should stop."""
+        if goal_handle.is_cancel_requested:
+            return self._canceled_deposit_result(goal_handle, elapsed)
+        if timeout_s > 0.0 and elapsed >= timeout_s:
+            return self._timeout_deposit_result(goal_handle, elapsed)
+        if self._should_force_failure("deposit"):
+            return self._forced_failure_result(goal_handle, elapsed)
+        return None
+
+    def execute_deposit(self, goal_handle):
+        """Run deposition stub with success, timeout, and failure paths."""
+        nominal_duration = self._deposit_nominal_duration(goal_handle)
+        timeout_s = float(goal_handle.request.timeout_s)
+        start = monotonic()
+
+        while rclpy.ok():
+            elapsed = monotonic() - start
+            terminal_result = self._terminal_deposit_result(
+                goal_handle, elapsed, timeout_s
+            )
+            if terminal_result is not None:
+                return terminal_result
+
+            progress = self._publish_deposit_feedback(
+                goal_handle, elapsed, nominal_duration
+            )
+            if progress >= 1.0:
+                return self._succeeded_deposit_result(goal_handle, elapsed)
+
+            sleep(self.loop_period_s)
+
+        return self._shutdown_deposit_result(goal_handle, start)
 
 
 def main(args=None):

--- a/src/lunabot_control/test/test_copyright.py
+++ b/src/lunabot_control/test/test_copyright.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_copyright.main import main
 import pytest
+from ament_copyright.main import main
 
 
 # Remove the `skip` decorator once the source file(s) have a copyright header

--- a/src/lunabot_control/test/test_flake8.py
+++ b/src/lunabot_control/test/test_flake8.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_flake8.main import main_with_errors
 import pytest
+from ament_flake8.main import main_with_errors
 
 
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
     rc, errors = main_with_errors(argv=[])
-    assert rc == 0, \
-        'Found %d code style errors / warnings:\n' % len(errors) + \
-        '\n'.join(errors)
+    assert rc == 0, "Found {} code style errors / warnings:\n{}".format(
+        len(errors), "\n".join(errors)
+    )

--- a/src/lunabot_control/test/test_material_action_server_behaviour.py
+++ b/src/lunabot_control/test/test_material_action_server_behaviour.py
@@ -11,6 +11,7 @@ from lunabot_interfaces.action import Deposit
 
 def _material_server():
     server = object.__new__(MaterialActionServer)
+
     def _parameter(name):
         values = {
             "deposit_nominal_duration_s": 5.0,

--- a/src/lunabot_control/test/test_material_action_server_behaviour.py
+++ b/src/lunabot_control/test/test_material_action_server_behaviour.py
@@ -11,13 +11,15 @@ from lunabot_interfaces.action import Deposit
 
 def _material_server():
     server = object.__new__(MaterialActionServer)
-    server.get_parameter = lambda name: SimpleNamespace(
-        value={
+    def _parameter(name):
+        values = {
             "deposit_nominal_duration_s": 5.0,
             "loop_period_s": 0.2,
             "force_failure_action": "",
-        }[name]
-    )
+        }
+        return SimpleNamespace(value=values[name])
+
+    server.get_parameter = _parameter
     return server
 
 

--- a/src/lunabot_control/test/test_pep257.py
+++ b/src/lunabot_control/test/test_pep257.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_pep257.main import main
 import pytest
+from ament_pep257.main import main
 
 
 @pytest.mark.linter


### PR DESCRIPTION
## Summary
- split the deposit action loop into explicit validation, feedback, terminal-result and shutdown helpers
- keep the material action server behaviour the same while reducing runtime complexity
- clean the directly related control package test files so the package passes its own lint/test gates again

## Validation
- `uv run --with ruff==0.11.13 ruff check src/lunabot_control/lunabot_control/material_action_server.py src/lunabot_control/test/test_material_action_server_behaviour.py src/lunabot_control/test/test_copyright.py src/lunabot_control/test/test_flake8.py src/lunabot_control/test/test_pep257.py --select I,B,UP,SIM,RET,ARG,PTH,RUF,C4`
- `uv run --with radon==6.0.1 radon cc -s -a src/lunabot_control/lunabot_control/material_action_server.py src/lunabot_control/test/test_material_action_server_behaviour.py`
- `python3 -m compileall src/lunabot_control/lunabot_control/material_action_server.py src/lunabot_control/test/test_material_action_server_behaviour.py src/lunabot_control/test/test_copyright.py src/lunabot_control/test/test_flake8.py src/lunabot_control/test/test_pep257.py`
- remote ROS validation on `18.133.105.14`:
  - `colcon build --packages-up-to lunabot_control --event-handlers console_direct+`
  - `colcon test --packages-select lunabot_control --event-handlers console_direct+`
  - `colcon test-result --verbose`
