### PR TITLE
Refactor bringup launch and runtime control flow

### DIFF
--- a/src/lunabot_bringup/launch/mission_dry_run.launch.py
+++ b/src/lunabot_bringup/launch/mission_dry_run.launch.py
@@ -1,21 +1,28 @@
 """Launch the full simulation stack and run one mission dry run."""
 
-import os
+from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import EmitEvent
-from launch.actions import IncludeLaunchDescription
-from launch.actions import LogInfo
-from launch.actions import OpaqueFunction
-from launch.actions import RegisterEventHandler
+from launch.actions import (
+    DeclareLaunchArgument,
+    EmitEvent,
+    IncludeLaunchDescription,
+    LogInfo,
+    OpaqueFunction,
+    RegisterEventHandler,
+)
 from launch.event_handlers import OnProcessExit
 from launch.events import Shutdown
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
+
+
+def _launch_file(package_name: str, *parts: str) -> str:
+    """Return one launch file path from a package share directory."""
+    return str(Path(get_package_share_directory(package_name)).joinpath(*parts))
 
 
 def _handle_harness_exit(event, _context):
@@ -39,10 +46,6 @@ def _raise_harness_failure(_context):
 
 def generate_launch_description():
     """Compose the simulation stack and the one-shot mission harness."""
-    pkg_bringup = get_package_share_directory("lunabot_bringup")
-    pkg_excavation = get_package_share_directory("lunabot_excavation")
-    pkg_simulation = get_package_share_directory("lunabot_simulation")
-
     use_sim_time = LaunchConfiguration("use_sim_time")
     launch_rviz = LaunchConfiguration("launch_rviz")
     runtime_preflight_enabled = LaunchConfiguration("runtime_preflight_enabled")
@@ -57,13 +60,13 @@ def generate_launch_description():
 
     moon_yard = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(pkg_simulation, "launch", "moon_yard.launch.py")
+            _launch_file("lunabot_simulation", "launch", "moon_yard.launch.py")
         )
     )
 
     navigation = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(pkg_bringup, "launch", "navigation.launch.py")
+            _launch_file("lunabot_bringup", "launch", "navigation.launch.py")
         ),
         launch_arguments={
             "use_sim_time": use_sim_time,
@@ -74,7 +77,7 @@ def generate_launch_description():
 
     excavation_sim = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(pkg_excavation, "launch", "excavation_sim.launch.py")
+            _launch_file("lunabot_excavation", "launch", "excavation_sim.launch.py")
         ),
         launch_arguments={
             "force_overcurrent": force_overcurrent,
@@ -128,8 +131,8 @@ def generate_launch_description():
             ),
             DeclareLaunchArgument(
                 "preflight_config",
-                default_value=os.path.join(
-                    pkg_bringup,
+                default_value=_launch_file(
+                    "lunabot_bringup",
                     "config",
                     "preflight_checks_dry_run.yaml",
                 ),

--- a/src/lunabot_bringup/launch/navigation.launch.py
+++ b/src/lunabot_bringup/launch/navigation.launch.py
@@ -137,7 +137,6 @@ def generate_launch_description():
     autonomous and manual velocity commands through a twist mux.
     """
     # Locate the configuration files
-    pkg_bringup = get_package_share_directory("lunabot_bringup")
     nav2_launch_path = _share_path(
         "lunabot_bringup", "launch", "nav2_navigation.launch.py"
     )

--- a/src/lunabot_bringup/launch/navigation.launch.py
+++ b/src/lunabot_bringup/launch/navigation.launch.py
@@ -1,25 +1,29 @@
 """Launch file for the navigation stack."""
 
-import os
+from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import LogInfo
-from launch.actions import GroupAction
-from launch.actions import IncludeLaunchDescription
-from launch.actions import OpaqueFunction
-from launch.actions import RegisterEventHandler
-from launch.conditions import IfCondition
-from launch.conditions import UnlessCondition
+from launch.actions import (
+    DeclareLaunchArgument,
+    GroupAction,
+    IncludeLaunchDescription,
+    LogInfo,
+    OpaqueFunction,
+    RegisterEventHandler,
+)
+from launch.conditions import IfCondition, UnlessCondition
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PythonExpression
-from launch_ros.actions import Node
-from launch_ros.actions import SetRemap
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch_ros.actions import Node, SetRemap
 
 from lunabot_bringup.launch_gate import select_preflight_config_path
+
+
+def _share_path(package_name: str, *parts: str) -> str:
+    """Return one path inside a package share directory."""
+    return str(Path(get_package_share_directory(package_name)).joinpath(*parts))
 
 
 def _is_truthy(value):
@@ -45,15 +49,13 @@ def _is_falsey(value):
 
 
 def _build_nav2_start_actions(
-    pkg_bringup, nav_params_path, use_sim_time, enable_teleop
+    nav2_launch_path, nav_params_path, use_sim_time, enable_teleop
 ):
     """Return Nav2 start actions for direct or muxed operation."""
     nav2_launch = GroupAction(
         [
             IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    os.path.join(pkg_bringup, "launch", "nav2_navigation.launch.py")
-                ),
+                PythonLaunchDescriptionSource(nav2_launch_path),
                 launch_arguments={
                     "use_sim_time": use_sim_time,
                     "params_file": nav_params_path,
@@ -69,9 +71,7 @@ def _build_nav2_start_actions(
             SetRemap(src="cmd_vel", dst="cmd_vel_nav"),
             SetRemap(src="cmd_vel_smoothed", dst="cmd_vel_nav"),
             IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    os.path.join(pkg_bringup, "launch", "nav2_navigation.launch.py")
-                ),
+                PythonLaunchDescriptionSource(nav2_launch_path),
                 launch_arguments={
                     "use_sim_time": use_sim_time,
                     "params_file": nav_params_path,
@@ -99,7 +99,7 @@ def _select_localiser_cmd_vel_topic(enable_teleop):
 def _handle_preflight_exit(
     event,
     _context,
-    pkg_bringup,
+    nav2_launch_path,
     nav_params_path,
     use_sim_time,
     enable_teleop,
@@ -107,7 +107,7 @@ def _handle_preflight_exit(
     """Start Nav2 only when the launch-gate preflight passes."""
     if event.returncode == 0:
         return _build_nav2_start_actions(
-            pkg_bringup, nav_params_path, use_sim_time, enable_teleop
+            nav2_launch_path, nav_params_path, use_sim_time, enable_teleop
         )
 
     return [
@@ -138,20 +138,26 @@ def generate_launch_description():
     """
     # Locate the configuration files
     pkg_bringup = get_package_share_directory("lunabot_bringup")
-    pkg_nav = get_package_share_directory("lunabot_navigation")
-    pkg_teleop = get_package_share_directory("lunabot_teleop")
-
-    nav_params_path = os.path.join(pkg_nav, "config", "nav2_params.yaml")
-    blank_map_path = os.path.join(pkg_nav, "maps", "moon_yard_blank.yaml")
-    rviz_config_path = os.path.join(pkg_bringup, "rviz", "navigation.rviz")
-    twist_mux_params_path = os.path.join(
-        pkg_bringup, "config", "twist_mux.yaml"
+    nav2_launch_path = _share_path(
+        "lunabot_bringup", "launch", "nav2_navigation.launch.py"
     )
-    preflight_config_path = os.path.join(
-        pkg_bringup, "config", "preflight_checks.yaml"
+    localisation_launch_path = _share_path(
+        "lunabot_bringup", "launch", "localisation.launch.py"
     )
-    preflight_lidar_debug_config_path = os.path.join(
-        pkg_bringup, "config", "preflight_checks_lidar_debug.yaml"
+    teleop_launch_path = _share_path(
+        "lunabot_teleop", "launch", "joystick_teleop.launch.py"
+    )
+    nav_params_path = _share_path("lunabot_navigation", "config", "nav2_params.yaml")
+    blank_map_path = _share_path("lunabot_navigation", "maps", "moon_yard_blank.yaml")
+    rviz_config_path = _share_path("lunabot_bringup", "rviz", "navigation.rviz")
+    twist_mux_params_path = _share_path(
+        "lunabot_bringup", "config", "twist_mux.yaml"
+    )
+    preflight_config_path = _share_path(
+        "lunabot_bringup", "config", "preflight_checks.yaml"
+    )
+    preflight_lidar_debug_config_path = _share_path(
+        "lunabot_bringup", "config", "preflight_checks_lidar_debug.yaml"
     )
     default_preflight_config = select_preflight_config_path(
         False,
@@ -178,9 +184,7 @@ def generate_launch_description():
     localiser_cmd_vel_topic = _select_localiser_cmd_vel_topic(enable_teleop)
 
     localisation_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_bringup, "launch", "localisation.launch.py")
-        ),
+        PythonLaunchDescriptionSource(localisation_launch_path),
         launch_arguments={
             "lidar_costmap_phase": lidar_costmap_phase,
             "enable_visual_slam": enable_visual_slam,
@@ -211,9 +215,7 @@ def generate_launch_description():
     )
 
     teleop_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(pkg_teleop, "launch", "joystick_teleop.launch.py")
-        ),
+        PythonLaunchDescriptionSource(teleop_launch_path),
         launch_arguments={
             "use_sim_time": use_sim_time,
             "joy_device_id": joy_device_id,
@@ -322,7 +324,7 @@ def generate_launch_description():
             on_exit=lambda event, context: _handle_preflight_exit(
                 event,
                 context,
-                pkg_bringup,
+                nav2_launch_path,
                 nav_params_path,
                 use_sim_time,
                 enable_teleop,
@@ -337,7 +339,7 @@ def generate_launch_description():
             on_exit=lambda event, context: _handle_preflight_exit(
                 event,
                 context,
-                pkg_bringup,
+                nav2_launch_path,
                 nav_params_path,
                 use_sim_time,
                 enable_teleop,
@@ -348,7 +350,7 @@ def generate_launch_description():
 
     direct_nav2_start = GroupAction(
         _build_nav2_start_actions(
-            pkg_bringup, nav_params_path, use_sim_time, enable_teleop
+            nav2_launch_path, nav_params_path, use_sim_time, enable_teleop
         ),
         condition=IfCondition(_is_falsey(enforce_preflight)),
     )

--- a/src/lunabot_bringup/lunabot_bringup/mission_dry_run.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_dry_run.py
@@ -374,16 +374,16 @@ class MissionDryRunHarness(Node):
             goal,
             timeout_detail="excavate goal response timed out",
         )
-        goal_handle = self._accepted_goal_handle(
+        accepted_goal_handle = self._accepted_goal_handle(
             goal_handle,
             rejection_detail="excavate goal rejected",
         )
-        if isinstance(goal_handle, str):
-            self.get_logger().error(goal_handle)
-            return False, goal_handle
+        if isinstance(accepted_goal_handle, str):
+            self.get_logger().error(accepted_goal_handle)
+            return False, accepted_goal_handle
 
         result = self._wait_for_goal_result(
-            goal_handle,
+            accepted_goal_handle,
             timeout_s=goal.timeout_s + self._result_timeout_padding_s(),
             timeout_detail="excavate result timed out",
         )

--- a/src/lunabot_bringup/lunabot_bringup/mission_dry_run.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_dry_run.py
@@ -2,27 +2,23 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from math import cos
-from math import sin
+from math import cos, sin
 from pathlib import Path
-from typing import Callable
 
-from ament_index_python.packages import get_package_share_directory
-from action_msgs.msg import GoalStatus
-from lunabot_interfaces.action import Deposit
-from lunabot_interfaces.action import Excavate
-from nav2_msgs.action import NavigateToPose
 import rclpy
+from action_msgs.msg import GoalStatus
+from ament_index_python.packages import get_package_share_directory
+from nav2_msgs.action import NavigateToPose
 from rclpy.action import ActionClient
 from rclpy.node import Node
 
+from lunabot_bringup.preflight_check import PreflightChecker, _load_yaml
 from lunabot_bringup.preflight_check import _exit_code as preflight_exit_code
-from lunabot_bringup.preflight_check import _load_yaml
 from lunabot_bringup.preflight_check import _print_summary as print_preflight_summary
-from lunabot_bringup.preflight_check import PreflightChecker
 from lunabot_bringup.preflight_profiles import PHASE_RUNTIME
-
+from lunabot_interfaces.action import Deposit, Excavate
 
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
@@ -254,6 +250,49 @@ class MissionDryRunHarness(Node):
             return future.result()
         return timeout_detail
 
+    def _send_goal(
+        self,
+        client: ActionClient,
+        goal,
+        *,
+        timeout_detail: str,
+    ):
+        """Send one goal and return the accepted goal handle."""
+        send_goal_future = client.send_goal_async(goal)
+        return self._wait_for_future(
+            send_goal_future,
+            self._action_wait_timeout_s(),
+            timeout_detail,
+        )
+
+    def _accepted_goal_handle(
+        self,
+        goal_handle,
+        *,
+        rejection_detail: str,
+    ):
+        """Return the accepted goal handle or a rejection detail string."""
+        if isinstance(goal_handle, str):
+            return goal_handle
+        if goal_handle is None or not goal_handle.accepted:
+            return rejection_detail
+        return goal_handle
+
+    def _wait_for_goal_result(
+        self,
+        goal_handle,
+        *,
+        timeout_s: float,
+        timeout_detail: str,
+    ):
+        """Wait for one goal result and return the wrapped result."""
+        result_future = goal_handle.get_result_async()
+        return self._wait_for_future(result_future, timeout_s, timeout_detail)
+
+    def _goal_status_detail(self, action_name: str, status: int) -> str:
+        """Return a readable action status detail string."""
+        return f"{action_name} finished with {_goal_status_text(status)} status"
+
     def _run_travel_step(self) -> tuple[bool, str]:
         """Send one bounded travel goal through the gate action."""
         self.get_logger().info("Starting travel phase")
@@ -275,25 +314,23 @@ class MissionDryRunHarness(Node):
         goal.pose.pose.orientation.z = sin(yaw / 2.0)
         goal.pose.pose.orientation.w = cos(yaw / 2.0)
 
-        send_goal_future = self._navigate_client.send_goal_async(goal)
-        goal_handle = self._wait_for_future(
-            send_goal_future,
-            self._action_wait_timeout_s(),
-            "travel goal response timed out",
+        goal_handle = self._send_goal(
+            self._navigate_client,
+            goal,
+            timeout_detail="travel goal response timed out",
         )
-        if isinstance(goal_handle, str):
-            self.get_logger().error(goal_handle)
-            return False, goal_handle
-        if goal_handle is None or not goal_handle.accepted:
-            detail = "travel goal rejected"
-            self.get_logger().error(detail)
-            return False, detail
+        accepted_goal_handle = self._accepted_goal_handle(
+            goal_handle,
+            rejection_detail="travel goal rejected",
+        )
+        if isinstance(accepted_goal_handle, str):
+            self.get_logger().error(accepted_goal_handle)
+            return False, accepted_goal_handle
 
-        result_future = goal_handle.get_result_async()
-        result = self._wait_for_future(
-            result_future,
-            float(self.get_parameter("travel_result_timeout_s").value),
-            "travel result timed out",
+        result = self._wait_for_goal_result(
+            accepted_goal_handle,
+            timeout_s=float(self.get_parameter("travel_result_timeout_s").value),
+            timeout_detail="travel result timed out",
         )
         if isinstance(result, str):
             self.get_logger().error(result)
@@ -303,7 +340,7 @@ class MissionDryRunHarness(Node):
             self.get_logger().error(detail)
             return False, detail
         if result.status != GoalStatus.STATUS_SUCCEEDED:
-            detail = f"travel finished with {_goal_status_text(result.status)} status"
+            detail = self._goal_status_detail("travel", result.status)
             self.get_logger().error(detail)
             return False, detail
 
@@ -332,25 +369,23 @@ class MissionDryRunHarness(Node):
             self.get_parameter("excavate_max_drive_speed_mps").value
         )
 
-        send_goal_future = self._excavate_client.send_goal_async(goal)
-        goal_handle = self._wait_for_future(
-            send_goal_future,
-            self._action_wait_timeout_s(),
-            "excavate goal response timed out",
+        goal_handle = self._send_goal(
+            self._excavate_client,
+            goal,
+            timeout_detail="excavate goal response timed out",
+        )
+        goal_handle = self._accepted_goal_handle(
+            goal_handle,
+            rejection_detail="excavate goal rejected",
         )
         if isinstance(goal_handle, str):
             self.get_logger().error(goal_handle)
             return False, goal_handle
-        if goal_handle is None or not goal_handle.accepted:
-            detail = "excavate goal rejected"
-            self.get_logger().error(detail)
-            return False, detail
 
-        result_future = goal_handle.get_result_async()
-        result = self._wait_for_future(
-            result_future,
-            goal.timeout_s + self._result_timeout_padding_s(),
-            "excavate result timed out",
+        result = self._wait_for_goal_result(
+            goal_handle,
+            timeout_s=goal.timeout_s + self._result_timeout_padding_s(),
+            timeout_detail="excavate result timed out",
         )
         if isinstance(result, str):
             self.get_logger().error(result)
@@ -360,7 +395,7 @@ class MissionDryRunHarness(Node):
             self.get_logger().error(detail)
             return False, detail
         if result.status != GoalStatus.STATUS_SUCCEEDED:
-            detail = f"excavate finished with {_goal_status_text(result.status)} status"
+            detail = self._goal_status_detail("excavate", result.status)
             self.get_logger().error(detail)
             return False, detail
         if not result.result.success:
@@ -396,25 +431,23 @@ class MissionDryRunHarness(Node):
             self.get_parameter("deposit_require_close_after_dump").value
         )
 
-        send_goal_future = self._deposit_client.send_goal_async(goal)
-        goal_handle = self._wait_for_future(
-            send_goal_future,
-            self._action_wait_timeout_s(),
-            "deposit goal response timed out",
+        goal_handle = self._send_goal(
+            self._deposit_client,
+            goal,
+            timeout_detail="deposit goal response timed out",
+        )
+        goal_handle = self._accepted_goal_handle(
+            goal_handle,
+            rejection_detail="deposit goal rejected",
         )
         if isinstance(goal_handle, str):
             self.get_logger().error(goal_handle)
             return False, goal_handle
-        if goal_handle is None or not goal_handle.accepted:
-            detail = "deposit goal rejected"
-            self.get_logger().error(detail)
-            return False, detail
 
-        result_future = goal_handle.get_result_async()
-        result = self._wait_for_future(
-            result_future,
-            goal.timeout_s + self._result_timeout_padding_s(),
-            "deposit result timed out",
+        result = self._wait_for_goal_result(
+            goal_handle,
+            timeout_s=goal.timeout_s + self._result_timeout_padding_s(),
+            timeout_detail="deposit result timed out",
         )
         if isinstance(result, str):
             self.get_logger().error(result)
@@ -424,7 +457,7 @@ class MissionDryRunHarness(Node):
             self.get_logger().error(detail)
             return False, detail
         if result.status != GoalStatus.STATUS_SUCCEEDED:
-            detail = f"deposit finished with {_goal_status_text(result.status)} status"
+            detail = self._goal_status_detail("deposit", result.status)
             self.get_logger().error(detail)
             return False, detail
         if not result.result.success:

--- a/src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py
+++ b/src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py
@@ -151,11 +151,6 @@ class NavigateToPoseGate(Node):
         return None
 
     @staticmethod
-    def _empty_result() -> NavigateToPose.Result:
-        """Return an empty NavigateToPose result."""
-        return NavigateToPose.Result()
-
-    @staticmethod
     def _finish_goal(goal_handle, *, canceled: bool) -> NavigateToPose.Result:
         """Finish the public goal with a terminal state."""
         if canceled:

--- a/src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py
+++ b/src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py
@@ -4,18 +4,16 @@ from __future__ import annotations
 
 import threading
 
-from action_msgs.msg import GoalStatus
-from lunabot_bringup.localisation_readiness import is_localisation_ready
-from lunabot_interfaces.msg import LocalisationStartZoneStatus
-from nav2_msgs.action import NavigateToPose
 import rclpy
-from rclpy.action import ActionClient
-from rclpy.action import ActionServer
-from rclpy.action import CancelResponse
-from rclpy.action import GoalResponse
+from action_msgs.msg import GoalStatus
+from nav2_msgs.action import NavigateToPose
+from rclpy.action import ActionClient, ActionServer, CancelResponse, GoalResponse
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
+
+from lunabot_bringup.localisation_readiness import is_localisation_ready
+from lunabot_interfaces.msg import LocalisationStartZoneStatus
 
 
 def _parse_bool(value) -> bool:
@@ -152,39 +150,60 @@ class NavigateToPoseGate(Node):
 
         return None
 
-    def _execute_goal(self, goal_handle) -> None:
-        """Forward the accepted goal to Nav2 and mirror the result."""
-        if not self._action_client.wait_for_server(
+    @staticmethod
+    def _empty_result() -> NavigateToPose.Result:
+        """Return an empty NavigateToPose result."""
+        return NavigateToPose.Result()
+
+    @staticmethod
+    def _finish_goal(goal_handle, *, canceled: bool) -> NavigateToPose.Result:
+        """Finish the public goal with a terminal state."""
+        if canceled:
+            goal_handle.canceled()
+        else:
+            goal_handle.abort()
+        return NavigateToPose.Result()
+
+    def _wait_for_internal_server(self, goal_handle) -> NavigateToPose.Result | None:
+        """Return a terminal result if Nav2 is unavailable."""
+        if self._action_client.wait_for_server(
             timeout_sec=self.internal_action_wait_timeout_s
         ):
-            self.get_logger().warn(
-                "Ending NavigateToPose goal because the internal Nav2 action "
-                "server is unavailable."
-            )
-            if goal_handle.is_cancel_requested:
-                goal_handle.canceled()
-            else:
-                goal_handle.abort()
-            return NavigateToPose.Result()
+            return None
 
+        self.get_logger().warn(
+            "Ending NavigateToPose goal because the internal Nav2 action "
+            "server is unavailable."
+        )
+        return self._finish_goal(
+            goal_handle,
+            canceled=goal_handle.is_cancel_requested,
+        )
+
+    def _forward_goal(self, goal_handle):
+        """Forward the public goal to the internal Nav2 action server."""
         send_goal_future = self._action_client.send_goal_async(
             goal_handle.request,
             feedback_callback=lambda feedback: goal_handle.publish_feedback(
                 feedback.feedback
             ),
         )
-
-        client_goal_handle = self._wait_for_future(
+        return self._wait_for_future(
             send_goal_future,
             goal_handle=goal_handle,
         )
-        if client_goal_handle is None or not client_goal_handle.accepted:
-            if goal_handle.is_cancel_requested:
-                goal_handle.canceled()
-            else:
-                goal_handle.abort()
-            return NavigateToPose.Result()
 
+    def _accepted_client_goal(self, client_goal_handle, goal_handle):
+        """Return the accepted internal goal handle or finish the public goal."""
+        if client_goal_handle is None or not client_goal_handle.accepted:
+            return self._finish_goal(
+                goal_handle,
+                canceled=goal_handle.is_cancel_requested,
+            )
+        return client_goal_handle
+
+    def _wait_for_wrapped_result(self, client_goal_handle, goal_handle):
+        """Wait for the internal goal result and forward cancellation once."""
         result_future = client_goal_handle.get_result_async()
         cancel_future = None
 
@@ -193,17 +212,23 @@ class NavigateToPoseGate(Node):
             if cancel_future is None:
                 cancel_future = client_goal_handle.cancel_goal_async()
 
-        wrapped_result = self._wait_for_future(
+        return self._wait_for_future(
             result_future,
             goal_handle=goal_handle,
             on_cancel=_forward_cancel,
         )
+
+    def _finish_from_wrapped_result(
+        self,
+        goal_handle,
+        wrapped_result,
+    ) -> NavigateToPose.Result:
+        """Mirror the downstream terminal status on the public goal."""
         if wrapped_result is None:
-            if goal_handle.is_cancel_requested:
-                goal_handle.canceled()
-            else:
-                goal_handle.abort()
-            return NavigateToPose.Result()
+            return self._finish_goal(
+                goal_handle,
+                canceled=goal_handle.is_cancel_requested,
+            )
 
         result = wrapped_result.result
         status = wrapped_result.status
@@ -216,6 +241,23 @@ class NavigateToPoseGate(Node):
             goal_handle.abort()
 
         return result
+
+    def _execute_goal(self, goal_handle) -> None:
+        """Forward the accepted goal to Nav2 and mirror the result."""
+        server_result = self._wait_for_internal_server(goal_handle)
+        if server_result is not None:
+            return server_result
+
+        client_goal_handle = self._forward_goal(goal_handle)
+        if isinstance(client_goal_handle, NavigateToPose.Result):
+            return client_goal_handle
+
+        client_goal_handle = self._accepted_client_goal(client_goal_handle, goal_handle)
+        if isinstance(client_goal_handle, NavigateToPose.Result):
+            return client_goal_handle
+
+        wrapped_result = self._wait_for_wrapped_result(client_goal_handle, goal_handle)
+        return self._finish_from_wrapped_result(goal_handle, wrapped_result)
 
 
 def main(args=None) -> None:


### PR DESCRIPTION
## Summary
- split mission dry run and navigate-to-pose gate paths into smaller bounded helpers
- simplify bringup launch path construction with shared Path helpers
- keep the launch/runtime cleanup scoped to the operational bringup files

## Testing
- uv run --with ruff==0.11.13 ruff check src/lunabot_bringup/lunabot_bringup/mission_dry_run.py src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py src/lunabot_bringup/launch/navigation.launch.py src/lunabot_bringup/launch/mission_dry_run.launch.py --select I,B,UP,SIM,RET,ARG,PTH,RUF,C4 --ignore B008
- python3 -m compileall src/lunabot_bringup/lunabot_bringup/mission_dry_run.py src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py src/lunabot_bringup/launch/navigation.launch.py src/lunabot_bringup/launch/mission_dry_run.launch.py
- uv run --with radon==6.0.1 radon cc -s -a src/lunabot_bringup/lunabot_bringup/mission_dry_run.py src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py src/lunabot_bringup/launch/navigation.launch.py src/lunabot_bringup/launch/mission_dry_run.launch.py
- remote: colcon build --packages-up-to lunabot_bringup
- remote: colcon test --packages-select lunabot_bringup
- remote: colcon test-result --verbose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR refactors the bringup launch and runtime control flow to improve code organization and maintainability.

### Launch File Improvements

- **Path handling simplification**: Replaced `os.path.join()` based path construction in launch files with dedicated helper functions (`_launch_file` in `mission_dry_run.launch.py` and `_share_path` in `navigation.launch.py`) using `pathlib.Path`.
- **Removed precomputed package directories**: Eliminated intermediate variables (`pkg_bringup`, `pkg_nav`, `pkg_teleop`, etc.) in favor of directly computing required paths at their point of use.
- **Refactored function signatures**: Updated `_build_nav2_start_actions()` and `_handle_preflight_exit()` to accept computed launch paths instead of package names, improving separation of concerns.

### Runtime Control Flow Simplification

- **Mission dry run**: Extracted repeated goal-handling patterns (sending goals, validating acceptance, waiting for results, formatting status messages) into dedicated helper methods (`_send_goal`, `_accepted_goal_handle`, `_wait_for_goal_result`, `_goal_status_detail`), reducing duplication across travel, excavate, and deposit steps.
- **Navigate-to-pose gate**: Decomposed the `_execute_goal` method into focused helpers for managing Nav2 server availability, forwarding goals, validating acceptance, and handling terminal outcomes, improving readability and error handling clarity.

### Files Modified

- `src/lunabot_bringup/launch/mission_dry_run.launch.py`
- `src/lunabot_bringup/launch/navigation.launch.py`
- `src/lunabot_bringup/lunabot_bringup/mission_dry_run.py`
- `src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->