### PR TITLE
Ratchet Python quality gates for cleaned packages

### DIFF
--- a/.github/scripts/audit_python_policies.py
+++ b/.github/scripts/audit_python_policies.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Report policy findings that generic linters do not capture well."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class PolicyAudit(ast.NodeVisitor):
+    """Collect broad exception handlers in production code."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.findings: list[str] = []
+
+    def visit_Try(self, node: ast.Try) -> None:
+        for handler in node.handlers:
+            if handler.type is None:
+                self.findings.append(
+                    f"{self.path}:{handler.lineno}: bare except is not allowed"
+                )
+                continue
+
+            if isinstance(handler.type, ast.Name) and handler.type.id == "Exception":
+                self.findings.append(
+                    f"{self.path}:{handler.lineno}: broad except Exception in "
+                    "production path"
+                )
+
+        self.generic_visit(node)
+
+
+def _python_files(paths: list[str]) -> list[Path]:
+    files: list[Path] = []
+    for raw_path in paths:
+        path = REPO_ROOT / raw_path
+        if path.is_file() and path.suffix == ".py":
+            files.append(path)
+            continue
+        files.extend(sorted(path.rglob("*.py")))
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--paths", nargs="+", required=True)
+    args = parser.parse_args()
+
+    findings: list[str] = []
+    for path in _python_files(args.paths):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        audit = PolicyAudit(path)
+        audit.visit(tree)
+        findings.extend(audit.findings)
+
+    if findings:
+        print("Policy audit findings:")
+        for finding in findings:
+            print(f"  {finding}")
+        return 1
+
+    print("Policy audit passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/run_quality_checks.py
+++ b/.github/scripts/run_quality_checks.py
@@ -9,8 +9,13 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-BLOCKING_PYTHON_TARGETS = [
+BLOCKING_BASE_PYTHON_TARGETS = [
     ".github/scripts",
+]
+BLOCKING_STRICT_PYTHON_TARGETS = [
+    ".github/scripts",
+    "src/lunabot_control",
+    "src/lunabot_excavation",
 ]
 ADVISORY_PYTHON_TARGETS = [
     ".github/scripts",
@@ -25,7 +30,11 @@ BLOCKING_YAML_TARGETS = [
     ".pre-commit-config.yaml",
     ".yamllint.yml",
 ]
-COMPLEXITY_TARGETS = [
+BLOCKING_COMPLEXITY_TARGETS = [
+    "src/lunabot_control",
+    "src/lunabot_excavation",
+]
+ADVISORY_COMPLEXITY_TARGETS = [
     "tools",
     "src/lunabot_bringup",
     "src/lunabot_control",
@@ -46,7 +55,7 @@ def _blocking_commands() -> list[list[str]]:
             "-m",
             "ruff",
             "check",
-            *BLOCKING_PYTHON_TARGETS,
+            *BLOCKING_BASE_PYTHON_TARGETS,
             "--output-format",
             "concise",
             "--select",
@@ -54,8 +63,40 @@ def _blocking_commands() -> list[list[str]]:
             "--ignore",
             "E501",
         ],
-        [sys.executable, "-m", "ruff", "format", "--check", *BLOCKING_PYTHON_TARGETS],
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "format",
+            "--check",
+            *BLOCKING_BASE_PYTHON_TARGETS,
+        ],
         [sys.executable, "-m", "yamllint", *BLOCKING_YAML_TARGETS],
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            *BLOCKING_STRICT_PYTHON_TARGETS,
+            "--output-format",
+            "concise",
+            "--select",
+            "I,B,UP,SIM,RET,ARG,PTH,RUF,C4",
+            "--ignore",
+            "B008",
+        ],
+        [
+            sys.executable,
+            "-m",
+            "xenon",
+            "--max-absolute",
+            "C",
+            "--max-modules",
+            "B",
+            "--max-average",
+            "B",
+            *BLOCKING_COMPLEXITY_TARGETS,
+        ],
     ]
 
 
@@ -85,7 +126,16 @@ def _advisory_commands() -> list[list[str]]:
             "B",
             "--max-average",
             "B",
-            *COMPLEXITY_TARGETS,
+            *ADVISORY_COMPLEXITY_TARGETS,
+        ],
+        [
+            sys.executable,
+            str(REPO_ROOT / ".github/scripts/audit_python_policies.py"),
+            "--paths",
+            "src/lunabot_bringup",
+            "src/lunabot_control",
+            "src/lunabot_excavation",
+            "src/lunabot_localisation",
         ],
     ]
 


### PR DESCRIPTION
## Summary
- make the stricter Ruff and complexity checks blocking for the cleaned  and  packages
- keep the wider bringup and localisation debt in the advisory path so CI stays workable while those packages are cleaned further
- add a small advisory policy audit for broad exception handlers in production Python paths

## Testing
- uv run --with ruff==0.11.13 --with yamllint==1.37.1 --with xenon==0.9.3 python3 .github/scripts/run_quality_checks.py --mode blocking
- uv run --with ruff==0.11.13 --with pyright==1.1.403 --with xenon==0.9.3 python3 .github/scripts/run_quality_checks.py --mode advisory