### PR TITLE
Complete bringup package quality cleanup

### DIFF
--- a/src/lunabot_bringup/launch/localisation.launch.py
+++ b/src/lunabot_bringup/launch/localisation.launch.py
@@ -1,13 +1,18 @@
 """Launch file for the localisation stack."""
 
-import os
+from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+
+
+def _launch_file(package_name: str, *parts: str) -> str:
+    """Return a package launch path as a string."""
+    package_root = Path(get_package_share_directory(package_name))
+    return str(package_root.joinpath(*parts))
 
 
 def generate_launch_description():
@@ -16,7 +21,6 @@ def generate_launch_description():
 
     Includes the master localisation launch from lunabot_localisation.
     """
-    pkg_localisation = get_package_share_directory("lunabot_localisation")
     lidar_costmap_phase = LaunchConfiguration("lidar_costmap_phase")
     enable_visual_slam = LaunchConfiguration("enable_visual_slam")
     use_sim_time = LaunchConfiguration("use_sim_time")
@@ -24,7 +28,7 @@ def generate_launch_description():
     cmd_vel_topic = LaunchConfiguration("cmd_vel_topic")
     localisation_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(pkg_localisation, "launch", "localisation.launch.py")
+            _launch_file("lunabot_localisation", "launch", "localisation.launch.py")
         ),
         launch_arguments={
             "lidar_costmap_phase": lidar_costmap_phase,

--- a/src/lunabot_bringup/launch/nav2_navigation.launch.py
+++ b/src/lunabot_bringup/launch/nav2_navigation.launch.py
@@ -1,26 +1,25 @@
 """Local Nav2 navigation launch."""
 
-import os
+from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.actions import GroupAction
-from launch.actions import SetEnvironmentVariable
+from launch.actions import DeclareLaunchArgument, GroupAction, SetEnvironmentVariable
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PythonExpression
-from launch_ros.actions import LoadComposableNodes
-from launch_ros.actions import Node
-from launch_ros.descriptions import ComposableNode
-from launch_ros.descriptions import ParameterFile
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch_ros.actions import LoadComposableNodes, Node
+from launch_ros.descriptions import ComposableNode, ParameterFile
 from nav2_common.launch import RewrittenYaml
+
+
+def _bringup_path(*parts: str) -> str:
+    """Return a Nav2 bringup package path as a string."""
+    package_root = Path(get_package_share_directory("nav2_bringup"))
+    return str(package_root.joinpath(*parts))
 
 
 def generate_launch_description():
     """Launch Nav2 with its standard NavigateToPose action surface."""
-    bringup_dir = get_package_share_directory("nav2_bringup")
-
     namespace = LaunchConfiguration("namespace")
     use_sim_time = LaunchConfiguration("use_sim_time")
     autostart = LaunchConfiguration("autostart")
@@ -81,7 +80,7 @@ def generate_launch_description():
 
     declare_params_file_cmd = DeclareLaunchArgument(
         "params_file",
-        default_value=os.path.join(bringup_dir, "params", "nav2_params.yaml"),
+        default_value=_bringup_path("params", "nav2_params.yaml"),
         description="Full path to the ROS2 parameters file to use for all launched nodes",
     )
 
@@ -126,7 +125,7 @@ def generate_launch_description():
                 respawn_delay=2.0,
                 parameters=[configured_params],
                 arguments=["--ros-args", "--log-level", log_level],
-                remappings=remappings + [("cmd_vel", "cmd_vel_nav")],
+                remappings=[*remappings, ("cmd_vel", "cmd_vel_nav")],
             ),
             Node(
                 package="nav2_smoother",
@@ -192,8 +191,11 @@ def generate_launch_description():
                 respawn_delay=2.0,
                 parameters=[configured_params],
                 arguments=["--ros-args", "--log-level", log_level],
-                remappings=remappings
-                + [("cmd_vel", "cmd_vel_nav"), ("cmd_vel_smoothed", "cmd_vel")],
+                remappings=[
+                    *remappings,
+                    ("cmd_vel", "cmd_vel_nav"),
+                    ("cmd_vel_smoothed", "cmd_vel"),
+                ],
             ),
             Node(
                 package="nav2_lifecycle_manager",
@@ -219,7 +221,7 @@ def generate_launch_description():
                 plugin="nav2_controller::ControllerServer",
                 name="controller_server",
                 parameters=[configured_params],
-                remappings=remappings + [("cmd_vel", "cmd_vel_nav")],
+                remappings=[*remappings, ("cmd_vel", "cmd_vel_nav")],
             ),
             ComposableNode(
                 package="nav2_smoother",
@@ -261,8 +263,11 @@ def generate_launch_description():
                 plugin="nav2_velocity_smoother::VelocitySmoother",
                 name="velocity_smoother",
                 parameters=[configured_params],
-                remappings=remappings
-                + [("cmd_vel", "cmd_vel_nav"), ("cmd_vel_smoothed", "cmd_vel")],
+                remappings=[
+                    *remappings,
+                    ("cmd_vel", "cmd_vel_nav"),
+                    ("cmd_vel_smoothed", "cmd_vel"),
+                ],
             ),
             ComposableNode(
                 package="nav2_lifecycle_manager",

--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -4,15 +4,14 @@ from __future__ import annotations
 
 from enum import IntEnum
 
-from action_msgs.msg import GoalStatus
-from lunabot_interfaces.action import Deposit
-from lunabot_interfaces.action import Excavate
-from nav2_msgs.action import NavigateToPose
 import rclpy
+from action_msgs.msg import GoalStatus
+from nav2_msgs.action import NavigateToPose
 from rclpy.action import ActionClient
 from rclpy.node import Node
 
 from lunabot_bringup.mission_timer import MissionTimer
+from lunabot_interfaces.action import Deposit, Excavate
 
 
 class MissionState(IntEnum):

--- a/src/lunabot_bringup/lunabot_bringup/preflight_profiles.py
+++ b/src/lunabot_bringup/lunabot_bringup/preflight_profiles.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
-
 CHECK_SECTIONS = (
     "required_topics",
     "required_tf_links",

--- a/src/lunabot_bringup/setup.py
+++ b/src/lunabot_bringup/setup.py
@@ -1,11 +1,11 @@
 """Setup script for the lunabot_bringup package."""
 
-import os
-from glob import glob
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
 package_name = "lunabot_bringup"
+package_root = Path(__file__).resolve().parent
 
 setup(
     name=package_name,
@@ -14,20 +14,29 @@ setup(
     data_files=[
         (
             "share/ament_index/resource_index/packages",
-            ["resource/" + package_name],
+            [f"resource/{package_name}"],
         ),
-        ("share/" + package_name, ["package.xml"]),
+        (f"share/{package_name}", ["package.xml"]),
         (
-            os.path.join("share", package_name, "launch"),
-            glob("launch/*.launch.py"),
+            f"share/{package_name}/launch",
+            [
+                str(path.relative_to(package_root))
+                for path in package_root.joinpath("launch").glob("*.launch.py")
+            ],
         ),
         (
-            os.path.join("share", package_name, "config"),
-            glob("config/*.yaml"),
+            f"share/{package_name}/config",
+            [
+                str(path.relative_to(package_root))
+                for path in package_root.joinpath("config").glob("*.yaml")
+            ],
         ),
         (
-            os.path.join("share", package_name, "rviz"),
-            glob("rviz/*.rviz"),
+            f"share/{package_name}/rviz",
+            [
+                str(path.relative_to(package_root))
+                for path in package_root.joinpath("rviz").glob("*.rviz")
+            ],
         ),
     ],
     install_requires=["setuptools"],
@@ -36,11 +45,7 @@ setup(
     maintainer_email="ko129@student.le.ac.uk",
     description="System bringup launch files and checks for Lunabot",
     license="Apache-2.0",
-    extras_require={
-        "test": [
-            "pytest",
-        ],
-    },
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "navigate_to_pose_gate = lunabot_bringup.navigate_to_pose_gate:main",

--- a/src/lunabot_bringup/test/navigate_to_pose_test_server.py
+++ b/src/lunabot_bringup/test/navigate_to_pose_test_server.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import time
 
-from nav2_msgs.action import NavigateToPose
 import rclpy
-from rclpy.action import ActionServer
-from rclpy.action import CancelResponse
-from rclpy.action import GoalResponse
+from nav2_msgs.action import NavigateToPose
+from rclpy.action import ActionServer, CancelResponse, GoalResponse
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node

--- a/src/lunabot_bringup/test/test_copyright.py
+++ b/src/lunabot_bringup/test/test_copyright.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_copyright.main import main
 import pytest
+from ament_copyright.main import main
 
 
 # Remove the `skip` decorator once the source file(s) have a copyright header

--- a/src/lunabot_bringup/test/test_flake8.py
+++ b/src/lunabot_bringup/test/test_flake8.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_flake8.main import main_with_errors
 import pytest
+from ament_flake8.main import main_with_errors
 
 
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
     rc, errors = main_with_errors(argv=[])
-    assert rc == 0, \
-        'Found %d code style errors / warnings:\n' % len(errors) + \
-        '\n'.join(errors)
+    assert rc == 0, (
+        f"Found {len(errors)} code style errors / warnings:\n" + "\n".join(errors)
+    )

--- a/src/lunabot_bringup/test/test_mission_manager.py
+++ b/src/lunabot_bringup/test/test_mission_manager.py
@@ -3,8 +3,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from lunabot_bringup.mission_manager import MissionManager
-from lunabot_bringup.mission_manager import MissionState
+from lunabot_bringup.mission_manager import MissionManager, MissionState
 from lunabot_bringup.mission_timer import MissionTimer
 
 
@@ -21,7 +20,7 @@ def _make_manager(monkeypatch):
     """Construct a MissionManager without spinning a real ROS node."""
     monkeypatch.setattr(
         "rclpy.node.Node.__init__",
-        lambda self, *args, **kwargs: None,
+        lambda _self, *_args, **_kwargs: None,
     )
     manager = object.__new__(MissionManager)
     manager.get_logger = _fake_logger

--- a/src/lunabot_bringup/test/test_mission_manager_launch.py
+++ b/src/lunabot_bringup/test/test_mission_manager_launch.py
@@ -2,8 +2,7 @@ import importlib.util
 from pathlib import Path
 
 from launch import LaunchContext
-from launch.actions import DeclareLaunchArgument
-from launch.actions import ExecuteProcess
+from launch.actions import DeclareLaunchArgument, ExecuteProcess
 from launch_ros.actions import Node
 
 
@@ -16,8 +15,9 @@ def _load_launch_module():
     spec = importlib.util.spec_from_file_location(
         "mission_manager_launch", launch_path
     )
-    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
     assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
@@ -39,7 +39,7 @@ def test_mission_manager_launch_starts_one_supervisor_node(monkeypatch):
 
     context = LaunchContext()
     context.launch_configurations["use_sim_time"] = "false"
-    monkeypatch.setattr(ExecuteProcess, "execute", lambda self, context: None)
+    monkeypatch.setattr(ExecuteProcess, "execute", lambda _self, _context: None)
     nodes[0].execute(context)
 
     assert nodes[0].node_name.rsplit("/", 1)[-1] == "mission_manager"

--- a/src/lunabot_bringup/test/test_navigate_to_pose_gate_launch.py
+++ b/src/lunabot_bringup/test/test_navigate_to_pose_gate_launch.py
@@ -4,22 +4,24 @@ from __future__ import annotations
 
 import atexit
 import os
-from pathlib import Path
 import sys
 import time
 import unittest
+from pathlib import Path
 
-from action_msgs.msg import GoalStatus
 import launch
-from launch.actions import ExecuteProcess
-from launch.actions import SetEnvironmentVariable
-from launch.actions import TimerAction
-from launch.actions import UnsetEnvironmentVariable
-from launch_ros.actions import Node
 import launch_testing.actions
-from nav2_msgs.action import NavigateToPose
 import pytest
 import rclpy
+from action_msgs.msg import GoalStatus
+from launch.actions import (
+    ExecuteProcess,
+    SetEnvironmentVariable,
+    TimerAction,
+    UnsetEnvironmentVariable,
+)
+from launch_ros.actions import Node
+from nav2_msgs.action import NavigateToPose
 from rclpy.action import ActionClient
 from rclpy.node import Node as RclpyNode
 

--- a/src/lunabot_bringup/test/test_pep257.py
+++ b/src/lunabot_bringup/test/test_pep257.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_pep257.main import main
 import pytest
+from ament_pep257.main import main
 
 
 @pytest.mark.linter


### PR DESCRIPTION
## Summary
- replace the remaining bringup launch and setup path plumbing with Path-based helpers
- clean the leftover bringup test scaffolding so the package passes the stricter Ruff gate cleanly
- keep the package changes focused on the remaining advisory debt outside the earlier runtime refactors

## Testing
- uv run --with ruff==0.11.13 ruff check src/lunabot_bringup --output-format concise --select I,B,UP,SIM,RET,ARG,PTH,RUF,C4 --ignore B008
- uv run --with radon==6.0.1 --with xenon==0.9.3 xenon --max-absolute C --max-modules B --max-average B src/lunabot_bringup
- python3 -m compileall src/lunabot_bringup/launch/localisation.launch.py src/lunabot_bringup/launch/nav2_navigation.launch.py src/lunabot_bringup/setup.py src/lunabot_bringup/test/test_mission_manager.py src/lunabot_bringup/test/test_mission_manager_launch.py src/lunabot_bringup/test/test_flake8.py src/lunabot_bringup/test/navigate_to_pose_test_server.py
- remote: colcon build --packages-up-to lunabot_bringup
- remote: colcon test --packages-select lunabot_bringup
- remote: colcon test-result --verbose
