### PR TITLE
Remove broad exception handlers from runtime paths

### DIFF
--- a/src/lunabot_bringup/lunabot_bringup/mission_dry_run.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_dry_run.py
@@ -220,7 +220,7 @@ class MissionDryRunHarness(Node):
             detail = "runtime preflight failed"
             self.get_logger().error(detail)
             return False, detail
-        except Exception as exc:
+        except (OSError, ValueError, RuntimeError) as exc:
             detail = f"runtime preflight error: {exc}"
             self.get_logger().error(detail)
             return False, detail

--- a/src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py
+++ b/src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py
@@ -133,11 +133,10 @@ class NavigateToPoseGate(Node):
 
         while rclpy.ok():
             if done.wait(timeout=0.05):
-                try:
-                    return future.result()
-                except Exception as exc:  # pragma: no cover - defensive logging
+                if (exc := future.exception()) is not None:
                     self.get_logger().error(f"NavigateToPose gate future failed: {exc}")
                     return None
+                return future.result()
 
             if (
                 goal_handle is not None
@@ -268,8 +267,4 @@ def main(args=None) -> None:
     finally:
         executor.shutdown()
         node.destroy_node()
-        try:
-            if rclpy.ok():
-                rclpy.shutdown()
-        except Exception:  # pragma: no cover - shutdown can already be in progress
-            pass
+        rclpy.try_shutdown()

--- a/src/lunabot_bringup/lunabot_bringup/preflight_check.py
+++ b/src/lunabot_bringup/lunabot_bringup/preflight_check.py
@@ -674,13 +674,13 @@ def main(args: list[str] | None = None) -> None:
         raise SystemExit(_exit_code(results))
     except SystemExit:
         raise
-    except Exception as exc:
+    except (OSError, ValueError, RuntimeError, yaml.YAMLError) as exc:
         print(f"Preflight checker internal error: {exc}")
         raise SystemExit(EXIT_INTERNAL_ERROR) from exc
     finally:
         if checker is not None:
             checker.destroy_node()
-        rclpy.shutdown()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py
+++ b/src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-from contextlib import suppress
 
 import rclpy
 import tf2_ros

--- a/src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py
+++ b/src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py
@@ -407,9 +407,7 @@ class StartZoneLocaliser(Node):
                 self._stop_search_motion()
             return True
 
-        try:
-            self.pending_set_pose_future.result()
-        except Exception as exc:  # pragma: no cover - defensive path
+        if (exc := self.pending_set_pose_future.exception()) is not None:
             self._set_state(
                 STATE_FAILED,
                 REASON_SET_POSE_FAILED,
@@ -461,8 +459,7 @@ class StartZoneLocaliser(Node):
             self._stop_search_motion()
             return True
 
-        with suppress(Exception):  # pragma: no cover - discarded result only
-            self.discarded_set_pose_future.result()
+        self.discarded_set_pose_future.exception()
 
         self.discarded_set_pose_future = None
         self.discarded_set_pose_started_ns = None
@@ -629,8 +626,4 @@ def main(args=None) -> None:
             executor.shutdown()
         if node is not None:
             node.destroy_node()
-        try:
-            if rclpy.ok():
-                rclpy.shutdown()
-        except Exception:  # pragma: no cover - shutdown can already be in progress
-            pass
+        rclpy.try_shutdown()

--- a/src/lunabot_localisation/lunabot_localisation/stereo_camera_info_publisher.py
+++ b/src/lunabot_localisation/lunabot_localisation/stereo_camera_info_publisher.py
@@ -140,5 +140,4 @@ def main(args=None):
         pass
     finally:
         node.destroy_node()
-        if rclpy.ok():
-            rclpy.shutdown()
+        rclpy.try_shutdown()

--- a/src/lunabot_localisation/lunabot_localisation/tag_pose_publisher.py
+++ b/src/lunabot_localisation/lunabot_localisation/tag_pose_publisher.py
@@ -337,8 +337,4 @@ def main(args=None):
             executor.shutdown()
         if node is not None:
             node.destroy_node()
-        try:
-            if rclpy.ok():
-                rclpy.shutdown()
-        except Exception:  # pragma: no cover - shutdown can already be in progress
-            pass
+        rclpy.try_shutdown()

--- a/src/lunabot_localisation/lunabot_localisation/visual_odometry_gate.py
+++ b/src/lunabot_localisation/lunabot_localisation/visual_odometry_gate.py
@@ -241,5 +241,4 @@ def main(args=None) -> None:
         pass
     finally:
         node.destroy_node()
-        if rclpy.ok():
-            rclpy.shutdown()
+        rclpy.try_shutdown()


### PR DESCRIPTION
## Summary
- replace broad shutdown exception handlers with `rclpy.try_shutdown()` in bringup and localisation runtime paths
- use `future.exception()` instead of broad `future.result()` exception catches where the ROS futures already expose failure state cleanly
- narrow the remaining preflight boundary catches to explicit error types so the policy audit passes on these production paths

## Testing
- uv run --with ruff==0.11.13 ruff check src/lunabot_bringup/lunabot_bringup/mission_dry_run.py src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py src/lunabot_bringup/lunabot_bringup/preflight_check.py src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py src/lunabot_localisation/lunabot_localisation/tag_pose_publisher.py src/lunabot_localisation/lunabot_localisation/visual_odometry_gate.py src/lunabot_localisation/lunabot_localisation/stereo_camera_info_publisher.py --output-format concise --select I,B,UP,SIM,RET,ARG,PTH,RUF,C4
- python3 .github/scripts/audit_python_policies.py --paths src/lunabot_bringup src/lunabot_localisation
- python3 -m compileall src/lunabot_bringup/lunabot_bringup/mission_dry_run.py src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py src/lunabot_bringup/lunabot_bringup/preflight_check.py src/lunabot_localisation/lunabot_localisation/start_zone_localiser.py src/lunabot_localisation/lunabot_localisation/tag_pose_publisher.py src/lunabot_localisation/lunabot_localisation/visual_odometry_gate.py src/lunabot_localisation/lunabot_localisation/stereo_camera_info_publisher.py
- remote: colcon build --packages-up-to lunabot_bringup lunabot_localisation
- remote: colcon test --packages-select lunabot_bringup lunabot_localisation
- remote: colcon test-result --verbose
