### PR TITLE
Make advisory type checks actionable

### DIFF
--- a/.github/scripts/run_quality_checks.py
+++ b/.github/scripts/run_quality_checks.py
@@ -101,6 +101,16 @@ def _blocking_commands() -> list[list[str]]:
             "B",
             *BLOCKING_COMPLEXITY_TARGETS,
         ],
+        [sys.executable, "-m", "pyright"],
+        [
+            sys.executable,
+            str(REPO_ROOT / ".github/scripts/audit_python_policies.py"),
+            "--paths",
+            "src/lunabot_bringup",
+            "src/lunabot_control",
+            "src/lunabot_excavation",
+            "src/lunabot_localisation",
+        ],
     ]
 
 
@@ -119,7 +129,6 @@ def _advisory_commands() -> list[list[str]]:
             "--ignore",
             "B008",
         ],
-        [sys.executable, "-m", "pyright"],
         [
             sys.executable,
             "-m",
@@ -131,15 +140,6 @@ def _advisory_commands() -> list[list[str]]:
             "--max-average",
             "B",
             *ADVISORY_COMPLEXITY_TARGETS,
-        ],
-        [
-            sys.executable,
-            str(REPO_ROOT / ".github/scripts/audit_python_policies.py"),
-            "--paths",
-            "src/lunabot_bringup",
-            "src/lunabot_control",
-            "src/lunabot_excavation",
-            "src/lunabot_localisation",
         ],
     ]
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -2,10 +2,10 @@
   "include": [
     ".github/scripts",
     "tools",
-    "src/lunabot_bringup",
-    "src/lunabot_control",
-    "src/lunabot_excavation",
-    "src/lunabot_localisation"
+    "src/lunabot_bringup/lunabot_bringup",
+    "src/lunabot_control/lunabot_control",
+    "src/lunabot_excavation/lunabot_excavation",
+    "src/lunabot_localisation/lunabot_localisation"
   ],
   "exclude": [
     "**/__pycache__",
@@ -17,6 +17,7 @@
     "research",
     "src/external"
   ],
+  "stubPath": "typings",
   "typeCheckingMode": "basic",
   "reportMissingImports": false,
   "reportMissingModuleSource": false,
@@ -26,4 +27,3 @@
   "reportUntypedFunctionDecorator": false,
   "pythonVersion": "3.10"
 }
-

--- a/src/lunabot_bringup/test/test_mission_dry_run.py
+++ b/src/lunabot_bringup/test/test_mission_dry_run.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from lunabot_bringup import mission_dry_run as dry_run_module
+import lunabot_bringup.mission_dry_run as dry_run_module
 from lunabot_bringup.mission_dry_run import (
     MissionDryRunHarness,
     dry_run_exit_code,

--- a/src/lunabot_control/test/test_material_action_server_behaviour.py
+++ b/src/lunabot_control/test/test_material_action_server_behaviour.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 from rclpy.action import GoalResponse
 
-from lunabot_control import material_action_server as material_module
+import lunabot_control.material_action_server as material_module
 from lunabot_control.material_action_server import MaterialActionServer
 from lunabot_interfaces.action import Deposit
 

--- a/src/lunabot_control/test/test_material_actions_launch.py
+++ b/src/lunabot_control/test/test_material_actions_launch.py
@@ -10,8 +10,9 @@ from launch_ros.actions import Node
 def _load_launch_module():
     launch_path = Path(__file__).resolve().parents[1] / "launch" / "material_actions.launch.py"
     spec = importlib.util.spec_from_file_location("material_actions_launch", launch_path)
-    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
     assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 

--- a/src/lunabot_excavation/lunabot_excavation/excavation_bench.py
+++ b/src/lunabot_excavation/lunabot_excavation/excavation_bench.py
@@ -151,7 +151,10 @@ def main(args=None):
 
     try:
         if parsed.command == "status":
-            _print_status(node._wait_for_status(parsed.timeout))
+            status = node._wait_for_status(parsed.timeout)
+            if status is None:
+                raise RuntimeError("Timed out waiting for excavation status")
+            _print_status(status)
         elif parsed.command == "home":
             response = node._call_trigger(node._home_client, parsed.timeout)
             print(response.message)

--- a/src/lunabot_excavation/test/test_excavation_bench_behaviour.py
+++ b/src/lunabot_excavation/test/test_excavation_bench_behaviour.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from lunabot_excavation import excavation_bench as bench_module
+import lunabot_excavation.excavation_bench as bench_module
 from lunabot_excavation.excavation_controller import (
     ActiveRun,
     ExcavationController,

--- a/src/lunabot_excavation/test/test_excavation_sim_proxy_behaviour.py
+++ b/src/lunabot_excavation/test/test_excavation_sim_proxy_behaviour.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 from builtin_interfaces.msg import Time
 
-from lunabot_excavation import excavation_sim_proxy as sim_proxy_module
+import lunabot_excavation.excavation_sim_proxy as sim_proxy_module
 from lunabot_excavation.excavation_sim_proxy import ExcavationSimProxy
 from lunabot_interfaces.msg import ExcavationCommand, ExcavationTelemetry
 

--- a/src/lunabot_excavation/test/test_excavation_telemetry_mock_behaviour.py
+++ b/src/lunabot_excavation/test/test_excavation_telemetry_mock_behaviour.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 from builtin_interfaces.msg import Time
 
-from lunabot_excavation import excavation_telemetry_mock as mock_module
+import lunabot_excavation.excavation_telemetry_mock as mock_module
 from lunabot_excavation.excavation_telemetry_mock import ExcavationTelemetryMock
 from lunabot_interfaces.msg import ExcavationCommand, ExcavationTelemetry
 

--- a/typings/launch/__init__.pyi
+++ b/typings/launch/__init__.pyi
@@ -1,0 +1,4 @@
+from .launch_context import LaunchContext as LaunchContext
+from .launch_description import LaunchDescription as LaunchDescription
+
+__all__: list[str]

--- a/typings/lunabot_interfaces/__init__.pyi
+++ b/typings/lunabot_interfaces/__init__.pyi
@@ -1,0 +1,5 @@
+from . import action as action
+from . import msg as msg
+from . import srv as srv
+
+__all__: list[str]

--- a/typings/lunabot_interfaces/action/__init__.pyi
+++ b/typings/lunabot_interfaces/action/__init__.pyi
@@ -1,0 +1,89 @@
+from typing import ClassVar
+
+class Deposit:
+    class Goal:
+        MODE_AUTO: ClassVar[int]
+        MODE_TELEOP_ASSIST: ClassVar[int]
+        mode: int
+        timeout_s: float
+        dump_duration_s: float
+        require_close_after_dump: bool
+
+        def __init__(self) -> None: ...
+
+    class Result:
+        REASON_SUCCESS: ClassVar[int]
+        REASON_TIMEOUT: ClassVar[int]
+        REASON_ESTOP: ClassVar[int]
+        REASON_DRIVER_FAULT: ClassVar[int]
+        REASON_LIMIT_NOT_REACHED: ClassVar[int]
+        REASON_INTERLOCK_BLOCKED: ClassVar[int]
+        REASON_CANCELED: ClassVar[int]
+        REASON_FORCED_FAILURE: ClassVar[int]
+        REASON_SHUTDOWN: ClassVar[int]
+        success: bool
+        reason_code: int
+        failure_reason: str
+        residual_fill_fraction_estimate: float
+        duration_s: float
+
+        def __init__(self) -> None: ...
+
+    class Feedback:
+        PHASE_PRECHECK: ClassVar[int]
+        PHASE_OPENING: ClassVar[int]
+        PHASE_RAISING: ClassVar[int]
+        PHASE_DUMPING: ClassVar[int]
+        PHASE_CLOSING: ClassVar[int]
+        phase: int
+        elapsed_s: float
+        actuator_current_a: float
+        door_open: bool
+        bed_raised: bool
+        estop_active: bool
+
+        def __init__(self) -> None: ...
+
+
+class Excavate:
+    class Goal:
+        MODE_AUTO: ClassVar[int]
+        MODE_TELEOP_ASSIST: ClassVar[int]
+        mode: int
+        timeout_s: float
+        target_fill_fraction: float
+        max_drive_speed_mps: float
+
+        def __init__(self) -> None: ...
+
+    class Result:
+        REASON_SUCCESS: ClassVar[int]
+        REASON_TIMEOUT: ClassVar[int]
+        REASON_ESTOP: ClassVar[int]
+        REASON_DRIVER_FAULT: ClassVar[int]
+        REASON_JAM_OR_OVERCURRENT: ClassVar[int]
+        REASON_INTERLOCK_BLOCKED: ClassVar[int]
+        REASON_CANCELED: ClassVar[int]
+        REASON_FORCED_FAILURE: ClassVar[int]
+        REASON_SHUTDOWN: ClassVar[int]
+        success: bool
+        reason_code: int
+        failure_reason: str
+        collected_mass_kg_estimate: float
+        duration_s: float
+
+        def __init__(self) -> None: ...
+
+    class Feedback:
+        PHASE_PRECHECK: ClassVar[int]
+        PHASE_SPINUP: ClassVar[int]
+        PHASE_DIGGING: ClassVar[int]
+        PHASE_RETRACT: ClassVar[int]
+        phase: int
+        elapsed_s: float
+        fill_fraction_estimate: float
+        excavation_motor_current_a: float
+        jam_detected: bool
+        estop_active: bool
+
+        def __init__(self) -> None: ...

--- a/typings/lunabot_interfaces/msg/__init__.pyi
+++ b/typings/lunabot_interfaces/msg/__init__.pyi
@@ -1,0 +1,75 @@
+from typing import ClassVar
+
+class _TimeMsg:
+    sec: int
+    nanosec: int
+
+
+class _HeaderMsg:
+    stamp: _TimeMsg
+
+
+class ExcavationCommand:
+    COMMAND_STOP: ClassVar[int]
+    COMMAND_HOME: ClassVar[int]
+    COMMAND_START: ClassVar[int]
+    COMMAND_CLEAR_FAULT: ClassVar[int]
+    command: int
+
+    def __init__(self) -> None: ...
+
+
+class ExcavationStatus:
+    STATE_IDLE: ClassVar[int]
+    STATE_HOMING: ClassVar[int]
+    STATE_READY: ClassVar[int]
+    STATE_STARTING: ClassVar[int]
+    STATE_EXCAVATING: ClassVar[int]
+    STATE_STOPPING: ClassVar[int]
+    STATE_FAULT: ClassVar[int]
+    FAULT_NONE: ClassVar[int]
+    FAULT_ESTOP: ClassVar[int]
+    FAULT_DRIVER: ClassVar[int]
+    FAULT_OVERCURRENT: ClassVar[int]
+    FAULT_HOME_SWITCH_INVALID: ClassVar[int]
+    FAULT_COMMAND_REJECTED: ClassVar[int]
+    header: _HeaderMsg
+    state: int
+    fault_code: int
+    estop_active: bool
+    driver_fault: bool
+    homed: bool
+    motor_enabled: bool
+    motor_current_a: float
+
+    def __init__(self) -> None: ...
+
+
+class ExcavationTelemetry:
+    FAULT_NONE: ClassVar[int]
+    FAULT_ESTOP: ClassVar[int]
+    FAULT_DRIVER: ClassVar[int]
+    FAULT_OVERCURRENT: ClassVar[int]
+    FAULT_HOME_SWITCH_INVALID: ClassVar[int]
+    FAULT_COMMAND_REJECTED: ClassVar[int]
+    header: _HeaderMsg
+    estop_active: bool
+    driver_fault: bool
+    home_switch: bool
+    motor_enabled: bool
+    motor_current_a: float
+    fault_code: int
+
+    def __init__(self) -> None: ...
+
+
+class LocalisationStartZoneStatus:
+    stamp: _TimeMsg
+    state: str
+    ready: bool
+    reason_code: str
+    reason_detail: str
+    stable_lock_age_s: float
+    search_elapsed_s: float
+
+    def __init__(self) -> None: ...

--- a/typings/lunabot_interfaces/srv/__init__.pyi
+++ b/typings/lunabot_interfaces/srv/__init__.pyi
@@ -1,0 +1,11 @@
+class ExcavationJog:
+    class Request:
+        duration_s: float
+
+        def __init__(self) -> None: ...
+
+    class Response:
+        success: bool
+        message: str
+
+        def __init__(self) -> None: ...


### PR DESCRIPTION
## Summary
- narrow Pyright to the production Python modules where it gives useful signal rather than ROS launch and test scaffolding noise
- add lightweight local stubs for `launch` exports and generated `lunabot_interfaces` types so Pyright can reason about the rover packages
- tidy the remaining import and module-loading cases that were only failing because of import mechanics, and harden `excavation_bench` against a timed-out status lookup

## Testing
- uv run --with ruff==0.11.13 --with pyright==1.1.403 --with xenon==0.9.3 python3 .github/scripts/run_quality_checks.py --mode advisory
- python3 -m compileall src/lunabot_excavation/lunabot_excavation/excavation_bench.py
- remote: colcon build --packages-up-to lunabot_excavation
- remote: colcon test --packages-select lunabot_excavation
- remote: colcon test-result --verbose
