### PR TITLE
Promote type checks into the blocking gate

### DIFF
--- a/.github/scripts/run_quality_checks.py
+++ b/.github/scripts/run_quality_checks.py
@@ -101,6 +101,16 @@ def _blocking_commands() -> list[list[str]]:
             "B",
             *BLOCKING_COMPLEXITY_TARGETS,
         ],
+        [sys.executable, "-m", "pyright"],
+        [
+            sys.executable,
+            str(REPO_ROOT / ".github/scripts/audit_python_policies.py"),
+            "--paths",
+            "src/lunabot_bringup",
+            "src/lunabot_control",
+            "src/lunabot_excavation",
+            "src/lunabot_localisation",
+        ],
     ]
 
 
@@ -119,7 +129,6 @@ def _advisory_commands() -> list[list[str]]:
             "--ignore",
             "B008",
         ],
-        [sys.executable, "-m", "pyright"],
         [
             sys.executable,
             "-m",
@@ -131,15 +140,6 @@ def _advisory_commands() -> list[list[str]]:
             "--max-average",
             "B",
             *ADVISORY_COMPLEXITY_TARGETS,
-        ],
-        [
-            sys.executable,
-            str(REPO_ROOT / ".github/scripts/audit_python_policies.py"),
-            "--paths",
-            "src/lunabot_bringup",
-            "src/lunabot_control",
-            "src/lunabot_excavation",
-            "src/lunabot_localisation",
         ],
     ]
 


### PR DESCRIPTION
## Summary
- move Pyright into the blocking quality gate now that the advisory lane is clean on the rover Python modules
- move the repo-specific broad-exception audit into the blocking gate alongside Ruff and Xenon
- leave the advisory lane focused on the remaining non-blocking structural checks rather than duplicating the same passes twice

## Testing
- uv run --with ruff==0.11.13 --with yamllint==1.37.1 --with xenon==0.9.3 --with pyright==1.1.403 python3 .github/scripts/run_quality_checks.py --mode blocking
- uv run --with ruff==0.11.13 --with pyright==1.1.403 --with xenon==0.9.3 python3 .github/scripts/run_quality_checks.py --mode advisory
