### PR TITLE
Tighten teleop launch validation

### DIFF
--- a/src/lunabot_teleop/launch/joystick_teleop.launch.py
+++ b/src/lunabot_teleop/launch/joystick_teleop.launch.py
@@ -1,13 +1,42 @@
 """Launch joystick teleoperation nodes for Lunabot."""
 
-import os
+from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
+
+
+def _config_path(*parts: str) -> str:
+    """Return a teleop package path as a string for launch parameters."""
+    return str(Path(get_package_share_directory("lunabot_teleop")).joinpath(*parts))
+
+
+def _validate_non_negative_int(value: str, argument_name: str) -> str:
+    """Return a normalised integer string or raise on invalid input."""
+    try:
+        parsed = int(str(value).strip())
+    except ValueError as error:
+        raise ValueError(
+            f"Expected an integer launch value for '{argument_name}', got '{value}'."
+        ) from error
+    if parsed < 0:
+        raise ValueError(
+            f"Expected '{argument_name}' to be zero or greater, got '{value}'."
+        )
+    return str(parsed)
+
+
+def _validate_launch_arguments(context):
+    """Reject invalid launch arguments before any teleop nodes start."""
+    _validate_non_negative_int(
+        LaunchConfiguration("joy_device_id").perform(context),
+        argument_name="joy_device_id",
+    )
+    return []
 
 
 def generate_launch_description():
@@ -18,8 +47,7 @@ def generate_launch_description():
     Lunabot Xbox-style mapping. Teleop commands are published on
     /cmd_vel_teleop so a mux can arbitrate between manual and autonomous input.
     """
-    pkg_share = get_package_share_directory("lunabot_teleop")
-    teleop_config = os.path.join(pkg_share, "config", "xbox_teleop.yaml")
+    teleop_config = _config_path("config", "xbox_teleop.yaml")
     use_sim_time = LaunchConfiguration("use_sim_time")
     joy_device_id = LaunchConfiguration("joy_device_id")
 
@@ -58,10 +86,9 @@ def generate_launch_description():
             DeclareLaunchArgument(
                 "joy_device_id",
                 default_value="0",
-                description=(
-                    "SDL device index for the connected controller."
-                ),
+                description=("SDL device index for the connected controller."),
             ),
+            OpaqueFunction(function=_validate_launch_arguments),
             game_controller,
             teleop_twist,
         ]

--- a/src/lunabot_teleop/setup.py
+++ b/src/lunabot_teleop/setup.py
@@ -1,9 +1,16 @@
-import os
-from glob import glob
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
 package_name = "lunabot_teleop"
+package_root = Path(__file__).resolve().parent
+
+
+def _relative_matches(pattern: str) -> list[str]:
+    """Return package-local files relative to the setup.py directory."""
+    return sorted(
+        str(path.relative_to(package_root)) for path in package_root.glob(pattern)
+    )
 
 setup(
     name=package_name,
@@ -16,12 +23,12 @@ setup(
         ),
         ("share/" + package_name, ["package.xml"]),
         (
-            os.path.join("share", package_name, "launch"),
-            glob("launch/*.launch.py"),
+            f"share/{package_name}/launch",
+            _relative_matches("launch/*.launch.py"),
         ),
         (
-            os.path.join("share", package_name, "config"),
-            glob("config/*.yaml"),
+            f"share/{package_name}/config",
+            _relative_matches("config/*.yaml"),
         ),
     ],
     install_requires=["setuptools"],

--- a/src/lunabot_teleop/setup.py
+++ b/src/lunabot_teleop/setup.py
@@ -12,6 +12,7 @@ def _relative_matches(pattern: str) -> list[str]:
         str(path.relative_to(package_root)) for path in package_root.glob(pattern)
     )
 
+
 setup(
     name=package_name,
     version="0.0.0",

--- a/src/lunabot_teleop/test/test_copyright.py
+++ b/src/lunabot_teleop/test/test_copyright.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_copyright.main import main
 import pytest
+from ament_copyright.main import main
 
 
 # Remove the `skip` decorator once source files have copyright headers.

--- a/src/lunabot_teleop/test/test_flake8.py
+++ b/src/lunabot_teleop/test/test_flake8.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_flake8.main import main_with_errors
 import pytest
+from ament_flake8.main import main_with_errors
 
 
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
     rc, errors = main_with_errors(argv=[])
-    assert rc == 0, \
-        'Found %d code style errors / warnings:\n' % len(errors) + \
-        '\n'.join(errors)
+    assert rc == 0, (
+        f"Found {len(errors)} code style errors / warnings:\n" + "\n".join(errors)
+    )

--- a/src/lunabot_teleop/test/test_joystick_launch.py
+++ b/src/lunabot_teleop/test/test_joystick_launch.py
@@ -1,0 +1,58 @@
+"""Behaviour tests for joystick teleop launch validation."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+
+def _load_launch_module():
+    """Import the joystick teleop launch file as a Python module."""
+    pytest.importorskip("launch")
+    pytest.importorskip("ament_index_python.packages")
+    pytest.importorskip("launch_ros.actions")
+    pytest.importorskip("launch_ros.parameter_descriptions")
+    module_path = (
+        Path(__file__).resolve().parents[1] / "launch" / "joystick_teleop.launch.py"
+    )
+    spec = spec_from_file_location("joystick_teleop_launch", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("0", "0"),
+        (" 7 ", "7"),
+        ("12", "12"),
+    ],
+)
+def test_validate_non_negative_int_accepts_non_negative_values(text, expected):
+    launch_module = _load_launch_module()
+
+    assert (
+        launch_module._validate_non_negative_int(text, argument_name="joy_device_id")
+        == expected
+    )
+
+
+@pytest.mark.parametrize("text", ["-1", "left", "1.5", ""])
+def test_validate_non_negative_int_rejects_invalid_values(text):
+    launch_module = _load_launch_module()
+
+    with pytest.raises(ValueError):
+        launch_module._validate_non_negative_int(text, argument_name="joy_device_id")
+
+
+def test_validate_launch_arguments_rejects_invalid_device_id():
+    launch_module = _load_launch_module()
+    launch_context_module = pytest.importorskip("launch.launch_context")
+    context = launch_context_module.LaunchContext()
+    context.launch_configurations["joy_device_id"] = "-1"
+
+    with pytest.raises(ValueError, match="joy_device_id"):
+        launch_module._validate_launch_arguments(context)

--- a/src/lunabot_teleop/test/test_pep257.py
+++ b/src/lunabot_teleop/test/test_pep257.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_pep257.main import main
 import pytest
+from ament_pep257.main import main
 
 
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found code style errors / warnings'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found code style errors / warnings"


### PR DESCRIPTION
## Summary
- validate the joystick device id up front instead of accepting bad launch values
- replace teleop setup path handling with Path-based helpers
- modernise the package lint tests and add launch behaviour coverage

## Testing
- uv run --with ruff==0.11.13 ruff check src/lunabot_teleop --select I,B,UP,SIM,RET,ARG,PTH,RUF,C4
- python3 -m compileall src/lunabot_teleop/launch/joystick_teleop.launch.py src/lunabot_teleop/test/test_joystick_launch.py src/lunabot_teleop/setup.py
- local: PYTHONPATH=src/lunabot_teleop uv run --with pytest pytest -q src/lunabot_teleop/test/test_joystick_launch.py
- remote: colcon build --packages-up-to lunabot_teleop
- remote: colcon test --packages-select lunabot_teleop
- remote: colcon test-result --verbose


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves the teleop launch system with upfront validation and modernized code patterns:

### Input Validation
- Added upfront validation for the joystick device ID launch argument, rejecting invalid (negative) values before the teleop nodes start rather than allowing bad launch values to propagate.

### Modernized Path Handling
- Replaced `os.path` and `glob`-based path construction with `pathlib.Path` helpers throughout the codebase:
  - In `joystick_teleop.launch.py`: Introduced `_config_path()` helper for building config file paths
  - In `setup.py`: Added `_relative_matches()` helper to collect matching files using Path-based patterns instead of glob

### Improved Test Suite
- Modernized package lint tests with import reordering and formatting updates across test files
- Added new pytest-based launch behavior tests (`test_joystick_launch.py`) to verify input validation helpers work correctly with edge cases (negative numbers, invalid inputs, empty strings)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->