### PR TITLE
Clean navigation and perception package scaffolding

### DIFF
--- a/src/lunabot_navigation/setup.py
+++ b/src/lunabot_navigation/setup.py
@@ -1,9 +1,17 @@
-import os
-from glob import glob
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
 package_name = "lunabot_navigation"
+package_root = Path(__file__).resolve().parent
+
+
+def _relative_matches(pattern: str) -> list[str]:
+    """Return package-local files relative to the setup.py directory."""
+    return sorted(
+        str(path.relative_to(package_root)) for path in package_root.glob(pattern)
+    )
+
 
 setup(
     name=package_name,
@@ -12,14 +20,14 @@ setup(
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         ("share/" + package_name, ["package.xml"]),
-        (os.path.join("share", package_name, "config"), glob("config/*.yaml")),
+        (f"share/{package_name}/config", _relative_matches("config/*.yaml")),
         (
-            os.path.join("share", package_name, "behavior_trees"),
-            glob("behavior_trees/*.xml"),
+            f"share/{package_name}/behavior_trees",
+            _relative_matches("behavior_trees/*.xml"),
         ),
         (
-            os.path.join("share", package_name, "maps"),
-            glob("maps/*"),
+            f"share/{package_name}/maps",
+            _relative_matches("maps/*"),
         ),
     ],
     install_requires=["setuptools"],

--- a/src/lunabot_navigation/test/test_copyright.py
+++ b/src/lunabot_navigation/test/test_copyright.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_copyright.main import main
 import pytest
+from ament_copyright.main import main
 
 
-# Remove the `skip` decorator once the source file(s) have a copyright header
-@pytest.mark.skip(reason='No copyright header has been placed in the generated source file.')
+# Remove the `skip` decorator once the source file(s) have copyright headers.
+@pytest.mark.skip(
+    reason="No copyright header has been placed in the generated source file."
+)
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found errors'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found errors"

--- a/src/lunabot_navigation/test/test_flake8.py
+++ b/src/lunabot_navigation/test/test_flake8.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_flake8.main import main_with_errors
 import pytest
+from ament_flake8.main import main_with_errors
 
 
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
     rc, errors = main_with_errors(argv=[])
-    assert rc == 0, \
-        'Found %d code style errors / warnings:\n' % len(errors) + \
-        '\n'.join(errors)
+    assert rc == 0, (
+        f"Found {len(errors)} code style errors / warnings:\n" + "\n".join(errors)
+    )

--- a/src/lunabot_navigation/test/test_pep257.py
+++ b/src/lunabot_navigation/test/test_pep257.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_pep257.main import main
 import pytest
+from ament_pep257.main import main
 
 
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found code style errors / warnings'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found code style errors / warnings"

--- a/src/lunabot_perception/test/test_copyright.py
+++ b/src/lunabot_perception/test/test_copyright.py
@@ -14,15 +14,17 @@
 
 """Test copyright headers in source files."""
 
-from ament_copyright.main import main
 import pytest
+from ament_copyright.main import main
 
 
-# Remove the `skip` decorator once the source file(s) have a copyright header
-@pytest.mark.skip(reason='No copyright header has been placed in the generated source file.')
+# Remove the `skip` decorator once source files have copyright headers.
+@pytest.mark.skip(
+    reason="No copyright header has been placed in the generated source file."
+)
 @pytest.mark.copyright
 @pytest.mark.linter
 def test_copyright():
     """Test that all source files have proper copyright headers."""
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found errors'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found errors"

--- a/src/lunabot_perception/test/test_flake8.py
+++ b/src/lunabot_perception/test/test_flake8.py
@@ -14,8 +14,8 @@
 
 """Test code follows flake8 style guidelines."""
 
-from ament_flake8.main import main_with_errors
 import pytest
+from ament_flake8.main import main_with_errors
 
 
 @pytest.mark.flake8
@@ -23,6 +23,6 @@ import pytest
 def test_flake8():
     """Test that code follows flake8 style guidelines."""
     rc, errors = main_with_errors(argv=[])
-    assert rc == 0, \
-        'Found %d code style errors / warnings:\n' % len(errors) + \
-        '\n'.join(errors)
+    assert rc == 0, (
+        f"Found {len(errors)} code style errors / warnings:\n" + "\n".join(errors)
+    )

--- a/src/lunabot_perception/test/test_pep257.py
+++ b/src/lunabot_perception/test/test_pep257.py
@@ -14,13 +14,13 @@
 
 """Test docstrings follow PEP257 conventions."""
 
-from ament_pep257.main import main
 import pytest
+from ament_pep257.main import main
 
 
 @pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
     """Test that code follows PEP257 docstring conventions."""
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found code style errors / warnings'
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found code style errors / warnings"


### PR DESCRIPTION
## Summary
- replace navigation package `setup.py` path handling with `Path`-based helpers
- modernise the navigation and perception lint tests so they match the repo standard
- keep the package scaffolding plain and easier to analyse

## Testing
- uv run --with ruff==0.11.13 ruff check src/lunabot_navigation src/lunabot_perception --select I,B,UP,SIM,RET,ARG,PTH,RUF,C4
- python3 -m compileall src/lunabot_navigation/setup.py src/lunabot_navigation/test/test_flake8.py src/lunabot_navigation/test/test_copyright.py src/lunabot_navigation/test/test_pep257.py src/lunabot_perception/test/test_flake8.py src/lunabot_perception/test/test_copyright.py src/lunabot_perception/test/test_pep257.py
- remote: colcon build --packages-up-to lunabot_navigation lunabot_perception
- remote: colcon test --packages-select lunabot_navigation lunabot_perception
- remote: colcon test-result --verbose
