### PR TITLE
Extend strict quality gates to remaining packages

### DIFF
--- a/.github/scripts/run_quality_checks.py
+++ b/.github/scripts/run_quality_checks.py
@@ -18,6 +18,10 @@ BLOCKING_STRICT_PYTHON_TARGETS = [
     "src/lunabot_control",
     "src/lunabot_excavation",
     "src/lunabot_localisation",
+    "src/lunabot_navigation",
+    "src/lunabot_perception",
+    "src/lunabot_simulation",
+    "src/lunabot_teleop",
 ]
 ADVISORY_PYTHON_TARGETS = [
     ".github/scripts",
@@ -26,6 +30,10 @@ ADVISORY_PYTHON_TARGETS = [
     "src/lunabot_control",
     "src/lunabot_excavation",
     "src/lunabot_localisation",
+    "src/lunabot_navigation",
+    "src/lunabot_perception",
+    "src/lunabot_simulation",
+    "src/lunabot_teleop",
 ]
 BLOCKING_YAML_TARGETS = [
     ".github",
@@ -37,6 +45,10 @@ BLOCKING_COMPLEXITY_TARGETS = [
     "src/lunabot_control",
     "src/lunabot_excavation",
     "src/lunabot_localisation",
+    "src/lunabot_navigation",
+    "src/lunabot_perception",
+    "src/lunabot_simulation",
+    "src/lunabot_teleop",
 ]
 ADVISORY_COMPLEXITY_TARGETS = [
     "tools",
@@ -44,6 +56,10 @@ ADVISORY_COMPLEXITY_TARGETS = [
     "src/lunabot_control",
     "src/lunabot_excavation",
     "src/lunabot_localisation",
+    "src/lunabot_navigation",
+    "src/lunabot_perception",
+    "src/lunabot_simulation",
+    "src/lunabot_teleop",
 ]
 
 


### PR DESCRIPTION
## Summary
- add navigation, perception, simulation and teleop to the strict Ruff gate
- add those same packages to the strict complexity gate
- keep the advisory gate aligned with the packages we now treat as clean

## Testing
- uv run --with ruff==0.11.13 --with yamllint==1.37.1 --with xenon==0.9.3 --with pyright==1.1.403 python3 .github/scripts/run_quality_checks.py --mode blocking
- uv run --with ruff==0.11.13 --with pyright==1.1.403 --with xenon==0.9.3 python3 .github/scripts/run_quality_checks.py --mode advisory
