### PR TITLE
Stop continuous AprilTag fusion in the localisation baseline

### DIFF
--- a/src/lunabot_localisation/README.md
+++ b/src/lunabot_localisation/README.md
@@ -4,31 +4,33 @@ This package contains localisation launch/config and localisation helper nodes f
 
 ## What this package is responsible for
 
-`lunabot_localisation` provides fused localisation outputs consumed by planning and mapping components. It owns configuration around EKF-based local/global pose estimation and tag-based correction paths.
+`lunabot_localisation` provides fused localisation outputs consumed by planning and mapping components. It owns configuration around EKF-based local/global pose estimation and the bounded start-zone tag initialisation path.
 
 ## Core outputs
 
 - Local fused odometry for navigation smoothness.
-- Global correction path through tag-derived pose updates.
+- Global pose initialisation and bounded stationary recovery through the start-zone tag path.
 - TF relationships required by planning components.
 
 ## June baseline
 
-The current baseline is deliberately simple: wheel odom, IMU, and start-zone
-AprilTag correction. RTAB-Map can still be launched for experimentation, but
-raw visual odometry is not fused into the EKFs as part of the June baseline.
+The current baseline is deliberately simple: wheel odom, IMU, and a start-zone
+AprilTag pose seed. The tag is used to initialise the global pose, not to
+continuously correct the global EKF while the rover is driving. RTAB-Map can
+still be launched for experimentation, but raw visual odometry is not fused
+into the EKFs as part of the June baseline.
 
 ## Key files
 
 - `config/ekf.yaml`: EKF fusion and frame configuration.
 - `launch/localisation.launch.py`: localisation bring-up path.
-- `lunabot_localisation/tag_pose_publisher.py`: bridge from tag detections to pose updates.
+- `lunabot_localisation/tag_pose_publisher.py`: bridge from tag detections to bounded pose seeding / recovery inputs.
 
 ## Common failure modes
 
 - Frame mismatch (`base_link` vs `base_footprint`) causing downstream planner instability.
 - Covariances set unrealistically low, making the filter overconfident.
-- Missing tag detections causing global drift to accumulate over longer runs.
+- Weak continuous odometry causing drift to accumulate after the start-zone seed.
 
 ## Where to read next
 

--- a/src/lunabot_localisation/config/ekf.yaml
+++ b/src/lunabot_localisation/config/ekf.yaml
@@ -1,6 +1,7 @@
 ### Dual EKF Configuration ###
 # Local EKF: smooth odom -> base_footprint (continuous, never jumps)
-# Global EKF: map -> odom (jumps when AprilTag seen, corrects drift)
+# Global EKF: seeded once from the start-zone tag, then propagated from the
+# local EKF without continuous tag fusion while driving.
 
 ekf_filter_node_odom:
   ros__parameters:
@@ -83,8 +84,9 @@ ekf_filter_node_map:
 
     # [X, Y, Z, Roll, Pitch, Yaw, VX, VY, VZ, VRoll, VPitch, VYaw, AX, AY, AZ]
 
-    # Continuous motion source from local EKF (odom -> base_footprint)
-    # Keep global EKF lightweight: local filtered odom + intermittent tag pose.
+    # Continuous motion source from local EKF (odom -> base_footprint).
+    # The competition baseline treats AprilTag as an initialisation / recovery
+    # aid, not as a live correction source while the rover is moving.
     odom0: /odometry/local
     odom0_config:
       [
@@ -104,27 +106,3 @@ ekf_filter_node_map:
         false,
         false,
       ]
-
-    # AprilTag pose correction (discontinuous, only in global EKF)
-    pose0: /tag_pose
-    pose0_config:
-      [
-        true,
-        true,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-      ]
-    pose0_differential: false
-    pose0_relative: false
-    pose0_rejection_threshold: 4.0

--- a/src/lunabot_localisation/test/test_localisation_launch.py
+++ b/src/lunabot_localisation/test/test_localisation_launch.py
@@ -144,3 +144,12 @@ def test_june_baseline_ekf_does_not_fuse_visual_odometry(config_name):
 
     assert "odom1" not in odom_parameters
     assert "/visual_odometry" not in odom_parameters.values()
+
+
+def test_competition_baseline_global_ekf_does_not_fuse_tag_pose_continuously():
+    ekf_path = Path(__file__).resolve().parents[1] / "config" / "ekf.yaml"
+    config = yaml.safe_load(ekf_path.read_text())
+    map_parameters = config["ekf_filter_node_map"]["ros__parameters"]
+
+    assert "pose0" not in map_parameters
+    assert "/tag_pose" not in map_parameters.values()


### PR DESCRIPTION
## Summary
- remove continuous `/tag_pose` fusion from the competition localisation baseline
- keep the start-zone tag path as the bounded pose-seeding mechanism
- document and test the stripped-down baseline behaviour

## Why
The current baseline lets intermittent AprilTag observations keep correcting the global EKF while the rover is driving. In manual testing that appears to let the world frame swim under the rover. This PR makes the phase-one simplification explicit: the tag seeds the pose, and continuous motion comes from the local odometry path.

## Validation
- `uv run --with ruff==0.11.13 ruff check src/lunabot_localisation/test/test_localisation_launch.py`
- `uv run --with pyyaml python - <<'PY' ... yaml.safe_load('src/lunabot_localisation/config/ekf.yaml') ... PY`
- `uv run --with yamllint yamllint src/lunabot_localisation/config/ekf.yaml`
- `python3 -m compileall src/lunabot_localisation/test/test_localisation_launch.py`
- local pytest for the launch test needs ROS `launch`, so the ROS-side test run is deferred to the external machine / CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Disables continuous AprilTag fusion in the global EKF (map-frame filter), retaining AprilTag only as a one-time bounded pose-seeding mechanism at the start zone. This addresses the issue where intermittent AprilTag observations during driving caused the world frame to drift relative to the rover.

## Changes
- **Configuration**: Removed `pose0: /tag_pose` and associated continuous pose correction parameters from the global EKF filter, keeping only local odometry (`odom0: /odometry/local`) as the live motion input.
- **Documentation**: Updated README to reflect the shift from continuous global correction to bounded pose initialization and recovery.
- **Testing**: Added test to verify the global EKF no longer fuses tag pose data continuously.

## Outcome
The global pose is now initialized (and recoverable) via the start-zone AprilTag detection, but continuous motion estimation is driven solely by local odometry, eliminating the "swimming" effect caused by intermittent tag-based corrections during driving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->