### PR TITLE
feat: launch crater_detection node from navigation stack

### DIFF
--- a/src/lunabot_bringup/launch/navigation.launch.py
+++ b/src/lunabot_bringup/launch/navigation.launch.py
@@ -188,6 +188,14 @@ def generate_launch_description():
         }.items(),
     )
 
+    crater_detection = Node(
+        package="lunabot_perception",
+        executable="crater_detection",
+        name="crater_detection",
+        output="screen",
+        parameters=[{"use_sim_time": use_sim_time}],
+    )
+
     navigate_to_pose_gate = Node(
         package="lunabot_bringup",
         executable="navigate_to_pose_gate",
@@ -398,6 +406,7 @@ def generate_launch_description():
                 description=("SDL device index for the connected controller."),
             ),
             localisation_launch,
+            crater_detection,
             navigate_to_pose_gate,
             teleop_launch,
             twist_mux,


### PR DESCRIPTION
## Summary
- Adds the `crater_detection` perception node to `navigation.launch.py`, starting it alongside localisation so the elevation grid warms up before Nav2 begins planning.
- Ensures `/crater_grid` is published automatically when the navigation stack launches, removing the need to start `crater_detection` manually.
- Part of the Phase 1 Travel Automation work (PR1 of 4).

## Changes
- `src/lunabot_bringup/launch/navigation.launch.py`: Added `crater_detection` Node definition with `use_sim_time` passthrough; placed it in the launch description immediately after `localisation_launch`.

## Test plan
- [ ] `colcon build --packages-select lunabot_bringup` succeeds
- [ ] `ros2 launch lunabot_bringup navigation.launch.py` starts `crater_detection` node
- [ ] `ros2 topic list` includes `/crater_grid` after launch
- [ ] CI passes (flake8, pep257, copyright, nav2 baseline tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Launches the `crater_detection` perception node as part of the navigation stack, ensuring the elevation grid (`/crater_grid`) is published and warmed up before Nav2 begins planning. This makes the grid immediately available to the CraterLayer costmap plugin, preventing delays in costmap initialization during autonomous navigation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->