### PR TITLE
feat: add LiDAR VoxelLayer and DenoiseLayer for boulder detection

### DIFF
--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -43,8 +43,8 @@ global_costmap:
       resolution: 0.05
       track_unknown_space: false
       rolling_window: true
-      width: 10
-      height: 8
+      width: 16
+      height: 10
       use_maximum: true
       plugins: ["obstacle_layer", "voxel_layer", "crater_layer", "denoise_layer", "inflation_layer"]
 

--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -1,6 +1,7 @@
 # Nav2 parameters for UK Lunabotics innex1 rover
-# Costmap uses: obstacle layer (boulders), crater layer (negative obstacles),
-# and inflation around both.
+# Costmap uses: obstacle layer (depth camera boulders), voxel layer (LiDAR 3D
+# boulders), crater layer (negative obstacles), denoise (speckle removal), and
+# inflation around all obstacles.
 
 bt_navigator:
   ros__parameters:
@@ -45,7 +46,7 @@ global_costmap:
       width: 10
       height: 8
       use_maximum: true
-      plugins: ["obstacle_layer", "crater_layer", "inflation_layer"]
+      plugins: ["obstacle_layer", "voxel_layer", "crater_layer", "denoise_layer", "inflation_layer"]
 
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
@@ -63,11 +64,38 @@ global_costmap:
           obstacle_max_range: 2.5
           obstacle_min_range: 0.0
 
+      voxel_layer:
+        plugin: "nav2_costmap_2d::VoxelLayer"
+        enabled: true
+        observation_sources: lidar_points
+        publish_voxel_map: false
+        z_voxels: 10
+        z_resolution: 0.1
+        max_obstacle_height: 0.8
+        origin_z: 0.0
+        mark_threshold: 2
+        lidar_points:
+          topic: /ouster/points
+          data_type: "PointCloud2"
+          min_obstacle_height: 0.10
+          max_obstacle_height: 0.80
+          clearing: true
+          marking: true
+          raytrace_max_range: 5.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 4.5
+          obstacle_min_range: 0.0
+
       crater_layer:
         plugin: "nav2_costmap_2d::StaticLayer"
         map_topic: "/crater_grid"
         map_subscribe_transient_local: false
         subscribe_to_updates: false
+
+      denoise_layer:
+        plugin: "nav2_costmap_2d::DenoiseLayer"
+        enabled: true
+        minimal_group_size: 2
 
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
@@ -90,7 +118,7 @@ local_costmap:
       height: 3
       resolution: 0.05
       use_maximum: true
-      plugins: ["obstacle_layer", "crater_layer", "inflation_layer"]
+      plugins: ["obstacle_layer", "voxel_layer", "crater_layer", "denoise_layer", "inflation_layer"]
 
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
@@ -108,11 +136,38 @@ local_costmap:
           obstacle_max_range: 2.5
           obstacle_min_range: 0.0
 
+      voxel_layer:
+        plugin: "nav2_costmap_2d::VoxelLayer"
+        enabled: true
+        observation_sources: lidar_points
+        publish_voxel_map: false
+        z_voxels: 10
+        z_resolution: 0.1
+        max_obstacle_height: 0.8
+        origin_z: 0.0
+        mark_threshold: 2
+        lidar_points:
+          topic: /ouster/points
+          data_type: "PointCloud2"
+          min_obstacle_height: 0.10
+          max_obstacle_height: 0.80
+          clearing: true
+          marking: true
+          raytrace_max_range: 4.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 3.5
+          obstacle_min_range: 0.0
+
       crater_layer:
         plugin: "nav2_costmap_2d::StaticLayer"
         map_topic: "/crater_grid"
         map_subscribe_transient_local: false
         subscribe_to_updates: false
+
+      denoise_layer:
+        plugin: "nav2_costmap_2d::DenoiseLayer"
+        enabled: true
+        minimal_group_size: 2
 
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"


### PR DESCRIPTION
## Summary
- Adds Ouster LiDAR (`/ouster/points`) as a second obstacle source via Nav2's **VoxelLayer** with 3D raycasting, providing 360-degree boulder detection to complement the forward-facing depth camera ObstacleLayer.
- Adds **DenoiseLayer** between obstacle sources and inflation to remove single-cell speckle noise (pattern from EDT and lunabot_ros teams).
- Updates costmap plugin order to: `obstacle_layer -> voxel_layer -> crater_layer -> denoise_layer -> inflation_layer` in both global and local costmaps.

## Design decisions
- **Height bounds (0.10-0.80m):** 0.10m floor rejects ground plane noise; 0.80m ceiling is above max boulder height (~40cm per rule book) but below the rover body to avoid self-hits.
- **mark_threshold: 2** reduces false positives from single-ray noise.
- **Local costmap uses shorter ranges** (4.0m raytrace / 3.5m obstacle) vs global (5.0m / 4.5m) since the local window is only 3x3m.
- **DenoiseLayer minimal_group_size: 2** removes isolated single-cell speckle while preserving real obstacle clusters.

## Test plan
- [ ] `colcon build --packages-select lunabot_navigation` succeeds
- [ ] CI passes (nav2 baseline test, flake8, pep257)
- [ ] In simulation: `ros2 topic echo /ouster/points --once` confirms LiDAR data flows
- [ ] In simulation: costmap visualisation in RViz shows LiDAR-sourced obstacles around boulders
- [ ] Rover avoids boulders when navigating through the obstacle field

Closes #112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Adds LiDAR-based obstacle detection to the Nav2 costmap using Ouster point clouds, complementing the existing depth-camera obstacle detection. This provides 360° boulder detection with a new `VoxelLayer` and introduces a `DenoiseLayer` to remove speckle noise from the obstacle detection pipeline.

## Changes
- **Added VoxelLayer**: Configures LiDAR point cloud processing from `/ouster/points` for both global and local costmaps, enabling 3D raycasting-based obstacle marking and clearing within specified height and range bounds.
- **Added DenoiseLayer**: Places between obstacle sources and inflation layer to filter out single-cell speckle noise in both costmaps.
- **Updated costmap plugin order**: Changed from `[obstacle_layer, crater_layer, inflation_layer]` to `[obstacle_layer, voxel_layer, crater_layer, denoise_layer, inflation_layer]` for both global and local costmaps.
- **Expanded global costmap window**: Increased from 10×8 m to 16×10 m to ensure full arena coverage and prevent goals near the far end from falling outside the costmap bounds.
- **Configured layer parameters**: Set voxel layer ranges and height thresholds; configured denoise layer noise filtering sensitivity.

## Impact
Establishes a stable, computationally inexpensive 3D obstacle detection baseline for Nav2 that leverages LiDAR for comprehensive terrain-aware navigation while maintaining compatibility with future traversability analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->