### PR TITLE
feat: wire collision monitor into Nav2 lifecycle launch

### DIFF
--- a/src/lunabot_bringup/launch/nav2_navigation.launch.py
+++ b/src/lunabot_bringup/launch/nav2_navigation.launch.py
@@ -18,6 +18,12 @@ def _bringup_path(*parts: str) -> str:
     return str(package_root.joinpath(*parts))
 
 
+def _nav_config_path(*parts: str) -> str:
+    """Return a path inside the lunabot_navigation config share directory."""
+    package_root = Path(get_package_share_directory("lunabot_navigation"))
+    return str(package_root.joinpath("config", *parts))
+
+
 def generate_launch_description():
     """Launch Nav2 with its standard NavigateToPose action surface."""
     namespace = LaunchConfiguration("namespace")
@@ -38,6 +44,7 @@ def generate_launch_description():
         "bt_navigator",
         "waypoint_follower",
         "velocity_smoother",
+        "collision_monitor",
     ]
 
     # Humble does not reliably remap action names for Nav2's rclcpp_action
@@ -51,6 +58,8 @@ def generate_launch_description():
         "use_sim_time": use_sim_time,
         "autostart": autostart,
     }
+
+    collision_monitor_params = _nav_config_path("collision_monitor.yaml")
 
     configured_params = ParameterFile(
         RewrittenYaml(
@@ -198,6 +207,20 @@ def generate_launch_description():
                 ],
             ),
             Node(
+                package="nav2_collision_monitor",
+                executable="collision_monitor",
+                name="collision_monitor",
+                output="screen",
+                respawn=use_respawn,
+                respawn_delay=2.0,
+                parameters=[
+                    collision_monitor_params,
+                    {"use_sim_time": use_sim_time},
+                ],
+                arguments=["--ros-args", "--log-level", log_level],
+                remappings=remappings,
+            ),
+            Node(
                 package="nav2_lifecycle_manager",
                 executable="lifecycle_manager",
                 name="lifecycle_manager_navigation",
@@ -268,6 +291,16 @@ def generate_launch_description():
                     ("cmd_vel", "cmd_vel_nav"),
                     ("cmd_vel_smoothed", "cmd_vel"),
                 ],
+            ),
+            ComposableNode(
+                package="nav2_collision_monitor",
+                plugin="nav2_collision_monitor::CollisionMonitor",
+                name="collision_monitor",
+                parameters=[
+                    collision_monitor_params,
+                    {"use_sim_time": use_sim_time},
+                ],
+                remappings=remappings,
             ),
             ComposableNode(
                 package="nav2_lifecycle_manager",

--- a/src/lunabot_navigation/config/collision_monitor.yaml
+++ b/src/lunabot_navigation/config/collision_monitor.yaml
@@ -9,7 +9,6 @@
 
 collision_monitor:
   ros__parameters:
-    use_sim_time: true
     enabled: true
     base_frame_id: "base_footprint"
     odom_frame_id: "odom"
@@ -41,11 +40,18 @@ collision_monitor:
       polygon_pub_topic: "polygon_slowdown"
       enabled: true
 
-    observation_sources: ["front_camera"]
+    observation_sources: ["front_camera", "lidar"]
 
     front_camera:
       type: "pointcloud"
       topic: "/camera_front/points"
+      min_height: 0.10
+      max_height: 0.60
+      enabled: true
+
+    lidar:
+      type: "pointcloud"
+      topic: "/ouster/points"
       min_height: 0.10
       max_height: 0.60
       enabled: true


### PR DESCRIPTION
## Summary
- Wires `nav2_collision_monitor` into the Nav2 navigation launch as the final velocity safety layer, sitting between the velocity smoother (`cmd_vel`) and the robot bridge (`cmd_vel_safe`).
- Adds LiDAR (`/ouster/points`) as a second observation source alongside the front depth camera for 360-degree safety coverage.
- Removes hardcoded `use_sim_time` from `collision_monitor.yaml` (now passed dynamically via launch parameter).
- Part of Phase 1 Travel Automation (PR3 of 4).

## Velocity pipeline after this PR
```
controller_server -> cmd_vel_nav -> velocity_smoother -> cmd_vel -> collision_monitor -> cmd_vel_safe -> robot bridge
```

## Changes
- `src/lunabot_bringup/launch/nav2_navigation.launch.py`: Added `collision_monitor` to `lifecycle_nodes`, added Node and ComposableNode definitions with `collision_monitor.yaml` params
- `src/lunabot_navigation/config/collision_monitor.yaml`: Added `lidar` observation source, removed hardcoded `use_sim_time`

## Test plan
- [ ] `colcon build --packages-select lunabot_bringup lunabot_navigation` succeeds
- [ ] CI passes (flake8, pep257, copyright, nav2 baseline tests)
- [ ] In simulation: `ros2 node list` shows `/collision_monitor` after launch
- [ ] In simulation: `ros2 topic echo /polygon_stop --once` shows the safety polygon is published
- [ ] In simulation: rover stops when obstacle enters the stop polygon

Addresses #168