### PR TITLE
feat: add arena waypoints and fix mission_manager goal poses

### DIFF
--- a/src/lunabot_bringup/config/arena_waypoints.yaml
+++ b/src/lunabot_bringup/config/arena_waypoints.yaml
@@ -1,0 +1,26 @@
+# Arena waypoints for the UK Lunabotics competition.
+# All poses are in the map frame.  Adjust these for each arena setup.
+#
+# Arena layout (7.9 m x 4.4 m, origin at start-zone centre):
+#   [Start / Deposition Zone]  ->  [Obstacle Zone]  ->  [Excavation Zone]
+#
+# The rover starts facing +x.  Excavation is at the far +x end; deposition
+# is near the start zone at the -x end.
+
+mission_manager:
+  ros__parameters:
+    # Waypoint in the middle of the obstacle zone -- a safe intermediate
+    # target that avoids sending the planner a goal across the entire arena.
+    waypoint_mid_obstacle_x: 3.5
+    waypoint_mid_obstacle_y: 0.0
+    waypoint_mid_obstacle_yaw: 0.0
+
+    # Excavation zone target pose.
+    waypoint_excavation_x: 6.5
+    waypoint_excavation_y: 0.0
+    waypoint_excavation_yaw: 0.0
+
+    # Deposition zone target pose (near the berm in the start zone).
+    waypoint_deposition_x: 0.8
+    waypoint_deposition_y: 0.0
+    waypoint_deposition_yaw: 3.14159

--- a/src/lunabot_bringup/config/arena_waypoints.yaml
+++ b/src/lunabot_bringup/config/arena_waypoints.yaml
@@ -1,26 +1,30 @@
 # Arena waypoints for the UK Lunabotics competition.
 # All poses are in the map frame.  Adjust these for each arena setup.
 #
-# Arena layout (7.9 m x 4.4 m, origin at start-zone centre):
-#   [Start / Deposition Zone]  ->  [Obstacle Zone]  ->  [Excavation Zone]
+# Sim coordinate system (from moon_yard_craters.sdf):
+#   Rover spawns at (0, 0) in the top-left of the arena.
+#   X increases rightward toward the excavation zone.
+#   Y decreases downward (the arena floor spans roughly y=1.1 to y=-3.3).
+#   Walls: west x=-1.0, east x=6.9, north y=1.1, south y=-3.3
 #
-# The rover starts facing +x.  Excavation is at the far +x end; deposition
-# is near the start zone at the -x end.
+#   [Start Zone x<1]  ->  [Obstacle Zone 1<x<5]  ->  [Excavation Zone x>5]
+#   Deposition / berm is at the bottom of the start zone (low Y).
 
 mission_manager:
   ros__parameters:
-    # Waypoint in the middle of the obstacle zone -- a safe intermediate
-    # target that avoids sending the planner a goal across the entire arena.
-    waypoint_mid_obstacle_x: 3.5
-    waypoint_mid_obstacle_y: 0.0
+    # Waypoint in the middle of the obstacle zone, centred vertically.
+    # The planner routes around detected boulders and craters.
+    waypoint_mid_obstacle_x: 3.0
+    waypoint_mid_obstacle_y: -1.1
     waypoint_mid_obstacle_yaw: 0.0
 
-    # Excavation zone target pose.
-    waypoint_excavation_x: 6.5
-    waypoint_excavation_y: 0.0
+    # Excavation zone target pose -- clear of rock_6 (6.15,-2.1).
+    waypoint_excavation_x: 6.0
+    waypoint_excavation_y: -1.5
     waypoint_excavation_yaw: 0.0
 
-    # Deposition zone target pose (near the berm in the start zone).
-    waypoint_deposition_x: 0.8
-    waypoint_deposition_y: 0.0
-    waypoint_deposition_yaw: 3.14159
+    # Deposition zone target pose -- near the berm at the bottom of the
+    # start zone.  Yaw faces -Y (toward the berm).
+    waypoint_deposition_x: 0.3
+    waypoint_deposition_y: -2.8
+    waypoint_deposition_yaw: -1.5708

--- a/src/lunabot_bringup/launch/mission_manager.launch.py
+++ b/src/lunabot_bringup/launch/mission_manager.launch.py
@@ -1,3 +1,8 @@
+"""Launch the mission manager with arena waypoint configuration."""
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
@@ -5,17 +10,24 @@ from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
 
 
-def generate_launch_description():
-    use_sim_time = LaunchConfiguration("use_sim_time")
+def _bringup_config_path(*parts: str) -> str:
+    """Return a path inside the lunabot_bringup config share directory."""
+    return str(Path(get_package_share_directory("lunabot_bringup")).joinpath("config", *parts))
 
-    # Start only the standalone mission manager; dependent action servers stay separate.
+
+def generate_launch_description():
+    """Generate the mission manager launch description."""
+    use_sim_time = LaunchConfiguration("use_sim_time")
+    waypoints_file = LaunchConfiguration("waypoints_file")
+
     mission_manager = Node(
         package="lunabot_bringup",
         executable="mission_manager",
         name="mission_manager",
         output="screen",
         parameters=[
-            {"use_sim_time": ParameterValue(use_sim_time, value_type=bool)}
+            waypoints_file,
+            {"use_sim_time": ParameterValue(use_sim_time, value_type=bool)},
         ],
     )
 
@@ -25,6 +37,11 @@ def generate_launch_description():
                 "use_sim_time",
                 default_value="false",
                 description="Use /clock instead of wall time for the mission manager.",
+            ),
+            DeclareLaunchArgument(
+                "waypoints_file",
+                default_value=_bringup_config_path("arena_waypoints.yaml"),
+                description="Path to arena waypoints YAML for the mission manager.",
             ),
             mission_manager,
         ]

--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -56,15 +56,15 @@ class MissionManager(Node):
         self.declare_parameter("prehoc_s_start_exc_m", 5.0)
         self.declare_parameter("prehoc_s_exc_dep_m", 5.0)
 
-        self.declare_parameter("waypoint_mid_obstacle_x", 3.5)
-        self.declare_parameter("waypoint_mid_obstacle_y", 0.0)
+        self.declare_parameter("waypoint_mid_obstacle_x", 3.0)
+        self.declare_parameter("waypoint_mid_obstacle_y", -1.1)
         self.declare_parameter("waypoint_mid_obstacle_yaw", 0.0)
-        self.declare_parameter("waypoint_excavation_x", 6.5)
-        self.declare_parameter("waypoint_excavation_y", 0.0)
+        self.declare_parameter("waypoint_excavation_x", 6.0)
+        self.declare_parameter("waypoint_excavation_y", -1.5)
         self.declare_parameter("waypoint_excavation_yaw", 0.0)
-        self.declare_parameter("waypoint_deposition_x", 0.8)
-        self.declare_parameter("waypoint_deposition_y", 0.0)
-        self.declare_parameter("waypoint_deposition_yaw", 3.14159)
+        self.declare_parameter("waypoint_deposition_x", 0.3)
+        self.declare_parameter("waypoint_deposition_y", -2.8)
+        self.declare_parameter("waypoint_deposition_yaw", -1.5708)
         self.declare_parameter("nav_goal_timeout_s", 120.0)
 
         self._state: MissionState = MissionState.INITIALIZE_MISSION

--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -56,6 +56,17 @@ class MissionManager(Node):
         self.declare_parameter("prehoc_s_start_exc_m", 5.0)
         self.declare_parameter("prehoc_s_exc_dep_m", 5.0)
 
+        self.declare_parameter("waypoint_mid_obstacle_x", 3.5)
+        self.declare_parameter("waypoint_mid_obstacle_y", 0.0)
+        self.declare_parameter("waypoint_mid_obstacle_yaw", 0.0)
+        self.declare_parameter("waypoint_excavation_x", 6.5)
+        self.declare_parameter("waypoint_excavation_y", 0.0)
+        self.declare_parameter("waypoint_excavation_yaw", 0.0)
+        self.declare_parameter("waypoint_deposition_x", 0.8)
+        self.declare_parameter("waypoint_deposition_y", 0.0)
+        self.declare_parameter("waypoint_deposition_yaw", 3.14159)
+        self.declare_parameter("nav_goal_timeout_s", 120.0)
+
         self._state: MissionState = MissionState.INITIALIZE_MISSION
         self._timer: MissionTimer | None = None
 
@@ -312,41 +323,60 @@ class MissionManager(Node):
             return True, f"{action_name} server available"
         return False, f"{action_name} server unavailable after {timeout_s}s"
 
-    def _send_navigate_to_excavation(self) -> tuple[bool, str]:
-        """Send a NavigateToPose goal toward the excavation zone."""
+    def _build_nav_goal(self, x: float, y: float, yaw: float) -> NavigateToPose.Goal:
+        """Build a NavigateToPose goal in the map frame."""
+        goal = NavigateToPose.Goal()
+        goal.pose.header.frame_id = "map"
+        goal.pose.header.stamp = self.get_clock().now().to_msg()
+        goal.pose.pose.position.x = x
+        goal.pose.pose.position.y = y
+        goal.pose.pose.orientation.z = math.sin(yaw / 2.0)
+        goal.pose.pose.orientation.w = math.cos(yaw / 2.0)
+        return goal
+
+    def _send_nav_goal(self, goal, label: str) -> tuple[bool, str]:
+        """Send a NavigateToPose goal and wait for the result."""
         available, detail = self._wait_for_server(
-            self._navigate_client, "/navigate_to_pose_gate"
+            self._navigate_client, "/navigate_to_pose"
         )
         if not available:
             return False, detail
 
-        goal = NavigateToPose.Goal()
-        goal.pose.header.frame_id = "map"
-        goal.pose.header.stamp = self.get_clock().now().to_msg()
+        timeout = self._safe_float_parameter("nav_goal_timeout_s")
+        if timeout is None:
+            return False, f"{label}: nav_goal_timeout_s parameter invalid"
 
+        self.get_logger().info(
+            f"{label}: goal at ({goal.pose.pose.position.x:.2f}, "
+            f"{goal.pose.pose.position.y:.2f})"
+        )
         send_future = self._navigate_client.send_goal_async(goal)
         goal_handle = self._wait_for_future(
-            send_future, 30.0, "navigate_to_excavation goal response timed out"
+            send_future, 30.0, f"{label} goal response timed out"
         )
-        return self._check_goal_result(goal_handle, "navigate_to_excavation", 60.0)
+        return self._check_goal_result(goal_handle, label, timeout)
+
+    def _send_navigate_to_excavation(self) -> tuple[bool, str]:
+        """Send a NavigateToPose goal toward the excavation zone."""
+        x = self._safe_float_parameter("waypoint_excavation_x")
+        y = self._safe_float_parameter("waypoint_excavation_y")
+        yaw = self._safe_float_parameter("waypoint_excavation_yaw")
+        if x is None or y is None or yaw is None:
+            return False, "excavation waypoint parameters invalid"
+
+        goal = self._build_nav_goal(x, y, yaw)
+        return self._send_nav_goal(goal, "navigate_to_excavation")
 
     def _send_navigate_to_deposition(self) -> tuple[bool, str]:
         """Send a NavigateToPose goal toward the deposition zone."""
-        available, detail = self._wait_for_server(
-            self._navigate_client, "/navigate_to_pose_gate"
-        )
-        if not available:
-            return False, detail
+        x = self._safe_float_parameter("waypoint_deposition_x")
+        y = self._safe_float_parameter("waypoint_deposition_y")
+        yaw = self._safe_float_parameter("waypoint_deposition_yaw")
+        if x is None or y is None or yaw is None:
+            return False, "deposition waypoint parameters invalid"
 
-        goal = NavigateToPose.Goal()
-        goal.pose.header.frame_id = "map"
-        goal.pose.header.stamp = self.get_clock().now().to_msg()
-
-        send_future = self._navigate_client.send_goal_async(goal)
-        goal_handle = self._wait_for_future(
-            send_future, 30.0, "navigate_to_deposition goal response timed out"
-        )
-        return self._check_goal_result(goal_handle, "navigate_to_deposition", 60.0)
+        goal = self._build_nav_goal(x, y, yaw)
+        return self._send_nav_goal(goal, "navigate_to_deposition")
 
     def _send_excavate(self) -> tuple[bool, str]:
         """Send an Excavate action goal."""

--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -337,7 +337,7 @@ class MissionManager(Node):
     def _send_nav_goal(self, goal, label: str) -> tuple[bool, str]:
         """Send a NavigateToPose goal and wait for the result."""
         available, detail = self._wait_for_server(
-            self._navigate_client, "/navigate_to_pose"
+            self._navigate_client, "/navigate_to_pose_gate"
         )
         if not available:
             return False, detail

--- a/src/lunabot_bringup/test/test_mission_manager_launch.py
+++ b/src/lunabot_bringup/test/test_mission_manager_launch.py
@@ -33,12 +33,13 @@ def test_mission_manager_launch_starts_one_supervisor_node(monkeypatch):
         if isinstance(entity, DeclareLaunchArgument)
     ]
 
-    assert declared_arguments == ["use_sim_time"]
+    assert declared_arguments == ["use_sim_time", "waypoints_file"]
     assert len(nodes) == 1
     assert nodes[0].node_executable == "mission_manager"
 
     context = LaunchContext()
     context.launch_configurations["use_sim_time"] = "false"
+    context.launch_configurations["waypoints_file"] = "/tmp/test_waypoints.yaml"
     monkeypatch.setattr(ExecuteProcess, "execute", lambda _self, _context: None)
     nodes[0].execute(context)
 


### PR DESCRIPTION
## Summary
- Adds `arena_waypoints.yaml` with tunable excavation, deposition, and mid-obstacle waypoints based on the 7.9m x 4.4m arena layout
- Fixes mission_manager's `_send_navigate_to_excavation` and `_send_navigate_to_deposition` to build goals with actual position and orientation (was sending empty goals at 0,0,0)
- Updates `mission_manager.launch.py` to load the waypoints config

## Test plan
- [ ] CI passes
- [ ] On VM: launch mission_manager, verify it logs correct goal coordinates
- [ ] Waypoint parameters can be overridden via launch arguments

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes mission_manager's navigation to send proper waypoint coordinates instead of empty goals, and introduces configurable arena waypoints.

## Changes

**Fixed empty goal bug**: mission_manager was sending NavigateToPose goals with empty position/orientation (0,0,0). Now it sends actual coordinates by:
- Reading waypoint coordinates from a new configuration file
- Building NavigateToPose goals with position and yaw orientation
- Using a configurable timeout for navigation goal results

**Added configurable waypoints**: Introduced `arena_waypoints.yaml` containing three tunable waypoint sets for the 7.9 m × 4.4 m arena:
- Excavation zone pose
- Deposition zone pose  
- Mid-obstacle corridor waypoint

Each waypoint includes X, Y position and yaw orientation parameters, allowing easy adjustment without code changes.

**Updated launch configuration**: mission_manager.launch.py now loads the waypoints configuration file via a declarable launch argument.

**Coordinates**: Waypoints are specified in simulation coordinate system (rover spawn at top-left, Y negative downward):
- Excavation: (6.0, -1.5)
- Deposition: (0.3, -2.8) with yaw = -π/2
- Mid-obstacle: (3.0, -1.1)

**Tests updated**: Test expectations updated to verify the new waypoints_file launch argument.

Closes #102.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->