### PR TITLE
feat: bound Nav2 recovery loops with custom behavior tree

### DIFF
--- a/src/lunabot_navigation/behavior_trees/navigate_to_pose_bounded_recovery.xml
+++ b/src/lunabot_navigation/behavior_trees/navigate_to_pose_bounded_recovery.xml
@@ -1,0 +1,36 @@
+<!--
+  Bounded-recovery variant of Nav2's navigate_to_pose_w_replanning_and_recovery.
+  Limits the outer RecoveryNode to 3 retries (was 6 in stock) so a stuck goal
+  aborts within ~30 s rather than consuming the entire mission budget.
+  Issue: https://github.com/KJdotIO/innex1-rover/issues/74
+-->
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="3" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <RateController hz="1.0">
+          <RecoveryNode number_of_retries="1" name="ComputePathToPose">
+            <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"/>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="{path}" controller_id="FollowPath"/>
+          <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
+        </RecoveryNode>
+      </PipelineSequence>
+      <ReactiveFallback name="RecoveryFallback">
+        <GoalUpdated/>
+        <RoundRobin name="RecoveryActions">
+          <Sequence name="ClearingActions">
+            <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </Sequence>
+          <Spin spin_dist="1.57"/>
+          <Wait wait_duration="5"/>
+          <BackUp backup_dist="0.30" backup_speed="0.05"/>
+        </RoundRobin>
+      </ReactiveFallback>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -5,7 +5,7 @@
 
 bt_navigator:
   ros__parameters:
-    default_bt_xml_filename: "/opt/ros/humble/share/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_and_recovery.xml"
+    default_bt_xml_filename: "$(find-pkg-share lunabot_navigation)/behavior_trees/navigate_to_pose_bounded_recovery.xml"
 
 controller_server:
   ros__parameters:

--- a/src/lunabot_navigation/test/test_nav2_params_baseline.py
+++ b/src/lunabot_navigation/test/test_nav2_params_baseline.py
@@ -1,16 +1,31 @@
-"""Regression tests for the June Nav2 behaviour tree baseline."""
+"""Regression tests for the Nav2 behaviour tree baseline."""
 
 from pathlib import Path
 
 import yaml
 
 
-def test_june_baseline_uses_stock_nav2_bt():
+def test_uses_bounded_recovery_bt():
     nav2_params_path = (
         Path(__file__).resolve().parents[1] / "config" / "nav2_params.yaml"
     )
     config = yaml.safe_load(nav2_params_path.read_text())
     bt_xml = config["bt_navigator"]["ros__parameters"]["default_bt_xml_filename"]
 
-    assert "nav2_bt_navigator" in bt_xml
-    assert "navigate_to_pose_w_replanning_and_recovery" in bt_xml
+    assert "navigate_to_pose_bounded_recovery" in bt_xml
+
+
+def test_bounded_recovery_bt_exists():
+    bt_path = (
+        Path(__file__).resolve().parents[1]
+        / "behavior_trees"
+        / "navigate_to_pose_bounded_recovery.xml"
+    )
+    assert bt_path.exists(), f"Expected BT XML at {bt_path}"
+
+    content = bt_path.read_text()
+    assert 'number_of_retries="3"' in content, (
+        "Outer RecoveryNode should limit retries to 3"
+    )
+    assert "ComputePathToPose" in content
+    assert "FollowPath" in content


### PR DESCRIPTION
## Summary
- Adds `navigate_to_pose_bounded_recovery.xml` -- identical to stock Nav2 BT but with outer RecoveryNode limited to 3 retries (was 6)
- Updates `nav2_params.yaml` to use the new BT via `$(find-pkg-share lunabot_navigation)`
- Updates regression test to verify bounded recovery BT is configured and valid

## Test plan
- [ ] CI passes
- [ ] On VM: send a goal to an unreachable location, verify the rover aborts after ~3 recovery attempts instead of looping indefinitely

Closes #74