### PR TITLE
feat: add disable_nav_gate launch argument for sim bypass

### DIFF
--- a/src/lunabot_bringup/launch/navigation.launch.py
+++ b/src/lunabot_bringup/launch/navigation.launch.py
@@ -175,6 +175,7 @@ def generate_launch_description():
     preflight_config = LaunchConfiguration("preflight_config")
     preflight_lidar_debug_config = LaunchConfiguration("preflight_lidar_debug_config")
     joy_device_id = LaunchConfiguration("joy_device_id")
+    disable_nav_gate = LaunchConfiguration("disable_nav_gate")
     localiser_cmd_vel_topic = _select_localiser_cmd_vel_topic(enable_teleop)
 
     localisation_launch = IncludeLaunchDescription(
@@ -208,6 +209,8 @@ def generate_launch_description():
                     [
                         "(",
                         _is_falsey(lidar_costmap_phase),
+                        ") and (",
+                        _is_falsey(disable_nav_gate),
                         ")",
                     ]
                 ),
@@ -404,6 +407,15 @@ def generate_launch_description():
                 "joy_device_id",
                 default_value="0",
                 description=("SDL device index for the connected controller."),
+            ),
+            DeclareLaunchArgument(
+                "disable_nav_gate",
+                default_value="false",
+                description=(
+                    "Bypass the navigate_to_pose_gate readiness check. "
+                    "Set to true for simulation or when AprilTag localisation "
+                    "is unavailable."
+                ),
             ),
             localisation_launch,
             crater_detection,


### PR DESCRIPTION
## Summary
- Adds `disable_nav_gate` launch argument (default: false) to `navigation.launch.py`
- When set to true, the navigate_to_pose_gate passes all goals without requiring localisation readiness
- Cleaner than the existing workaround of setting `lidar_costmap_phase=true` to bypass the gate in sim

## Test plan
- [ ] CI passes
- [ ] On VM: `ros2 launch lunabot_bringup navigation.launch.py disable_nav_gate:=true` allows goals without AprilTag localisation
- [ ] Default behavior (gate enabled) unchanged

Partially addresses #125