### PR TITLE
feat: add rear depth camera to URDF and simulation bridge

### DIFF
--- a/src/lunabot_description/urdf/lunabot.urdf.xacro
+++ b/src/lunabot_description/urdf/lunabot.urdf.xacro
@@ -124,4 +124,60 @@
       <gz_frame_id>camera_front_link</gz_frame_id>
       </sensor>
     </gazebo>
+
+    <!-- Rear depth camera — mirrors the front camera for reverse-drive obstacle
+         detection in the shuttle drive strategy. -->
+    <link name="camera_rear_link">
+    <visual>
+      <geometry>
+        <cylinder length="0.05" radius="0.03" />
+      </geometry>
+      <material name="dark_grey">
+        <color rgba="0.2 0.2 0.2 1.0" />
+      </material>
+    </visual>
+    <collision>
+      <geometry>
+        <cylinder length="0.05" radius="0.03" />
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="0.1" />
+      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001" />
+    </inertial>
+  </link>
+
+    <joint name="camera_rear_joint" type="fixed">
+      <parent link="base_link" />
+      <child link="camera_rear_link" />
+      <origin xyz="-0.12 0.0 0.05" rpy="0 0.3 ${pi}" />
+    </joint>
+
+    <link name="camera_rear_optical_frame" />
+
+    <joint name="camera_rear_optical_joint" type="fixed">
+      <parent link="camera_rear_link" />
+      <child link="camera_rear_optical_frame" />
+      <origin xyz="0 0 0" rpy="-${pi/2} 0.0 -${pi/2}" />
+    </joint>
+
+    <gazebo reference="camera_rear_link">
+      <sensor name="camera_rear" type="rgbd_camera">
+      <camera>
+        <horizontal_fov>1.57</horizontal_fov>
+        <image>
+          <width>640</width>
+          <height>480</height>
+        </image>
+        <clip>
+          <near>0.1</near>
+          <far>10</far>
+        </clip>
+      </camera>
+      <always_on>1</always_on>
+      <update_rate>15</update_rate>
+      <topic>camera_rear</topic>
+      <gz_frame_id>camera_rear_link</gz_frame_id>
+      </sensor>
+    </gazebo>
 </robot>

--- a/src/lunabot_simulation/launch/moon_yard.launch.py
+++ b/src/lunabot_simulation/launch/moon_yard.launch.py
@@ -179,6 +179,28 @@ def generate_launch_description():
         output="screen",
     )
 
+    camera_rear_bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        name="camera_rear_bridge",
+        arguments=[
+            "/camera_rear/camera_info@sensor_msgs/msg/CameraInfo[ignition.msgs.CameraInfo",
+            "/camera_rear/image@sensor_msgs/msg/Image[ignition.msgs.Image",
+            "/camera_rear/depth_image@sensor_msgs/msg/Image[ignition.msgs.Image",
+        ],
+        output="screen",
+    )
+
+    camera_rear_points_bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        name="camera_rear_points_bridge",
+        arguments=[
+            "/camera_rear/points@sensor_msgs/msg/PointCloud2[ignition.msgs.PointCloudPacked",
+        ],
+        output="screen",
+    )
+
     return LaunchDescription(
         [
             DeclareLaunchArgument(
@@ -196,5 +218,7 @@ def generate_launch_description():
             robot_bridge,
             camera_bridge,
             camera_points_bridge,
+            camera_rear_bridge,
+            camera_rear_points_bridge,
         ]
     )


### PR DESCRIPTION
## Summary
- Adds `camera_rear_link`, `camera_rear_joint`, and `camera_rear_optical_frame` to the robot URDF, mirroring the front depth camera at the back of the rover
- Adds Gazebo RGBD sensor `camera_rear` on the rear link
- Adds `camera_rear_bridge` and `camera_rear_points_bridge` nodes in `moon_yard.launch.py`

Foundation for the shuttle drive strategy where the rover faces the excavation zone at all times and reverses to the deposition zone.

Closes #238

## Test plan
- [ ] `colcon build` passes
- [ ] `ros2 topic list` shows `/camera_rear/camera_info`, `/camera_rear/image`, `/camera_rear/depth_image`, `/camera_rear/points`
- [ ] Rear point cloud visible in RViz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a rear-facing depth camera to the rover's URDF description and simulation bridge, enabling obstacle detection behind the rover for safe reverse driving as part of the shuttle drive strategy.

### Changes

**URDF Updates** (`lunabot.urdf.xacro`)
- Added rear camera link, joint, and optical frame to match the front depth camera design
- Positioned the camera at the rear of the rover for backward-facing obstacle detection
- Added Gazebo RGBD sensor configuration for the rear camera

**Launch Configuration** (`moon_yard.launch.py`)
- Added bridge nodes to expose rear camera topics to ROS:
  - Camera info, RGB image, and depth image topics
  - Point cloud topic for 3D obstacle perception

### Result

The rover now publishes the following rear camera topics during simulation:
- `/camera_rear/camera_info`
- `/camera_rear/image`
- `/camera_rear/depth_image`
- `/camera_rear/points`

This provides the foundation for shuttle drive strategy where the rover faces the excavation zone and reverses to the deposition zone with rear obstacle awareness.

**Closes issue #238**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->