### PR TITLE
feat: wire rear camera into Nav2 costmaps, collision monitor, enable reversing, and update waypoints

### DIFF
--- a/src/lunabot_bringup/config/arena_waypoints.yaml
+++ b/src/lunabot_bringup/config/arena_waypoints.yaml
@@ -24,7 +24,9 @@ mission_manager:
     waypoint_excavation_yaw: 0.0
 
     # Deposition zone target pose -- near the berm at the bottom of the
-    # start zone.  Yaw faces -Y (toward the berm).
+    # start zone.  Yaw faces +X (toward excavation) so the rover can
+    # reverse here without turning; the shuttle strategy keeps the rover
+    # facing one direction for the entire mission.
     waypoint_deposition_x: 0.3
     waypoint_deposition_y: -2.8
-    waypoint_deposition_yaw: -1.5708
+    waypoint_deposition_yaw: 0.0

--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -64,7 +64,7 @@ class MissionManager(Node):
         self.declare_parameter("waypoint_excavation_yaw", 0.0)
         self.declare_parameter("waypoint_deposition_x", 0.3)
         self.declare_parameter("waypoint_deposition_y", -2.8)
-        self.declare_parameter("waypoint_deposition_yaw", -1.5708)
+        self.declare_parameter("waypoint_deposition_yaw", 0.0)
         self.declare_parameter("nav_goal_timeout_s", 120.0)
 
         self._state: MissionState = MissionState.INITIALIZE_MISSION

--- a/src/lunabot_navigation/config/collision_monitor.yaml
+++ b/src/lunabot_navigation/config/collision_monitor.yaml
@@ -23,7 +23,7 @@ collision_monitor:
 
     PolygonStop:
       type: "polygon"
-      points: [0.30, 0.22, 0.30, -0.22, -0.20, -0.22, -0.20, 0.22]
+      points: [0.30, 0.22, 0.30, -0.22, -0.35, -0.22, -0.35, 0.22]
       action_type: "stop"
       max_points: 3
       visualize: true
@@ -32,7 +32,7 @@ collision_monitor:
 
     PolygonSlow:
       type: "polygon"
-      points: [0.50, 0.35, 0.50, -0.35, -0.25, -0.35, -0.25, 0.35]
+      points: [0.50, 0.35, 0.50, -0.35, -0.50, -0.35, -0.50, 0.35]
       action_type: "slowdown"
       max_points: 6
       slowdown_ratio: 0.3
@@ -40,11 +40,18 @@ collision_monitor:
       polygon_pub_topic: "polygon_slowdown"
       enabled: true
 
-    observation_sources: ["front_camera", "lidar"]
+    observation_sources: ["front_camera", "rear_camera", "lidar"]
 
     front_camera:
       type: "pointcloud"
       topic: "/camera_front/points"
+      min_height: 0.10
+      max_height: 0.60
+      enabled: true
+
+    rear_camera:
+      type: "pointcloud"
+      topic: "/camera_rear/points"
       min_height: 0.10
       max_height: 0.60
       enabled: true

--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -51,9 +51,20 @@ global_costmap:
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
-        observation_sources: camera_points
-        camera_points:
+        observation_sources: camera_front_points camera_rear_points
+        camera_front_points:
           topic: /camera_front/points
+          data_type: "PointCloud2"
+          min_obstacle_height: 0.15
+          max_obstacle_height: 0.8
+          clearing: true
+          marking: true
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+        camera_rear_points:
+          topic: /camera_rear/points
           data_type: "PointCloud2"
           min_obstacle_height: 0.15
           max_obstacle_height: 0.8
@@ -123,9 +134,20 @@ local_costmap:
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: true
-        observation_sources: camera_points
-        camera_points:
+        observation_sources: camera_front_points camera_rear_points
+        camera_front_points:
           topic: /camera_front/points
+          data_type: "PointCloud2"
+          min_obstacle_height: 0.15
+          max_obstacle_height: 0.8
+          clearing: true
+          marking: true
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+        camera_rear_points:
+          topic: /camera_rear/points
           data_type: "PointCloud2"
           min_obstacle_height: 0.15
           max_obstacle_height: 0.8

--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -16,6 +16,7 @@ controller_server:
       max_linear_vel: 0.3
       desired_linear_vel: 0.3
       max_angular_vel: 0.5
+      allow_reversing: true
       use_cost_regulated_linear_velocity_scaling: true
       cost_scaling_dist: 0.6
       cost_scaling_gain: 1.0

--- a/src/lunabot_navigation/test/test_obstacle_avoidance_config.py
+++ b/src/lunabot_navigation/test/test_obstacle_avoidance_config.py
@@ -66,23 +66,31 @@ class TestObstacleLayerConfig:
             if "obstacle_layer" in params:
                 self.layers.append((key, params["obstacle_layer"]))
 
-    def test_depth_camera_topic(self):
+    def test_front_depth_camera_topic(self):
         for costmap_key, layer in self.layers:
-            assert layer["camera_points"]["topic"] == "/camera_front/points", (
-                f"{costmap_key}: unexpected camera topic"
+            assert layer["camera_front_points"]["topic"] == "/camera_front/points", (
+                f"{costmap_key}: unexpected front camera topic"
+            )
+
+    def test_rear_depth_camera_topic(self):
+        for costmap_key, layer in self.layers:
+            assert layer["camera_rear_points"]["topic"] == "/camera_rear/points", (
+                f"{costmap_key}: unexpected rear camera topic"
             )
 
     def test_height_bounds_are_positive(self):
         for _key, layer in self.layers:
-            pts = layer["camera_points"]
-            assert pts["min_obstacle_height"] > 0.0
-            assert pts["max_obstacle_height"] > pts["min_obstacle_height"]
+            for source in ("camera_front_points", "camera_rear_points"):
+                pts = layer[source]
+                assert pts["min_obstacle_height"] > 0.0
+                assert pts["max_obstacle_height"] > pts["min_obstacle_height"]
 
     def test_marking_and_clearing_enabled(self):
         for _key, layer in self.layers:
-            pts = layer["camera_points"]
-            assert pts["marking"] is True
-            assert pts["clearing"] is True
+            for source in ("camera_front_points", "camera_rear_points"):
+                pts = layer[source]
+                assert pts["marking"] is True
+                assert pts["clearing"] is True
 
 
 class TestCraterLayerConfig:


### PR DESCRIPTION
## Summary
Stacked on #243 (rear camera URDF/sim). This PR completes the shuttle drive strategy:

1. **Costmaps** (#239): Adds `camera_rear_points` as observation source in both global and local costmap obstacle layers
2. **Collision monitor** (#240): Adds `rear_camera` source, extends stop polygon rear to -0.35 and slowdown to -0.50
3. **Controller** (#241): Enables `allow_reversing: true` on RegulatedPurePursuitController
4. **Waypoints** (#242): Changes deposition yaw from -π/2 to 0.0 so rover always faces +X

Closes #239, #240, #241, #242

## Test plan
- [ ] CI green
- [ ] VM test: rear camera topics publishing
- [ ] VM test: rover reverses to deposition instead of turning
- [ ] VM test: collision monitor stops rover when reversing toward obstacle