### PR TITLE
fix: switch to SmacPlannerHybrid with Reeds-Shepp for actual reverse driving

### DIFF
--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -27,7 +27,7 @@ planner_server:
     expected_planner_frequency: 1.0
     planner_plugins: ["GridBased"]
     GridBased:
-      plugin: "nav2_smac_planner::SmacPlannerHybrid"
+      plugin: "nav2_smac_planner/SmacPlannerHybrid"
       tolerance: 0.25
       allow_unknown: true
       max_iterations: 1000000

--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -17,6 +17,7 @@ controller_server:
       desired_linear_vel: 0.3
       max_angular_vel: 0.5
       allow_reversing: true
+      use_rotate_to_heading: false
       use_cost_regulated_linear_velocity_scaling: true
       cost_scaling_dist: 0.6
       cost_scaling_gain: 1.0
@@ -26,10 +27,34 @@ planner_server:
     expected_planner_frequency: 1.0
     planner_plugins: ["GridBased"]
     GridBased:
-      plugin: "nav2_navfn_planner/NavfnPlanner"
-      tolerance: 0.5
-      use_astar: true
+      plugin: "nav2_smac_planner::SmacPlannerHybrid"
+      tolerance: 0.25
       allow_unknown: true
+      max_iterations: 1000000
+      max_on_approach_iterations: 1000
+      max_planning_time: 5.0
+      motion_model_for_search: "REEDS_SHEPP"
+      angle_quantization_bins: 72
+      minimum_turning_radius: 0.40
+      reverse_penalty: 2.0
+      change_penalty: 0.0
+      non_straight_penalty: 1.20
+      cost_penalty: 2.0
+      retrospective_penalty: 0.015
+      analytic_expansion_ratio: 3.5
+      analytic_expansion_max_length: 3.0
+      lookup_table_size: 20.0
+      cache_obstacle_heuristic: false
+      downsample_costmap: false
+      downsampling_factor: 1
+      smooth_path: true
+      smoother:
+        max_iterations: 1000
+        w_smooth: 0.3
+        w_data: 0.2
+        tolerance: 1.0e-10
+        do_refinement: true
+        refinement_num: 2
 
 # -- COSTMAPS --
 


### PR DESCRIPTION
## Summary
- Replaces `NavfnPlanner` with `SmacPlannerHybrid` using `REEDS_SHEPP` motion model
- NavfnPlanner is 2D-only and can't generate reverse path segments — the rover was always turning 180° and driving forward
- SmacPlannerHybrid with Reeds-Shepp natively plans forward+reverse segments with orientation cusps that RPP can follow
- Sets `use_rotate_to_heading: false` which conflicts with `allow_reversing` (defaults to true, causing rotate-in-place instead of reversing)

Refs #241

## Test plan
- [ ] CI green
- [ ] VM: rover actually reverses when given a behind goal (no 180° turn)
- [ ] VM: forward driving still works normally
- [ ] VM: full shuttle cycle with visible reversing in RViz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Enables actual reverse driving by switching to SmacPlannerHybrid with Reeds-Shepp motion model

### Problem
The rover was unable to drive in reverse. When given a goal behind its current position, it would perform a 180° turn and drive forward instead of reversing. This was due to the use of `NavfnPlanner`, which only supports 2D planning and cannot generate path segments with backward motion.

### Solution
Replaced `NavfnPlanner` with `SmacPlannerHybrid` using the `REEDS_SHEPP` motion model, which natively supports planning paths with both forward and reverse segments. This allows the path planner to generate optimal paths that include reversing when appropriate.

### Configuration Changes
- **Planner**: Changed from `nav2_navfn_planner/NavfnPlanner` to `nav2_smac_planner::SmacPlannerHybrid`
- **Motion Model**: Set to `REEDS_SHEPP` to enable forward/reverse planning with proper orientation cusps
- **Controller**: Set `use_rotate_to_heading: false` to prevent conflicts with the planner's `allow_reversing` behavior (which defaults to true); this resolves rotate-in-place behavior that was blocking actual reversing
- **Tolerance**: Reduced from 0.5 to 0.25 for more precise path following
- **Path Smoothing**: Enabled with configurable smoothing parameters for trajectory refinement

### Impact
The rover can now properly reverse when given goals behind its current position, improving shuttle-style operations and general maneuverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->