### PR TITLE
feat: define drivetrain ROS interfaces and telemetry contract

### DIFF
--- a/.github/contracts/interface_contracts.json
+++ b/.github/contracts/interface_contracts.json
@@ -46,6 +46,9 @@
     "/mission/autonomy_mode",
     "/mission/time_remaining_s",
     "/mission/cycle_count",
-    "/mission/last_failure_reason"
+    "/mission/last_failure_reason",
+    "/drivetrain/command",
+    "/drivetrain/telemetry",
+    "/drivetrain/status"
   ]
 }

--- a/src/lunabot_interfaces/CMakeLists.txt
+++ b/src/lunabot_interfaces/CMakeLists.txt
@@ -9,6 +9,9 @@ find_package(std_msgs REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/Excavate.action"
   "action/Deposit.action"
+  "msg/DrivetrainCommand.msg"
+  "msg/DrivetrainStatus.msg"
+  "msg/DrivetrainTelemetry.msg"
   "msg/ExcavationCommand.msg"
   "msg/ExcavationStatus.msg"
   "msg/ExcavationTelemetry.msg"

--- a/src/lunabot_interfaces/msg/DrivetrainCommand.msg
+++ b/src/lunabot_interfaces/msg/DrivetrainCommand.msg
@@ -1,0 +1,18 @@
+# Drivetrain hardware-facing command contract.
+# Sent by the drivetrain bridge to the motor controllers.
+# Per-wheel throttle values normalised to [-1.0, 1.0] where positive is
+# forward and negative is reverse.  The bridge maps these to Sabertooth
+# Packetized Serial bytes.
+#
+# A command with all throttles at zero is a STOP.  If no command is received
+# within the watchdog period the bridge must send a stop.
+
+uint8 COMMAND_DRIVE=0
+uint8 COMMAND_STOP=1
+uint8 COMMAND_CLEAR_FAULT=2
+
+uint8 command
+
+# Per-wheel throttle [FL, FR, RL, RR], range [-1.0, 1.0].
+# Ignored when command is COMMAND_STOP or COMMAND_CLEAR_FAULT.
+float32[4] wheel_throttle

--- a/src/lunabot_interfaces/msg/DrivetrainStatus.msg
+++ b/src/lunabot_interfaces/msg/DrivetrainStatus.msg
@@ -1,0 +1,25 @@
+# Drivetrain controller-facing status contract.
+# Published by the drivetrain bridge.  Consumed by the mission coordinator
+# and preflight checks to determine drivetrain readiness.
+
+std_msgs/Header header
+
+uint8 STATE_UNINITIALISED=0
+uint8 STATE_READY=1
+uint8 STATE_DRIVING=2
+uint8 STATE_STOPPING=3
+uint8 STATE_FAULT=4
+uint8 STATE_ESTOP=5
+
+uint16 FAULT_NONE=0
+uint16 FAULT_ESTOP=1
+uint16 FAULT_ENCODER_STALL=2
+uint16 FAULT_CONTROLLER_OFFLINE=3
+uint16 FAULT_OVERCURRENT=4
+uint16 FAULT_COMMAND_TIMEOUT=5
+
+uint8  state
+uint16 fault_code
+bool   estop_active
+bool   motion_inhibited
+bool[2] controller_online

--- a/src/lunabot_interfaces/msg/DrivetrainTelemetry.msg
+++ b/src/lunabot_interfaces/msg/DrivetrainTelemetry.msg
@@ -1,0 +1,26 @@
+# Drivetrain hardware-facing telemetry contract.
+# Published by the drivetrain bridge at the control loop rate.
+# All encoder-derived values are per-wheel, ordered [FL, FR, RL, RR].
+
+std_msgs/Header header
+
+# Encoder-derived feedback per wheel.
+float32[4] wheel_velocity_rps     # Wheel angular velocity (revolutions/sec)
+int32[4]   encoder_ticks           # Raw cumulative encoder tick count
+
+# Controller status per Sabertooth (index 0 = front pair, 1 = rear pair).
+bool[2] controller_online         # True if UART heartbeat received
+
+# Safety state (mirrors /safety/motion_inhibit for convenience).
+bool estop_active
+bool motion_inhibited
+
+# Fault information.
+uint16 fault_code
+
+uint16 FAULT_NONE=0
+uint16 FAULT_ESTOP=1
+uint16 FAULT_ENCODER_STALL=2
+uint16 FAULT_CONTROLLER_OFFLINE=3
+uint16 FAULT_OVERCURRENT=4
+uint16 FAULT_COMMAND_TIMEOUT=5


### PR DESCRIPTION
## Summary
Adds typed ROS 2 message definitions for the four-wheel skid-steer drivetrain:

- **DrivetrainCommand.msg**: Per-wheel throttle [-1.0, 1.0] with DRIVE/STOP/CLEAR_FAULT commands. Maps to Sabertooth 2x32 Packetized Serial.
- **DrivetrainTelemetry.msg**: Encoder ticks, wheel velocity (rps), controller online status, e-stop/inhibit state, and fault codes.
- **DrivetrainStatus.msg**: State machine (UNINITIALISED → READY → DRIVING → STOPPING → FAULT/ESTOP) for mission coordinator and preflight.

### Hardware context
- 4x GR-WM4-V4 brushed DC motors
- 2x Sabertooth 2x32 motor controllers (Packetized Serial via Jetson UART)
- Hall-sensor quadrature encoders (2 channels × 4 motors = 8 channels on Jetson GPIO)
- E-stop cuts main battery power domain only; compute domain stays live

Refs #186, #187, #197

## Test plan
- [ ] `colcon build --packages-select lunabot_interfaces` succeeds
- [ ] `ros2 interface show lunabot_interfaces/msg/DrivetrainCommand` works
- [ ] CI green