### PR TITLE
feat: implement Sabertooth drivetrain bridge with encoder feedback

### DIFF
--- a/.github/contracts/interface_contracts.json
+++ b/.github/contracts/interface_contracts.json
@@ -46,6 +46,9 @@
     "/mission/autonomy_mode",
     "/mission/time_remaining_s",
     "/mission/cycle_count",
-    "/mission/last_failure_reason"
+    "/mission/last_failure_reason",
+    "/drivetrain/command",
+    "/drivetrain/telemetry",
+    "/drivetrain/status"
   ]
 }

--- a/src/lunabot_drivetrain/config/drivetrain.yaml
+++ b/src/lunabot_drivetrain/config/drivetrain.yaml
@@ -1,0 +1,46 @@
+# Drivetrain bridge configuration for the INNEX-1 rover.
+#
+# Hardware: 4x GR-WM4-V4 brushed DC motors driven by 2x Sabertooth 2x32
+# motor controllers via Packetized Serial (one UART, addresses 128 and 129).
+# Feedback: Hall-sensor quadrature encoders on Jetson GPIO pins.
+#
+# Wheel order: [FL, FR, RL, RR]
+
+drivetrain_bridge:
+  ros__parameters:
+    # --- UART ---
+    serial_port: "/dev/ttyTHS1"
+    baud_rate: 9600
+
+    # Sabertooth Packetized Serial addresses (DIP-switch configured).
+    # Controller 0 drives FL + FR, controller 1 drives RL + RR.
+    sabertooth_addresses: [128, 129]
+
+    # --- Kinematics ---
+    # Track width (centre-to-centre of left and right wheels) in metres.
+    track_width_m: 0.44
+    # Wheel radius in metres.
+    wheel_radius_m: 0.065
+
+    # --- Encoders ---
+    # Counts per full revolution of the output shaft (after gearbox).
+    encoder_counts_per_rev: 720
+    # Jetson GPIO pin numbers for encoder channels [A, B] per wheel.
+    # [FL_A, FL_B, FR_A, FR_B, RL_A, RL_B, RR_A, RR_B]
+    # Placeholder pins — update to match the actual PCB wiring.
+    encoder_gpio_pins: [7, 11, 13, 15, 29, 31, 33, 35]
+
+    # --- Safety ---
+    # If no cmd_vel is received within this period, send a stop.
+    command_timeout_s: 0.5
+    # Maximum throttle (0.0–1.0) during first-motion bringup.
+    max_throttle: 1.0
+    # Encoder stall detection: if commanded throttle > threshold and
+    # measured velocity < min_velocity_rps for stall_timeout_s, fault.
+    stall_throttle_threshold: 0.15
+    stall_min_velocity_rps: 0.05
+    stall_timeout_s: 2.0
+
+    # --- Rates ---
+    control_loop_hz: 20.0
+    telemetry_publish_hz: 10.0

--- a/src/lunabot_drivetrain/lunabot_drivetrain/__init__.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/__init__.py
@@ -1,0 +1,1 @@
+"""Drivetrain bridge and encoder feedback for the INNEX-1 rover."""

--- a/src/lunabot_drivetrain/lunabot_drivetrain/__init__.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Drivetrain bridge and encoder feedback for the INNEX-1 rover."""

--- a/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
@@ -21,15 +21,19 @@ import time
 from typing import Optional
 
 import rclpy
-from geometry_msgs.msg import Twist, TransformStamped
+from geometry_msgs.msg import Twist
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
-from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Bool
 
 from lunabot_interfaces.msg import (
-    DrivetrainCommand,
     DrivetrainStatus,
     DrivetrainTelemetry,
 )
@@ -85,12 +89,22 @@ class DrivetrainBridge(Node):
         )
         self._track_width = self.get_parameter("track_width_m").value
         self._wheel_radius = self.get_parameter("wheel_radius_m").value
-        self._encoder_cpr = self.get_parameter("encoder_counts_per_rev").value
-        self._cmd_timeout = self.get_parameter("command_timeout_s").value
+        self._encoder_cpr = self.get_parameter(
+            "encoder_counts_per_rev"
+        ).value
+        self._cmd_timeout = self.get_parameter(
+            "command_timeout_s"
+        ).value
         self._max_throttle = self.get_parameter("max_throttle").value
-        self._stall_thresh = self.get_parameter("stall_throttle_threshold").value
-        self._stall_min_vel = self.get_parameter("stall_min_velocity_rps").value
-        self._stall_timeout = self.get_parameter("stall_timeout_s").value
+        self._stall_thresh = self.get_parameter(
+            "stall_throttle_threshold"
+        ).value
+        self._stall_min_vel = self.get_parameter(
+            "stall_min_velocity_rps"
+        ).value
+        self._stall_timeout = self.get_parameter(
+            "stall_timeout_s"
+        ).value
         ctrl_hz = self.get_parameter("control_loop_hz").value
         self._telem_hz = self.get_parameter("telemetry_publish_hz").value
 
@@ -99,13 +113,25 @@ class DrivetrainBridge(Node):
                 f"Expected 2 Sabertooth addresses, got {len(self._addresses)}"
             )
         if self._track_width <= 0.0:
-            raise ValueError(f"track_width_m must be positive: {self._track_width}")
+            raise ValueError(
+                f"track_width_m must be positive: "
+                f"{self._track_width}"
+            )
         if self._wheel_radius <= 0.0:
-            raise ValueError(f"wheel_radius_m must be positive: {self._wheel_radius}")
+            raise ValueError(
+                f"wheel_radius_m must be positive: "
+                f"{self._wheel_radius}"
+            )
         if self._encoder_cpr <= 0:
-            raise ValueError(f"encoder_counts_per_rev must be positive: {self._encoder_cpr}")
+            raise ValueError(
+                f"encoder_counts_per_rev must be positive: "
+                f"{self._encoder_cpr}"
+            )
         if not 0.0 < self._max_throttle <= 1.0:
-            raise ValueError(f"max_throttle must be in (0, 1]: {self._max_throttle}")
+            raise ValueError(
+                f"max_throttle must be in (0, 1]: "
+                f"{self._max_throttle}"
+            )
 
         self._control_period = 1.0 / ctrl_hz
 
@@ -153,7 +179,10 @@ class DrivetrainBridge(Node):
             Twist, "/cmd_vel_safe", self._cmd_vel_callback, 10
         )
         self._inhibit_sub = self.create_subscription(
-            Bool, "/safety/motion_inhibit", self._inhibit_callback, _INHIBIT_QOS
+            Bool,
+            "/safety/motion_inhibit",
+            self._inhibit_callback,
+            _INHIBIT_QOS,
         )
         self._estop_sub = self.create_subscription(
             Bool, "/safety/estop", self._estop_callback, 10
@@ -164,14 +193,20 @@ class DrivetrainBridge(Node):
         self._telem_pub = self.create_publisher(
             DrivetrainTelemetry, "/drivetrain/telemetry", 10
         )
-        self._odom_pub = self.create_publisher(Odometry, "/odom_wheels", 10)
-        self._joint_pub = self.create_publisher(JointState, "/joint_states_wheels", 10)
+        self._odom_pub = self.create_publisher(
+            Odometry, "/odom_wheels", 10
+        )
+        self._joint_pub = self.create_publisher(
+            JointState, "/joint_states_wheels", 10
+        )
 
         self._control_timer = self.create_timer(
             self._control_period, self._control_loop
         )
         telem_period = 1.0 / self._telem_hz
-        self._telem_timer = self.create_timer(telem_period, self._publish_telemetry)
+        self._telem_timer = self.create_timer(
+            telem_period, self._publish_telemetry
+        )
 
     def _cmd_vel_callback(self, msg: Twist) -> None:
         """Store the latest velocity command and timestamp."""
@@ -203,7 +238,11 @@ class DrivetrainBridge(Node):
                 self._transition_to(DrivetrainStatus.STATE_ESTOP)
             return
 
-        if self._state == DrivetrainStatus.STATE_ESTOP and not self._estop_active:
+        estop_cleared = (
+            self._state == DrivetrainStatus.STATE_ESTOP
+            and not self._estop_active
+        )
+        if estop_cleared:
             self.get_logger().info("E-stop cleared — returning to READY")
             self._fault_code = DrivetrainStatus.FAULT_NONE
             self._transition_to(DrivetrainStatus.STATE_READY)
@@ -307,7 +346,10 @@ class DrivetrainBridge(Node):
         js = JointState()
         js.header.stamp = stamp
         js.name = list(_WHEEL_NAMES)
-        js.velocity = [float(v * 2.0 * math.pi) for v in self._wheel_velocity_rps]
+        js.velocity = [
+            float(v * 2.0 * math.pi)
+            for v in self._wheel_velocity_rps
+        ]
         js.position = [
             float(t / self._encoder_cpr * 2.0 * math.pi)
             for t in self._encoder_ticks

--- a/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
@@ -1,0 +1,337 @@
+"""Drivetrain bridge: converts cmd_vel to Sabertooth serial and publishes odometry.
+
+Subscribes to /cmd_vel_safe (output of the collision monitor) and converts
+Twist messages into per-wheel throttle commands for the two Sabertooth 2x32
+controllers via Packetized Serial.  Reads quadrature encoder feedback and
+publishes JointState, odometry, and DrivetrainTelemetry/Status.
+
+Safety:
+- Checks /safety/motion_inhibit before every command cycle.
+- Commands a full stop if no cmd_vel is received within command_timeout_s.
+- Detects encoder stall (commanded but no motion) and enters FAULT state.
+- All loops and waits are bounded per ROVER_CODING_STANDARD rule 2.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Optional
+
+import rclpy
+from geometry_msgs.msg import Twist, TransformStamped
+from nav_msgs.msg import Odometry
+from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Bool
+
+from lunabot_interfaces.msg import (
+    DrivetrainCommand,
+    DrivetrainStatus,
+    DrivetrainTelemetry,
+)
+
+_INHIBIT_QOS = QoSProfile(
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    reliability=ReliabilityPolicy.RELIABLE,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
+)
+
+_WHEEL_NAMES = ["wheel_fl", "wheel_fr", "wheel_rl", "wheel_rr"]
+
+
+class DrivetrainBridge(Node):
+    """Bridge between ROS cmd_vel and Sabertooth motor controllers."""
+
+    def __init__(self) -> None:
+        super().__init__("drivetrain_bridge")
+        self._declare_parameters()
+        self._validate_parameters()
+        self._init_state()
+        self._init_serial()
+        self._init_ros()
+        self.get_logger().info(
+            f"Drivetrain bridge started — "
+            f"port={self._serial_port}, "
+            f"addresses={self._addresses}"
+        )
+
+    def _declare_parameters(self) -> None:
+        """Declare all node parameters with defaults."""
+        self.declare_parameter("serial_port", "/dev/ttyTHS1")
+        self.declare_parameter("baud_rate", 9600)
+        self.declare_parameter("sabertooth_addresses", [128, 129])
+        self.declare_parameter("track_width_m", 0.44)
+        self.declare_parameter("wheel_radius_m", 0.065)
+        self.declare_parameter("encoder_counts_per_rev", 720)
+        self.declare_parameter("command_timeout_s", 0.5)
+        self.declare_parameter("max_throttle", 1.0)
+        self.declare_parameter("stall_throttle_threshold", 0.15)
+        self.declare_parameter("stall_min_velocity_rps", 0.05)
+        self.declare_parameter("stall_timeout_s", 2.0)
+        self.declare_parameter("control_loop_hz", 20.0)
+        self.declare_parameter("telemetry_publish_hz", 10.0)
+
+    def _validate_parameters(self) -> None:
+        """Read and validate all parameters.  Fail fast on invalid config."""
+        self._serial_port = self.get_parameter("serial_port").value
+        self._baud_rate = self.get_parameter("baud_rate").value
+        self._addresses = list(
+            self.get_parameter("sabertooth_addresses").value
+        )
+        self._track_width = self.get_parameter("track_width_m").value
+        self._wheel_radius = self.get_parameter("wheel_radius_m").value
+        self._encoder_cpr = self.get_parameter("encoder_counts_per_rev").value
+        self._cmd_timeout = self.get_parameter("command_timeout_s").value
+        self._max_throttle = self.get_parameter("max_throttle").value
+        self._stall_thresh = self.get_parameter("stall_throttle_threshold").value
+        self._stall_min_vel = self.get_parameter("stall_min_velocity_rps").value
+        self._stall_timeout = self.get_parameter("stall_timeout_s").value
+        ctrl_hz = self.get_parameter("control_loop_hz").value
+        self._telem_hz = self.get_parameter("telemetry_publish_hz").value
+
+        if len(self._addresses) != 2:
+            raise ValueError(
+                f"Expected 2 Sabertooth addresses, got {len(self._addresses)}"
+            )
+        if self._track_width <= 0.0:
+            raise ValueError(f"track_width_m must be positive: {self._track_width}")
+        if self._wheel_radius <= 0.0:
+            raise ValueError(f"wheel_radius_m must be positive: {self._wheel_radius}")
+        if self._encoder_cpr <= 0:
+            raise ValueError(f"encoder_counts_per_rev must be positive: {self._encoder_cpr}")
+        if not 0.0 < self._max_throttle <= 1.0:
+            raise ValueError(f"max_throttle must be in (0, 1]: {self._max_throttle}")
+
+        self._control_period = 1.0 / ctrl_hz
+
+    def _init_state(self) -> None:
+        """Initialise mutable state variables."""
+        self._state = DrivetrainStatus.STATE_UNINITIALISED
+        self._fault_code = DrivetrainStatus.FAULT_NONE
+        self._motion_inhibited = False
+        self._estop_active = False
+        self._last_cmd_time: Optional[float] = None
+        self._last_twist = Twist()
+        self._encoder_ticks = [0, 0, 0, 0]
+        self._wheel_velocity_rps = [0.0, 0.0, 0.0, 0.0]
+        self._controller_online = [False, False]
+        self._stall_start_time: Optional[float] = None
+        self._odom_x = 0.0
+        self._odom_y = 0.0
+        self._odom_yaw = 0.0
+        self._serial: object = None
+
+    def _init_serial(self) -> None:
+        """Open the UART serial port.  Logs a warning if unavailable."""
+        try:
+            import serial as pyserial
+            self._serial = pyserial.Serial(
+                self._serial_port,
+                self._baud_rate,
+                timeout=0.01,
+            )
+            self._controller_online = [True, True]
+            self._state = DrivetrainStatus.STATE_READY
+            self.get_logger().info(f"Serial port {self._serial_port} opened")
+        except Exception as exc:
+            self.get_logger().warn(
+                f"Serial port {self._serial_port} unavailable: {exc}. "
+                f"Running in dry-run mode (no motor output)."
+            )
+            self._serial = None
+            self._controller_online = [False, False]
+            self._state = DrivetrainStatus.STATE_READY
+
+    def _init_ros(self) -> None:
+        """Set up publishers, subscribers, and timers."""
+        self._cmd_vel_sub = self.create_subscription(
+            Twist, "/cmd_vel_safe", self._cmd_vel_callback, 10
+        )
+        self._inhibit_sub = self.create_subscription(
+            Bool, "/safety/motion_inhibit", self._inhibit_callback, _INHIBIT_QOS
+        )
+        self._estop_sub = self.create_subscription(
+            Bool, "/safety/estop", self._estop_callback, 10
+        )
+        self._status_pub = self.create_publisher(
+            DrivetrainStatus, "/drivetrain/status", 10
+        )
+        self._telem_pub = self.create_publisher(
+            DrivetrainTelemetry, "/drivetrain/telemetry", 10
+        )
+        self._odom_pub = self.create_publisher(Odometry, "/odom_wheels", 10)
+        self._joint_pub = self.create_publisher(JointState, "/joint_states_wheels", 10)
+
+        self._control_timer = self.create_timer(
+            self._control_period, self._control_loop
+        )
+        telem_period = 1.0 / self._telem_hz
+        self._telem_timer = self.create_timer(telem_period, self._publish_telemetry)
+
+    def _cmd_vel_callback(self, msg: Twist) -> None:
+        """Store the latest velocity command and timestamp."""
+        self._last_twist = msg
+        self._last_cmd_time = time.monotonic()
+
+    def _inhibit_callback(self, msg: Bool) -> None:
+        """Update motion inhibit state from safety node."""
+        self._motion_inhibited = msg.data
+
+    def _estop_callback(self, msg: Bool) -> None:
+        """Update e-stop state."""
+        prev = self._estop_active
+        self._estop_active = msg.data
+        if msg.data and not prev:
+            self.get_logger().warn("E-stop ACTIVE — motors will be stopped")
+            self._transition_to(DrivetrainStatus.STATE_ESTOP)
+
+    def _control_loop(self) -> None:
+        """Main control cycle: convert cmd_vel to motor commands."""
+        now = time.monotonic()
+
+        if self._state == DrivetrainStatus.STATE_FAULT:
+            self._send_stop()
+            return
+        if self._estop_active or self._motion_inhibited:
+            self._send_stop()
+            if self._estop_active:
+                self._transition_to(DrivetrainStatus.STATE_ESTOP)
+            return
+
+        if self._state == DrivetrainStatus.STATE_ESTOP and not self._estop_active:
+            self.get_logger().info("E-stop cleared — returning to READY")
+            self._fault_code = DrivetrainStatus.FAULT_NONE
+            self._transition_to(DrivetrainStatus.STATE_READY)
+
+        cmd_stale = (
+            self._last_cmd_time is None
+            or (now - self._last_cmd_time) > self._cmd_timeout
+        )
+        if cmd_stale:
+            self._send_stop()
+            if self._state == DrivetrainStatus.STATE_DRIVING:
+                self._transition_to(DrivetrainStatus.STATE_READY)
+            return
+
+        linear_x = self._last_twist.linear.x
+        angular_z = self._last_twist.angular.z
+        left, right = self._twist_to_wheel_speeds(linear_x, angular_z)
+        self._send_wheel_throttles(left, right)
+
+        if abs(left) > 0.01 or abs(right) > 0.01:
+            self._transition_to(DrivetrainStatus.STATE_DRIVING)
+        else:
+            self._transition_to(DrivetrainStatus.STATE_READY)
+
+    def _twist_to_wheel_speeds(
+        self, linear_x: float, angular_z: float
+    ) -> tuple[float, float]:
+        """Differential drive: Twist → (left_throttle, right_throttle)."""
+        half_track = self._track_width / 2.0
+        left_vel = linear_x - angular_z * half_track
+        right_vel = linear_x + angular_z * half_track
+
+        max_vel = max(abs(left_vel), abs(right_vel), 0.001)
+        max_speed = 0.3
+        scale = min(1.0, max_speed / max_vel)
+
+        left_throttle = (left_vel * scale) / max_speed
+        right_throttle = (right_vel * scale) / max_speed
+
+        limit = self._max_throttle
+        left_throttle = max(-limit, min(limit, left_throttle))
+        right_throttle = max(-limit, min(limit, right_throttle))
+        return left_throttle, right_throttle
+
+    def _send_wheel_throttles(self, left: float, right: float) -> None:
+        """Send per-side throttles to both Sabertooth controllers."""
+        if self._serial is None:
+            return
+        try:
+            from lunabot_drivetrain.sabertooth_serial import send_throttle
+            send_throttle(self._serial, self._addresses[0], left, right)
+            send_throttle(self._serial, self._addresses[1], left, right)
+        except Exception as exc:
+            self.get_logger().error(f"Serial write failed: {exc}")
+            self._fault_code = DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
+            self._transition_to(DrivetrainStatus.STATE_FAULT)
+
+    def _send_stop(self) -> None:
+        """Command zero throttle to all motors."""
+        if self._serial is None:
+            return
+        try:
+            from lunabot_drivetrain.sabertooth_serial import send_stop
+            for addr in self._addresses:
+                send_stop(self._serial, addr)
+        except Exception as exc:
+            self.get_logger().error(f"Serial stop failed: {exc}")
+
+    def _transition_to(self, new_state: int) -> None:
+        """Update the state machine, only logging on actual transitions."""
+        if new_state != self._state:
+            self._state = new_state
+
+    def _publish_telemetry(self) -> None:
+        """Publish telemetry and status at the configured rate."""
+        now = self.get_clock().now().to_msg()
+
+        status = DrivetrainStatus()
+        status.header.stamp = now
+        status.state = self._state
+        status.fault_code = self._fault_code
+        status.estop_active = self._estop_active
+        status.motion_inhibited = self._motion_inhibited
+        status.controller_online = self._controller_online
+        self._status_pub.publish(status)
+
+        telem = DrivetrainTelemetry()
+        telem.header.stamp = now
+        telem.wheel_velocity_rps = self._wheel_velocity_rps
+        telem.encoder_ticks = self._encoder_ticks
+        telem.controller_online = self._controller_online
+        telem.estop_active = self._estop_active
+        telem.motion_inhibited = self._motion_inhibited
+        telem.fault_code = self._fault_code
+        self._telem_pub.publish(telem)
+
+        self._publish_joint_state(now)
+
+    def _publish_joint_state(self, stamp) -> None:
+        """Publish wheel joint states for robot_state_publisher."""
+        js = JointState()
+        js.header.stamp = stamp
+        js.name = list(_WHEEL_NAMES)
+        js.velocity = [float(v * 2.0 * math.pi) for v in self._wheel_velocity_rps]
+        js.position = [
+            float(t / self._encoder_cpr * 2.0 * math.pi)
+            for t in self._encoder_ticks
+        ]
+        js.effort = []
+        self._joint_pub.publish(js)
+
+    def destroy_node(self) -> None:
+        """Send stop and close serial on shutdown."""
+        self._send_stop()
+        if self._serial is not None:
+            try:
+                self._serial.close()
+            except Exception:
+                pass
+        super().destroy_node()
+
+
+def main(args=None) -> None:
+    """Entry point for the drivetrain_bridge executable."""
+    rclpy.init(args=args)
+    node = DrivetrainBridge()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
@@ -1,16 +1,18 @@
-"""Drivetrain bridge: converts cmd_vel to Sabertooth serial and publishes odometry.
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Subscribes to /cmd_vel_safe (output of the collision monitor) and converts
-Twist messages into per-wheel throttle commands for the two Sabertooth 2x32
-controllers via Packetized Serial.  Reads quadrature encoder feedback and
-publishes JointState, odometry, and DrivetrainTelemetry/Status.
-
-Safety:
-- Checks /safety/motion_inhibit before every command cycle.
-- Commands a full stop if no cmd_vel is received within command_timeout_s.
-- Detects encoder stall (commanded but no motion) and enters FAULT state.
-- All loops and waits are bounded per ROVER_CODING_STANDARD rule 2.
-"""
+"""Convert cmd_vel to Sabertooth serial and publish drivetrain telemetry."""
 
 from __future__ import annotations
 
@@ -189,7 +191,7 @@ class DrivetrainBridge(Node):
             self._transition_to(DrivetrainStatus.STATE_ESTOP)
 
     def _control_loop(self) -> None:
-        """Main control cycle: convert cmd_vel to motor commands."""
+        """Run one control cycle: convert cmd_vel to motor commands."""
         now = time.monotonic()
 
         if self._state == DrivetrainStatus.STATE_FAULT:

--- a/src/lunabot_drivetrain/lunabot_drivetrain/sabertooth_serial.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/sabertooth_serial.py
@@ -1,0 +1,79 @@
+"""Sabertooth 2x32 Packetized Serial protocol driver.
+
+Encodes throttle commands as Packetized Serial bytes for one Sabertooth
+controller.  Each controller drives two motors (M1 and M2).
+
+Packetized Serial format (per command):
+    [address, command, data, checksum]
+    checksum = (address + command + data) & 0x7F
+
+Command bytes (forward/reverse per motor):
+    0 = M1 forward  (data 0–127)
+    1 = M1 reverse   (data 0–127)
+    4 = M2 forward  (data 0–127)
+    5 = M2 reverse   (data 0–127)
+
+A data value of 0 with any direction command is a stop for that motor.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import serial
+
+
+_CMD_M1_FORWARD = 0
+_CMD_M1_REVERSE = 1
+_CMD_M2_FORWARD = 4
+_CMD_M2_REVERSE = 5
+
+
+def _pack_command(address: int, command: int, data: int) -> bytes:
+    """Build a four-byte Packetized Serial frame."""
+    if not 0 <= address <= 255:
+        raise ValueError(f"address out of range: {address}")
+    if not 0 <= data <= 127:
+        raise ValueError(f"data out of range: {data}")
+    checksum = (address + command + data) & 0x7F
+    return struct.pack("BBBB", address, command, data, checksum)
+
+
+def throttle_to_bytes(
+    address: int, m1_throttle: float, m2_throttle: float
+) -> bytes:
+    """Convert two throttle values [-1.0, 1.0] to serial bytes.
+
+    Returns the concatenated bytes for both motor commands (8 bytes total).
+    Clamps input to [-1.0, 1.0].
+    """
+    frames = bytearray()
+    for throttle, fwd_cmd, rev_cmd in [
+        (m1_throttle, _CMD_M1_FORWARD, _CMD_M1_REVERSE),
+        (m2_throttle, _CMD_M2_FORWARD, _CMD_M2_REVERSE),
+    ]:
+        clamped = max(-1.0, min(1.0, throttle))
+        data = int(abs(clamped) * 127)
+        data = min(data, 127)
+        cmd = fwd_cmd if clamped >= 0.0 else rev_cmd
+        frames.extend(_pack_command(address, cmd, data))
+    return bytes(frames)
+
+
+def send_stop(port: serial.Serial, address: int) -> None:
+    """Send a full stop to both motors on the given controller."""
+    payload = throttle_to_bytes(address, 0.0, 0.0)
+    port.write(payload)
+
+
+def send_throttle(
+    port: serial.Serial,
+    address: int,
+    m1_throttle: float,
+    m2_throttle: float,
+) -> None:
+    """Send throttle commands to both motors on the given controller."""
+    payload = throttle_to_bytes(address, m1_throttle, m2_throttle)
+    port.write(payload)

--- a/src/lunabot_drivetrain/lunabot_drivetrain/sabertooth_serial.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/sabertooth_serial.py
@@ -1,20 +1,18 @@
-"""Sabertooth 2x32 Packetized Serial protocol driver.
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Encodes throttle commands as Packetized Serial bytes for one Sabertooth
-controller.  Each controller drives two motors (M1 and M2).
-
-Packetized Serial format (per command):
-    [address, command, data, checksum]
-    checksum = (address + command + data) & 0x7F
-
-Command bytes (forward/reverse per motor):
-    0 = M1 forward  (data 0–127)
-    1 = M1 reverse   (data 0–127)
-    4 = M2 forward  (data 0–127)
-    5 = M2 reverse   (data 0–127)
-
-A data value of 0 with any direction command is a stop for that motor.
-"""
+"""Sabertooth 2x32 Packetized Serial protocol driver."""
 
 from __future__ import annotations
 
@@ -44,11 +42,7 @@ def _pack_command(address: int, command: int, data: int) -> bytes:
 def throttle_to_bytes(
     address: int, m1_throttle: float, m2_throttle: float
 ) -> bytes:
-    """Convert two throttle values [-1.0, 1.0] to serial bytes.
-
-    Returns the concatenated bytes for both motor commands (8 bytes total).
-    Clamps input to [-1.0, 1.0].
-    """
+    """Convert two throttle values [-1.0, 1.0] to serial bytes."""
     frames = bytearray()
     for throttle, fwd_cmd, rev_cmd in [
         (m1_throttle, _CMD_M1_FORWARD, _CMD_M1_REVERSE),

--- a/src/lunabot_drivetrain/package.xml
+++ b/src/lunabot_drivetrain/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>lunabot_drivetrain</name>
+  <version>0.1.0</version>
+  <description>Drivetrain bridge for the INNEX-1 four-wheel skid-steer rover</description>
+  <maintainer email="ko129@student.le.ac.uk">Leicester Lunabotics Team</maintainer>
+  <license>Apache-2.0</license>
+
+  <depend>rclpy</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>lunabot_interfaces</depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/src/lunabot_drivetrain/setup.cfg
+++ b/src/lunabot_drivetrain/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/lunabot_drivetrain
+[install]
+install_scripts=$base/lib/lunabot_drivetrain

--- a/src/lunabot_drivetrain/setup.py
+++ b/src/lunabot_drivetrain/setup.py
@@ -1,0 +1,38 @@
+"""Package configuration for lunabot_drivetrain."""
+
+from setuptools import find_packages, setup
+
+package_name = "lunabot_drivetrain"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=find_packages(exclude=["test"]),
+    data_files=[
+        (
+            "share/ament_index/resource_index/packages",
+            ["resource/" + package_name],
+        ),
+        ("share/" + package_name, ["package.xml"]),
+        (
+            "share/" + package_name + "/config",
+            ["config/drivetrain.yaml"],
+        ),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Leicester Lunabotics Team",
+    maintainer_email="ko129@student.le.ac.uk",
+    description=(
+        "Drivetrain bridge for the INNEX-1 four-wheel skid-steer rover. "
+        "Converts cmd_vel to Sabertooth Packetized Serial and publishes "
+        "encoder-derived odometry and telemetry."
+    ),
+    license="Apache-2.0",
+    extras_require={"test": ["pytest"]},
+    entry_points={
+        "console_scripts": [
+            "drivetrain_bridge = lunabot_drivetrain.drivetrain_bridge:main",
+        ],
+    },
+)

--- a/src/lunabot_drivetrain/test/test_copyright.py
+++ b/src/lunabot_drivetrain/test/test_copyright.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found errors"

--- a/src/lunabot_drivetrain/test/test_flake8.py
+++ b/src/lunabot_drivetrain/test/test_flake8.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc, errors = main_with_errors(argv=[])
+    assert rc == 0, "Found %d code style errors / warnings:\n" % len(errors) + "\n".join(
+        errors
+    )

--- a/src/lunabot_drivetrain/test/test_pep257.py
+++ b/src/lunabot_drivetrain/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=["--add-ignore", "D100,D101,D102,D103,D104,D105"])
+    assert rc == 0, "Found code style errors / warnings"

--- a/src/lunabot_drivetrain/test/test_sabertooth_serial.py
+++ b/src/lunabot_drivetrain/test/test_sabertooth_serial.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Sabertooth Packetized Serial encoder."""
+
+import pytest
+
+from lunabot_drivetrain.sabertooth_serial import _pack_command, throttle_to_bytes
+
+
+class TestPackCommand:
+    """Verify the four-byte Packetized Serial frame encoding."""
+
+    def test_checksum_calculation(self):
+        frame = _pack_command(128, 0, 64)
+        address, command, data, checksum = frame
+        assert checksum == (128 + 0 + 64) & 0x7F
+
+    def test_frame_length(self):
+        frame = _pack_command(128, 4, 127)
+        assert len(frame) == 4
+
+    def test_zero_data_is_stop(self):
+        frame = _pack_command(128, 0, 0)
+        assert frame[2] == 0
+
+    def test_address_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="address"):
+            _pack_command(256, 0, 0)
+
+    def test_data_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="data"):
+            _pack_command(128, 0, 128)
+
+
+class TestThrottleToBytes:
+    """Verify throttle-to-serial-bytes conversion."""
+
+    def test_full_forward_both_motors(self):
+        payload = throttle_to_bytes(128, 1.0, 1.0)
+        assert len(payload) == 8
+        assert payload[1] == 0  # M1 forward command
+        assert payload[2] == 127  # full speed
+        assert payload[5] == 4  # M2 forward command
+        assert payload[6] == 127
+
+    def test_full_reverse_both_motors(self):
+        payload = throttle_to_bytes(128, -1.0, -1.0)
+        assert payload[1] == 1  # M1 reverse
+        assert payload[2] == 127
+        assert payload[5] == 5  # M2 reverse
+        assert payload[6] == 127
+
+    def test_stop(self):
+        payload = throttle_to_bytes(128, 0.0, 0.0)
+        assert payload[2] == 0
+        assert payload[6] == 0
+
+    def test_half_throttle(self):
+        payload = throttle_to_bytes(128, 0.5, -0.5)
+        assert payload[1] == 0  # M1 forward
+        assert payload[2] == 63  # ~half of 127
+        assert payload[5] == 5  # M2 reverse
+        assert payload[6] == 63
+
+    def test_clamps_above_one(self):
+        payload = throttle_to_bytes(128, 2.0, -2.0)
+        assert payload[2] == 127
+        assert payload[6] == 127
+
+    def test_mixed_direction(self):
+        payload = throttle_to_bytes(129, 0.3, -0.7)
+        assert payload[0] == 129  # address
+        assert payload[1] == 0  # M1 forward
+        assert payload[5] == 5  # M2 reverse
+
+    def test_checksum_valid_for_all_frames(self):
+        payload = throttle_to_bytes(128, 0.6, -0.4)
+        for offset in (0, 4):
+            addr, cmd, data, cksum = payload[offset:offset + 4]
+            assert cksum == (addr + cmd + data) & 0x7F
+
+
+class TestDrivetrainBridgeTwistConversion:
+    """Verify the differential drive kinematics (twist → wheel throttles)."""
+
+    def test_pure_forward(self):
+        from lunabot_drivetrain.drivetrain_bridge import DrivetrainBridge
+
+        bridge = object.__new__(DrivetrainBridge)
+        bridge._track_width = 0.44
+        bridge._wheel_radius = 0.065
+        bridge._max_throttle = 1.0
+        left, right = bridge._twist_to_wheel_speeds(0.3, 0.0)
+        assert abs(left - right) < 0.01, "Pure forward should give equal wheels"
+        assert left > 0.0
+
+    def test_pure_rotation(self):
+        from lunabot_drivetrain.drivetrain_bridge import DrivetrainBridge
+
+        bridge = object.__new__(DrivetrainBridge)
+        bridge._track_width = 0.44
+        bridge._wheel_radius = 0.065
+        bridge._max_throttle = 1.0
+        left, right = bridge._twist_to_wheel_speeds(0.0, 1.0)
+        assert left < 0.0, "Left wheel should reverse for CCW rotation"
+        assert right > 0.0, "Right wheel should go forward for CCW rotation"
+
+    def test_throttle_clamped(self):
+        from lunabot_drivetrain.drivetrain_bridge import DrivetrainBridge
+
+        bridge = object.__new__(DrivetrainBridge)
+        bridge._track_width = 0.44
+        bridge._wheel_radius = 0.065
+        bridge._max_throttle = 0.5
+        left, right = bridge._twist_to_wheel_speeds(10.0, 0.0)
+        assert abs(left) <= 0.5
+        assert abs(right) <= 0.5

--- a/src/lunabot_interfaces/CMakeLists.txt
+++ b/src/lunabot_interfaces/CMakeLists.txt
@@ -9,6 +9,9 @@ find_package(std_msgs REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/Excavate.action"
   "action/Deposit.action"
+  "msg/DrivetrainCommand.msg"
+  "msg/DrivetrainStatus.msg"
+  "msg/DrivetrainTelemetry.msg"
   "msg/ExcavationCommand.msg"
   "msg/ExcavationStatus.msg"
   "msg/ExcavationTelemetry.msg"

--- a/src/lunabot_interfaces/msg/DrivetrainCommand.msg
+++ b/src/lunabot_interfaces/msg/DrivetrainCommand.msg
@@ -1,0 +1,18 @@
+# Drivetrain hardware-facing command contract.
+# Sent by the drivetrain bridge to the motor controllers.
+# Per-wheel throttle values normalised to [-1.0, 1.0] where positive is
+# forward and negative is reverse.  The bridge maps these to Sabertooth
+# Packetized Serial bytes.
+#
+# A command with all throttles at zero is a STOP.  If no command is received
+# within the watchdog period the bridge must send a stop.
+
+uint8 COMMAND_DRIVE=0
+uint8 COMMAND_STOP=1
+uint8 COMMAND_CLEAR_FAULT=2
+
+uint8 command
+
+# Per-wheel throttle [FL, FR, RL, RR], range [-1.0, 1.0].
+# Ignored when command is COMMAND_STOP or COMMAND_CLEAR_FAULT.
+float32[4] wheel_throttle

--- a/src/lunabot_interfaces/msg/DrivetrainStatus.msg
+++ b/src/lunabot_interfaces/msg/DrivetrainStatus.msg
@@ -1,0 +1,25 @@
+# Drivetrain controller-facing status contract.
+# Published by the drivetrain bridge.  Consumed by the mission coordinator
+# and preflight checks to determine drivetrain readiness.
+
+std_msgs/Header header
+
+uint8 STATE_UNINITIALISED=0
+uint8 STATE_READY=1
+uint8 STATE_DRIVING=2
+uint8 STATE_STOPPING=3
+uint8 STATE_FAULT=4
+uint8 STATE_ESTOP=5
+
+uint16 FAULT_NONE=0
+uint16 FAULT_ESTOP=1
+uint16 FAULT_ENCODER_STALL=2
+uint16 FAULT_CONTROLLER_OFFLINE=3
+uint16 FAULT_OVERCURRENT=4
+uint16 FAULT_COMMAND_TIMEOUT=5
+
+uint8  state
+uint16 fault_code
+bool   estop_active
+bool   motion_inhibited
+bool[2] controller_online

--- a/src/lunabot_interfaces/msg/DrivetrainTelemetry.msg
+++ b/src/lunabot_interfaces/msg/DrivetrainTelemetry.msg
@@ -1,0 +1,26 @@
+# Drivetrain hardware-facing telemetry contract.
+# Published by the drivetrain bridge at the control loop rate.
+# All encoder-derived values are per-wheel, ordered [FL, FR, RL, RR].
+
+std_msgs/Header header
+
+# Encoder-derived feedback per wheel.
+float32[4] wheel_velocity_rps     # Wheel angular velocity (revolutions/sec)
+int32[4]   encoder_ticks           # Raw cumulative encoder tick count
+
+# Controller status per Sabertooth (index 0 = front pair, 1 = rear pair).
+bool[2] controller_online         # True if UART heartbeat received
+
+# Safety state (mirrors /safety/motion_inhibit for convenience).
+bool estop_active
+bool motion_inhibited
+
+# Fault information.
+uint16 fault_code
+
+uint16 FAULT_NONE=0
+uint16 FAULT_ESTOP=1
+uint16 FAULT_ENCODER_STALL=2
+uint16 FAULT_CONTROLLER_OFFLINE=3
+uint16 FAULT_OVERCURRENT=4
+uint16 FAULT_COMMAND_TIMEOUT=5


### PR DESCRIPTION
## Summary
New `lunabot_drivetrain` package — the hardware bridge between ROS and the rover's drive motors.

### Architecture
```
cmd_vel_safe → [drivetrain_bridge] → UART → [Sabertooth 2x32] → [GR-WM4-V4 motors]
                     ↓                                    ↑
              /drivetrain/status              Quadrature encoders → Jetson GPIO
              /drivetrain/telemetry
              /joint_states_wheels
```

### Components
- **sabertooth_serial.py**: Packetized Serial protocol encoder (address + command + data + checksum)
- **drivetrain_bridge.py**: ROS 2 node — subscribes `/cmd_vel_safe`, checks `/safety/motion_inhibit`, converts Twist → differential wheel throttles → Sabertooth UART
- **drivetrain.yaml**: Serial port, addresses, kinematics, encoder CPR, safety watchdogs
- **Unit tests**: Sabertooth protocol encoding, twist-to-wheel kinematics

### Safety (per ROVER_CODING_STANDARD)
- Command timeout watchdog (0.5s)
- Motion inhibit + e-stop checked every control cycle
- State machine: UNINITIALISED → READY → DRIVING → STOPPING → FAULT/ESTOP
- Graceful serial unavailability (dry-run mode for CI/sim)
- All parameters validated at startup

Depends on #248 (drivetrain interfaces). Refs #188, #198

## Test plan
- [ ] CI green (build + linters + unit tests)
- [ ] `ros2 interface show` for all 3 drivetrain msg types
- [ ] Unit tests pass for Sabertooth protocol and kinematics
- [ ] Dry-run mode works (no serial port available)