### PR TITLE
feat: add velocity gate, encoder stall detection, and E-stop recovery

### DIFF
--- a/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
@@ -147,6 +147,7 @@ class DrivetrainBridge(Node):
         self._wheel_velocity_rps = [0.0, 0.0, 0.0, 0.0]
         self._controller_online = [False, False]
         self._stall_start_time: Optional[float] = None
+        self._estop_clear_time: Optional[float] = None
         self._odom_x = 0.0
         self._odom_y = 0.0
         self._odom_yaw = 0.0
@@ -243,9 +244,21 @@ class DrivetrainBridge(Node):
             and not self._estop_active
         )
         if estop_cleared:
-            self.get_logger().info("E-stop cleared — returning to READY")
-            self._fault_code = DrivetrainStatus.FAULT_NONE
-            self._transition_to(DrivetrainStatus.STATE_READY)
+            if self._estop_clear_time is None:
+                self._estop_clear_time = now
+                self.get_logger().info(
+                    "E-stop cleared — waiting 2s for "
+                    "Sabertooth re-init"
+                )
+            elif (now - self._estop_clear_time) >= 2.0:
+                self._estop_clear_time = None
+                self._fault_code = DrivetrainStatus.FAULT_NONE
+                self._transition_to(DrivetrainStatus.STATE_READY)
+                self.get_logger().info(
+                    "Sabertooth re-init complete — READY"
+                )
+            self._send_stop()
+            return
 
         cmd_stale = (
             self._last_cmd_time is None
@@ -264,8 +277,10 @@ class DrivetrainBridge(Node):
 
         if abs(left) > 0.01 or abs(right) > 0.01:
             self._transition_to(DrivetrainStatus.STATE_DRIVING)
+            self._check_encoder_stall(now, left, right)
         else:
             self._transition_to(DrivetrainStatus.STATE_READY)
+            self._stall_start_time = None
 
     def _twist_to_wheel_speeds(
         self, linear_x: float, angular_z: float
@@ -286,6 +301,37 @@ class DrivetrainBridge(Node):
         left_throttle = max(-limit, min(limit, left_throttle))
         right_throttle = max(-limit, min(limit, right_throttle))
         return left_throttle, right_throttle
+
+    def _check_encoder_stall(
+        self, now: float, left: float, right: float
+    ) -> None:
+        """Detect encoder stall: throttle applied but no wheel motion."""
+        max_throttle = max(abs(left), abs(right))
+        if max_throttle < self._stall_thresh:
+            self._stall_start_time = None
+            return
+
+        max_vel = max(
+            abs(v) for v in self._wheel_velocity_rps
+        )
+        if max_vel >= self._stall_min_vel:
+            self._stall_start_time = None
+            return
+
+        if self._stall_start_time is None:
+            self._stall_start_time = now
+            return
+
+        elapsed = now - self._stall_start_time
+        if elapsed >= self._stall_timeout:
+            self.get_logger().error(
+                f"Encoder stall detected: throttle={max_throttle:.2f}"
+                f" but velocity={max_vel:.3f} rps for {elapsed:.1f}s"
+            )
+            self._fault_code = (
+                DrivetrainStatus.FAULT_ENCODER_STALL
+            )
+            self._transition_to(DrivetrainStatus.STATE_FAULT)
 
     def _send_wheel_throttles(self, left: float, right: float) -> None:
         """Send per-side throttles to both Sabertooth controllers."""

--- a/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
@@ -52,6 +52,7 @@ class DrivetrainBridge(Node):
     """Bridge between ROS cmd_vel and Sabertooth motor controllers."""
 
     def __init__(self) -> None:
+        """Initialise serial, parameters, and ROS interfaces."""
         super().__init__("drivetrain_bridge")
         self._declare_parameters()
         self._validate_parameters()

--- a/src/lunabot_drivetrain/lunabot_drivetrain/velocity_gate.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/velocity_gate.py
@@ -38,12 +38,7 @@ _ZERO_TWIST = Twist()
 
 
 class VelocityGate(Node):
-    """Pass or zero cmd_vel based on drivetrain health.
-
-    Sits between the collision monitor output (/cmd_vel_safe) and the
-    drivetrain bridge input (/cmd_vel_gated).  Provides a second
-    layer of safety beyond the bridge's own inhibit checks.
-    """
+    """Pass or zero cmd_vel based on drivetrain health."""
 
     _ALLOWED_STATES = frozenset({
         DrivetrainStatus.STATE_READY,

--- a/src/lunabot_drivetrain/lunabot_drivetrain/velocity_gate.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/velocity_gate.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Zero cmd_vel when the drivetrain is faulted or motion is inhibited."""
+
+import rclpy
+from geometry_msgs.msg import Twist
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+from std_msgs.msg import Bool
+
+from lunabot_interfaces.msg import DrivetrainStatus
+
+_INHIBIT_QOS = QoSProfile(
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    reliability=ReliabilityPolicy.RELIABLE,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
+)
+
+_ZERO_TWIST = Twist()
+
+
+class VelocityGate(Node):
+    """Pass or zero cmd_vel based on drivetrain health.
+
+    Sits between the collision monitor output (/cmd_vel_safe) and the
+    drivetrain bridge input (/cmd_vel_gated).  Provides a second
+    layer of safety beyond the bridge's own inhibit checks.
+    """
+
+    _ALLOWED_STATES = frozenset({
+        DrivetrainStatus.STATE_READY,
+        DrivetrainStatus.STATE_DRIVING,
+    })
+
+    def __init__(self) -> None:
+        super().__init__("velocity_gate")
+        self._gate_open = False
+        self._motion_inhibited = False
+
+        self._cmd_sub = self.create_subscription(
+            Twist, "/cmd_vel_safe", self._cmd_callback, 10
+        )
+        self._status_sub = self.create_subscription(
+            DrivetrainStatus,
+            "/drivetrain/status",
+            self._status_callback,
+            10,
+        )
+        self._inhibit_sub = self.create_subscription(
+            Bool,
+            "/safety/motion_inhibit",
+            self._inhibit_callback,
+            _INHIBIT_QOS,
+        )
+        self._cmd_pub = self.create_publisher(
+            Twist, "/cmd_vel_gated", 10
+        )
+
+        self.get_logger().info("Velocity gate started (gate closed)")
+
+    def _status_callback(self, msg: DrivetrainStatus) -> None:
+        """Update gate based on drivetrain state."""
+        was_open = self._gate_open
+        self._gate_open = (
+            msg.state in self._ALLOWED_STATES
+            and not msg.estop_active
+            and not msg.motion_inhibited
+        )
+        if was_open and not self._gate_open:
+            self.get_logger().warn("Gate CLOSED — drivetrain unhealthy")
+            self._cmd_pub.publish(_ZERO_TWIST)
+        elif not was_open and self._gate_open:
+            self.get_logger().info("Gate OPEN — drivetrain healthy")
+
+    def _inhibit_callback(self, msg: Bool) -> None:
+        """Track motion inhibit independently."""
+        self._motion_inhibited = msg.data
+        if msg.data:
+            self._gate_open = False
+            self._cmd_pub.publish(_ZERO_TWIST)
+
+    def _cmd_callback(self, msg: Twist) -> None:
+        """Forward or zero the velocity command."""
+        if self._gate_open and not self._motion_inhibited:
+            self._cmd_pub.publish(msg)
+        else:
+            self._cmd_pub.publish(_ZERO_TWIST)
+
+
+def main(args=None) -> None:
+    """Entry point for the velocity_gate executable."""
+    rclpy.init(args=args)
+    node = VelocityGate()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/src/lunabot_drivetrain/lunabot_drivetrain/velocity_gate.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/velocity_gate.py
@@ -51,6 +51,7 @@ class VelocityGate(Node):
     })
 
     def __init__(self) -> None:
+        """Initialise subscriptions, publisher, and gate state."""
         super().__init__("velocity_gate")
         self._gate_open = False
         self._motion_inhibited = False

--- a/src/lunabot_drivetrain/setup.py
+++ b/src/lunabot_drivetrain/setup.py
@@ -33,6 +33,7 @@ setup(
     entry_points={
         "console_scripts": [
             "drivetrain_bridge = lunabot_drivetrain.drivetrain_bridge:main",
+            "velocity_gate = lunabot_drivetrain.velocity_gate:main",
         ],
     },
 )

--- a/src/lunabot_drivetrain/test/test_velocity_gate.py
+++ b/src/lunabot_drivetrain/test/test_velocity_gate.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the velocity gate logic."""
+
+from lunabot_drivetrain.velocity_gate import VelocityGate
+from lunabot_interfaces.msg import DrivetrainStatus
+
+
+class TestVelocityGateAllowedStates:
+    """Verify the allowed-state set for the gate."""
+
+    def test_ready_is_allowed(self):
+        assert DrivetrainStatus.STATE_READY in VelocityGate._ALLOWED_STATES
+
+    def test_driving_is_allowed(self):
+        assert DrivetrainStatus.STATE_DRIVING in VelocityGate._ALLOWED_STATES
+
+    def test_fault_is_not_allowed(self):
+        assert DrivetrainStatus.STATE_FAULT not in VelocityGate._ALLOWED_STATES
+
+    def test_estop_is_not_allowed(self):
+        assert DrivetrainStatus.STATE_ESTOP not in VelocityGate._ALLOWED_STATES
+
+    def test_uninitialised_is_not_allowed(self):
+        states = VelocityGate._ALLOWED_STATES
+        assert DrivetrainStatus.STATE_UNINITIALISED not in states
+
+
+class TestStallDetection:
+    """Verify encoder stall detection in the drivetrain bridge."""
+
+    def _make_bridge(self):
+        from unittest.mock import MagicMock
+
+        from lunabot_drivetrain.drivetrain_bridge import DrivetrainBridge
+        bridge = object.__new__(DrivetrainBridge)
+        bridge._stall_thresh = 0.15
+        bridge._stall_min_vel = 0.05
+        bridge._stall_timeout = 2.0
+        bridge._stall_start_time = None
+        bridge._wheel_velocity_rps = [0.0, 0.0, 0.0, 0.0]
+        bridge._fault_code = DrivetrainStatus.FAULT_NONE
+        bridge._state = DrivetrainStatus.STATE_DRIVING
+        bridge.get_logger = MagicMock()
+        return bridge
+
+    def test_no_stall_when_below_threshold(self):
+        bridge = self._make_bridge()
+        bridge._check_encoder_stall(0.0, 0.10, 0.10)
+        assert bridge._state == DrivetrainStatus.STATE_DRIVING
+
+    def test_no_stall_when_velocity_present(self):
+        bridge = self._make_bridge()
+        bridge._wheel_velocity_rps = [0.1, 0.1, 0.1, 0.1]
+        bridge._check_encoder_stall(0.0, 0.5, 0.5)
+        assert bridge._state == DrivetrainStatus.STATE_DRIVING
+
+    def test_stall_detected_after_timeout(self):
+        bridge = self._make_bridge()
+        bridge._check_encoder_stall(0.0, 0.5, 0.5)
+        assert bridge._stall_start_time == 0.0
+        bridge._check_encoder_stall(3.0, 0.5, 0.5)
+        assert bridge._state == DrivetrainStatus.STATE_FAULT
+        assert bridge._fault_code == (
+            DrivetrainStatus.FAULT_ENCODER_STALL
+        )
+
+    def test_stall_resets_when_velocity_returns(self):
+        bridge = self._make_bridge()
+        bridge._check_encoder_stall(0.0, 0.5, 0.5)
+        assert bridge._stall_start_time is not None
+        bridge._wheel_velocity_rps = [0.1, 0.1, 0.1, 0.1]
+        bridge._check_encoder_stall(1.0, 0.5, 0.5)
+        assert bridge._stall_start_time is None


### PR DESCRIPTION
## Summary
Safety hardening for the drivetrain subsystem:

- **Velocity gate node**: Defence-in-depth layer between collision monitor and drivetrain bridge. Zeros cmd_vel when drivetrain is FAULT/ESTOP or motion inhibited.
- **Encoder stall detection**: Detects when motors are commanded but encoders report no movement. Enters FAULT after configurable timeout (default 2s).
- **E-stop recovery delay**: 2-second hold-off after E-stop release to allow Sabertooth controllers to re-initialise after main battery power returns.

### E-stop behaviour (per CDR electrical design)
The E-stop cuts the 22.2V main battery domain (motors, actuators). The 14.8V compute domain (Jetson, LiDAR, cameras) stays powered. When released:
1. Sabertooth controllers re-initialise (~2s)
2. Bridge sends stop commands to confirm link
3. Bridge transitions back to READY

### Pipeline with velocity gate
```
Nav2 → smoother → collision_monitor (/cmd_vel_safe) → velocity_gate (/cmd_vel_gated) → drivetrain_bridge → UART → Sabertooth
```

Refs #189, #190

## Test plan
- [ ] CI green
- [ ] Unit tests: stall detection state machine, gate allowed-states
- [ ] VM: `ros2 run lunabot_drivetrain velocity_gate` starts cleanly