### PR TITLE
fix: add retry/safety attributes to mission manager test fixture

### DIFF
--- a/src/lunabot_bringup/test/test_mission_manager.py
+++ b/src/lunabot_bringup/test/test_mission_manager.py
@@ -31,6 +31,13 @@ def _make_manager(monkeypatch):
     manager._navigate_client = MagicMock()
     manager._excavate_client = MagicMock()
     manager._deposit_client = MagicMock()
+    manager._max_nav_retries = 2
+    manager._max_exc_retries = 1
+    manager._max_dep_retries = 1
+    manager._max_cycles = 10
+    manager._cycle_count = 0
+    manager._estop_active = False
+    manager._motion_inhibited = False
     return manager
 
 


### PR DESCRIPTION
## Summary
The squash merge of #252 dropped the test fixture update. This adds the new attributes (retry counts, cycle limits, safety flags) to the `_make_manager` test helper.

## Test plan
- [ ] CI green (all 74 bringup tests pass)