### PR TITLE
fix: resolve ruff lint errors blocking main CI

### DIFF
--- a/src/lunabot_control/lunabot_control/deposition_bridge.py
+++ b/src/lunabot_control/lunabot_control/deposition_bridge.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Optional
+from typing import Any
 
 import rclpy
 from rclpy.action import ActionServer, CancelResponse, GoalResponse
@@ -211,7 +211,7 @@ class DepositionBridge(Node):
         if msg.data:
             self._all_stop()
 
-    def _goal_cb(self, goal_request) -> GoalResponse:
+    def _goal_cb(self, _goal_request) -> GoalResponse:
         """Accept goals only when safe."""
         if self._estop_active or self._motion_inhibited:
             self.get_logger().warn(
@@ -252,7 +252,7 @@ class DepositionBridge(Node):
         GPIO.output(dir_pin, direction)
         pwm_obj.ChangeDutyCycle(duty)
 
-    def _check_safety(self) -> Optional[str]:
+    def _check_safety(self) -> str | None:
         """Return a failure reason if unsafe, else None."""
         if self._estop_active:
             return "E-stop active during deposition"
@@ -268,7 +268,7 @@ class DepositionBridge(Node):
         door_open: bool,
         bed_raised: bool,
         start_time: float,
-    ) -> Optional[Deposit.Result]:
+    ) -> Deposit.Result | None:
         """Wait bounded duration, publishing feedback."""
         phase_start = time.monotonic()
         deadline = phase_start + min(


### PR DESCRIPTION
## Summary
- Prefix unused `goal_request` argument with underscore (ARG002)
- Replace `Optional[X]` with `X | None` (UP007 x2) — `from __future__ import annotations` is already active
- Remove unused `Optional` import

Fixes the 3 ruff errors causing `main` CI to fail since PR #254.

## Test plan
- [ ] CI preflight passes (ruff check clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Resolves three ruff lint errors that were blocking the main CI pipeline, introduced in PR #254.

## Changes

**File: `deposition_bridge.py`**
- Fixed ARG002 error by prefixing the unused callback parameter `goal_request` with an underscore in `_goal_cb`
- Fixed UP007 errors by replacing `Optional[X]` type annotations with PEP 604 union syntax (`X | None`)
- Removed the now-unused `Optional` import from `typing`

The changes are limited to type annotations and parameter naming; no runtime logic is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->