### PR TITLE
docs: refresh README and add missing package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,15 +146,18 @@ pkill -9 -f "gz sim"
 
 ```text
 src/
-├── external/                # Vendored third-party packages
-├── lunabot_bringup/         # Integrated launch entrypoints
-├── lunabot_control/         # Motion/material action servers
-├── lunabot_description/     # Robot model and meshes
-├── lunabot_interfaces/      # Shared ROS action/message contracts
-├── lunabot_localisation/    # EKF + global correction path
-├── lunabot_navigation/      # Nav2 config + mission BT assets
-├── lunabot_perception/      # Reserved shell for future perception nodes
-├── lunabot_simulation/      # Gazebo world/bridge launch
+├── external/                # Vendored third-party packages (Leo Rover)
+├── lunabot_bringup/         # Top-level launch files and mission manager
+├── lunabot_control/         # Deposition bridge (Cytron linear actuators)
+├── lunabot_description/     # URDF/xacro robot model and sensor frames
+├── lunabot_drivetrain/      # Sabertooth motor bridge, velocity gate, stall detection
+├── lunabot_excavation/      # Excavation action server
+├── lunabot_interfaces/      # Custom ROS messages and actions
+├── lunabot_localisation/    # EKF + RTAB-Map SLAM + AprilTag localisation
+├── lunabot_navigation/      # Nav2 config, costmaps, collision monitor
+├── lunabot_perception/      # Crater and hazard detection (scaffolding)
+├── lunabot_safety/          # Safety node scaffolding
+├── lunabot_simulation/      # Gazebo Fortress worlds and ros_gz bridges
 └── lunabot_teleop/          # Manual control
 ```
 

--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -37,6 +37,28 @@ This launch path only starts the supervisor node itself. Navigation, excavation,
 and deposition servers remain in their existing bringup paths and are not
 implicitly started here.
 
+### Bounded retries and cycle limits
+
+The mission manager wraps each action call in `_retry_action` with configurable
+retry counts:
+
+| Parameter | Default | Meaning |
+|-----------|---------|---------|
+| `max_nav_retries` | 2 | Extra attempts for each navigation goal |
+| `max_excavation_retries` | 1 | Extra attempts for excavation |
+| `max_deposition_retries` | 1 | Extra attempts for deposition |
+| `max_shuttle_cycles` | 10 | Total excavate→deposit round-trips before halt |
+
+If all retries are exhausted the manager transitions to a terminal failure state
+rather than looping indefinitely.
+
+### Safety gating
+
+The mission manager subscribes to `/safety/estop` and `/safety/motion_inhibit`
+(transient-local QoS). Before every action attempt, `_is_safe()` checks both
+signals — if either is active the attempt is short-circuited with a safety-stop
+failure, and no action goal is sent.
+
 ## Mission Dry Run
 
 Use the dry-run launch when you want one bounded operator-facing regression pass in sim:

--- a/src/lunabot_control/README.md
+++ b/src/lunabot_control/README.md
@@ -1,0 +1,60 @@
+# lunabot_control
+
+Deposition hardware bridge and material-handling action servers for the
+INNEX-1 rover.
+
+## Hardware
+
+- **Actuators**: 4x linear actuators — 1 door (hopper gate) + 2 bed
+  (left/right tilt) + 1 spare.
+- **Controllers**: 2x Cytron MDD10A in sign-magnitude mode (PWM + DIR),
+  driven by Jetson GPIO.
+- **Pin numbering**: BOARD convention. Defaults in `config/deposition.yaml`.
+
+If Jetson GPIO is unavailable (e.g. running on a desktop) the bridge enters
+**dry-run mode**: action goals are accepted and the phase state machine runs,
+but no physical actuation occurs.
+
+## Nodes
+
+### `deposition_bridge`
+
+ROS 2 action server for the hopper dump sequence. Runs on a
+`MultiThreadedExecutor` to allow concurrent feedback publishing.
+
+**Action**: `/mission/deposit` (`lunabot_interfaces/action/Deposit`)
+
+Dump sequence phases:
+1. **OPENING** — extend door actuator for `door_open_duration_s`.
+2. **RAISING** — extend both bed actuators for `bed_raise_duration_s`.
+3. **DUMPING** — hold raised for `dump_hold_duration_s`.
+4. **CLOSING** — retract bed, then retract door.
+
+Each phase is bounded to `_MAX_PHASE_DURATION_S` (30 s). Safety is checked
+every feedback tick; if E-stop or motion inhibit activates mid-sequence, all
+actuators stop and the goal aborts with `REASON_ESTOP`.
+
+| Direction | Topic / Action | Type |
+|-----------|----------------|------|
+| Action | `/mission/deposit` | `lunabot_interfaces/action/Deposit` |
+| Subscribe | `/safety/motion_inhibit` | `std_msgs/Bool` (transient-local) |
+| Subscribe | `/safety/estop` | `std_msgs/Bool` |
+
+### `material_action_server` / `material_action_client`
+
+Stub nodes from the original material-handling scaffold. Not yet connected to
+real hardware.
+
+## Key files
+
+- `config/deposition.yaml`: GPIO pin mapping, PWM frequency, duty cycle, and
+  phase durations.
+- `launch/material_actions.launch.py`: launch wrapper for the action nodes.
+
+## Common failure modes
+
+- GPIO permission errors on Jetson (`sudo groupadd -f -r gpio && sudo usermod -aG gpio $USER`).
+- Phase durations too short — actuators don't fully extend/retract. Tune on
+  real hardware.
+- E-stop during dump leaves the bed partially raised; operator must manually
+  lower or re-run the sequence after clearing E-stop.

--- a/src/lunabot_description/README.md
+++ b/src/lunabot_description/README.md
@@ -1,0 +1,44 @@
+# lunabot_description
+
+URDF/xacro robot model for the INNEX-1 rover.
+
+## Overview
+
+The model extends the stock Leo Rover description (`leo_description`) with
+the sensor payloads used on the competition rover:
+
+- **Ouster LiDAR** (`ouster_link`) — mounted on top of the base, 32-beam
+  GPU LiDAR in simulation (1024 horizontal samples, 20 m range).
+- **Front depth camera** (`camera_front_link` / `camera_front_optical_frame`)
+  — 640 x 480 RGBD at 15 Hz, 90° FOV, tilted 0.3 rad downward.
+- **Rear depth camera** (`camera_rear_link` / `camera_rear_optical_frame`)
+  — mirrors the front camera, facing backward for reverse-drive obstacle
+  detection.
+
+Optical frames follow the REP-103 convention (Z forward, X right, Y down).
+
+## Key files
+
+- `urdf/lunabot.urdf.xacro`: the single xacro file. Includes Leo Rover base,
+  adds sensor links/joints, and defines Gazebo sensor plugins.
+
+## Usage
+
+The xacro is processed at launch time by `robot_state_publisher`. In the
+simulation launch (`lunabot_simulation`), it is loaded via:
+
+```python
+robot_description = xacro.process(
+    str(pkg_lunabot_description / "urdf" / "lunabot.urdf.xacro")
+)
+```
+
+## TF frames added
+
+| Frame | Parent | Purpose |
+|-------|--------|---------|
+| `ouster_link` | `base_link` | LiDAR origin |
+| `camera_front_link` | `base_link` | Front camera body |
+| `camera_front_optical_frame` | `camera_front_link` | Optical convention |
+| `camera_rear_link` | `base_link` | Rear camera body |
+| `camera_rear_optical_frame` | `camera_rear_link` | Optical convention |

--- a/src/lunabot_drivetrain/README.md
+++ b/src/lunabot_drivetrain/README.md
@@ -1,0 +1,72 @@
+# lunabot_drivetrain
+
+Drivetrain bridge for the INNEX-1 four-wheel skid-steer rover. Converts
+`cmd_vel` to Sabertooth Packetized Serial commands over UART and publishes
+encoder-derived odometry and telemetry.
+
+## Hardware
+
+- **Motors**: 4x GR-WM4-V4 brushed DC with Hall-sensor quadrature encoders.
+- **Controllers**: 2x Sabertooth 2x32 on a single UART (`/dev/ttyTHS1`,
+  9600 baud). DIP-switch addresses 128 (FL+FR) and 129 (RL+RR).
+- **Protocol**: Packetized Serial — 4-byte frames
+  `[address, command, data, checksum]`.
+
+If the serial port is unavailable at startup the bridge enters **dry-run
+mode**: no motor output, but all ROS interfaces remain active. This allows
+desktop testing without hardware.
+
+## Nodes
+
+### `drivetrain_bridge`
+
+Differential-drive kinematics: splits `Twist` into per-side throttles, sends
+them to both Sabertooth controllers, and publishes status/telemetry.
+
+| Direction | Topic | Type |
+|-----------|-------|------|
+| Subscribe | `/cmd_vel_safe` | `geometry_msgs/Twist` |
+| Subscribe | `/safety/motion_inhibit` | `std_msgs/Bool` (transient-local) |
+| Subscribe | `/safety/estop` | `std_msgs/Bool` |
+| Publish | `/drivetrain/status` | `lunabot_interfaces/DrivetrainStatus` |
+| Publish | `/drivetrain/telemetry` | `lunabot_interfaces/DrivetrainTelemetry` |
+| Publish | `/odom_wheels` | `nav_msgs/Odometry` |
+| Publish | `/joint_states_wheels` | `sensor_msgs/JointState` |
+
+State machine: `UNINITIALISED → READY ⇄ DRIVING → FAULT` and `ESTOP`.
+
+- **Stall detection**: if throttle > threshold but encoder velocity ≈ 0 for
+  `stall_timeout_s`, the bridge faults with `FAULT_ENCODER_STALL`.
+- **E-stop recovery**: after `/safety/estop` clears, the bridge waits 2 s for
+  the Sabertooth to reboot before transitioning back to READY.
+- **Command timeout**: if no `cmd_vel` arrives within `command_timeout_s`, motors
+  are stopped.
+
+### `velocity_gate`
+
+Safety filter between the navigation stack and the drivetrain. Forwards
+`/cmd_vel_safe` to `/cmd_vel_gated` only when the drivetrain is in a healthy
+state (READY or DRIVING, no E-stop, no motion inhibit). Otherwise publishes
+zero twist.
+
+| Direction | Topic | Type |
+|-----------|-------|------|
+| Subscribe | `/cmd_vel_safe` | `geometry_msgs/Twist` |
+| Subscribe | `/drivetrain/status` | `lunabot_interfaces/DrivetrainStatus` |
+| Subscribe | `/safety/motion_inhibit` | `std_msgs/Bool` (transient-local) |
+| Publish | `/cmd_vel_gated` | `geometry_msgs/Twist` |
+
+## Key files
+
+- `config/drivetrain.yaml`: all tuneable parameters (kinematics, encoder CPR,
+  stall thresholds, control/telemetry rates).
+- `lunabot_drivetrain/sabertooth_serial.py`: low-level Packetized Serial
+  framing and `send_throttle`/`send_stop` helpers.
+
+## Common failure modes
+
+- Serial port permission denied on Jetson (`sudo usermod -aG dialout $USER`).
+- Wrong Sabertooth DIP-switch address — bridge writes succeed but motors don't
+  respond.
+- Stall false-positives during bringup if encoder GPIO pins are not wired
+  (reduce `max_throttle` or raise `stall_throttle_threshold` for bench tests).

--- a/src/lunabot_interfaces/README.md
+++ b/src/lunabot_interfaces/README.md
@@ -151,6 +151,59 @@ them real and necessary:
 If a posture or lift axis exists, treat it as a separate actuator contract instead of hiding it
 inside the ladder-motor contract.
 
+## Drivetrain Contract
+
+Added in PR [#248](https://github.com/KJdotIO/innex1-rover/pull/248).
+
+### Hardware-Facing Topics
+
+- `/drivetrain/command` uses `lunabot_interfaces/msg/DrivetrainCommand`
+- `/drivetrain/status` uses `lunabot_interfaces/msg/DrivetrainStatus`
+- `/drivetrain/telemetry` uses `lunabot_interfaces/msg/DrivetrainTelemetry`
+
+### DrivetrainCommand
+
+Per-wheel throttle command sent by the bridge to motor controllers.
+
+- `COMMAND_DRIVE=0` — drive at the given `wheel_throttle[4]` values (FL, FR, RL, RR), range [-1.0, 1.0].
+- `COMMAND_STOP=1` — immediate stop (throttle values ignored).
+- `COMMAND_CLEAR_FAULT=2` — clear a latched fault (throttle values ignored).
+
+### DrivetrainStatus
+
+Controller-facing status published by the drivetrain bridge. Consumed by the
+mission coordinator, velocity gate, and preflight checks.
+
+State table:
+
+- `STATE_UNINITIALISED=0`
+- `STATE_READY=1`
+- `STATE_DRIVING=2`
+- `STATE_STOPPING=3`
+- `STATE_FAULT=4`
+- `STATE_ESTOP=5`
+
+Fault codes:
+
+- `FAULT_NONE=0`
+- `FAULT_ESTOP=1`
+- `FAULT_ENCODER_STALL=2`
+- `FAULT_CONTROLLER_OFFLINE=3`
+- `FAULT_OVERCURRENT=4`
+- `FAULT_COMMAND_TIMEOUT=5`
+
+Additional fields: `estop_active`, `motion_inhibited`, `controller_online[2]`.
+
+### DrivetrainTelemetry
+
+Published at the control loop rate. Per-wheel encoder feedback ordered
+[FL, FR, RL, RR]:
+
+- `wheel_velocity_rps` — angular velocity in revolutions/sec.
+- `encoder_ticks` — raw cumulative tick count.
+- `controller_online[2]` — true if UART heartbeat received per Sabertooth.
+- `estop_active`, `motion_inhibited`, `fault_code` — mirrored safety state.
+
 ## Minimum Hardware Signals for Bridge Nodes
 
 - `estop_active` (latched)

--- a/src/lunabot_safety/README.md
+++ b/src/lunabot_safety/README.md
@@ -1,0 +1,37 @@
+# lunabot_safety
+
+Scaffolding package for centralised safety logic on the INNEX-1 rover.
+
+## Current state
+
+This package contains a single node. The bulk of the rover's safety behaviour
+is currently distributed across other packages:
+
+| Safety function | Where it lives |
+|-----------------|----------------|
+| E-stop → motion inhibit bridge | `lunabot_safety` (`estop_node`) |
+| Velocity gating (zero cmd_vel on fault) | `lunabot_drivetrain` (`velocity_gate`) |
+| Drivetrain stall detection & E-stop recovery | `lunabot_drivetrain` (`drivetrain_bridge`) |
+| Deposition safety callbacks (E-stop + inhibit) | `lunabot_control` (`deposition_bridge`) |
+| Mission-level safety gating | `lunabot_bringup` (`mission_manager`) |
+
+## Nodes
+
+### `estop_node`
+
+Bridges the hardware E-stop signal to a latched motion-inhibit topic.
+
+| Direction | Topic | Type | QoS |
+|-----------|-------|------|-----|
+| Subscribe | `/safety/estop` | `std_msgs/Bool` | default (reliable, volatile) |
+| Publish | `/safety/motion_inhibit` | `std_msgs/Bool` | reliable, transient-local |
+
+Transient-local durability ensures that nodes joining after an E-stop event
+(e.g. a motor controller that restarts) immediately receive the current
+inhibit state rather than waiting for the next event.
+
+## Safety topic convention
+
+All safety-aware nodes subscribe to `/safety/estop` and/or
+`/safety/motion_inhibit`. The inhibit topic uses `TRANSIENT_LOCAL` QoS
+throughout the stack so late joiners get the latest value.

--- a/src/lunabot_simulation/README.md
+++ b/src/lunabot_simulation/README.md
@@ -1,0 +1,61 @@
+# lunabot_simulation
+
+Gazebo Fortress simulation environment for the INNEX-1 rover, matching the
+UK Lunabotics arena (7.9 m x 4.4 m).
+
+## Worlds
+
+| World file | Description |
+|------------|-------------|
+| `worlds/moon_yard.sdf` | Flat regolith surface with scattered rocks. |
+| `worlds/moon_yard_craters.sdf` | Terrain with crater features for rougher traversal testing. |
+
+Both worlds include arena boundary walls and an AprilTag beacon for
+start-zone localisation.
+
+## Launch
+
+```bash
+# Default flat world
+ros2 launch lunabot_simulation moon_yard.launch.py
+
+# Cratered variant
+ros2 launch lunabot_simulation moon_yard.launch.py world:=moon_yard_craters
+```
+
+The launch file processes the `lunabot_description` xacro, starts
+`robot_state_publisher`, spawns the rover via `ros_gz_sim`, and sets up
+`ros_gz_bridge` nodes for the following topics:
+
+### Bridged topics
+
+| Gazebo topic | ROS 2 topic | Type |
+|--------------|-------------|------|
+| `cmd_vel` | `/cmd_vel_safe` | `geometry_msgs/Twist` |
+| `odom` | `/odom` | `nav_msgs/Odometry` |
+| `imu/data_raw` | `/imu/data_raw` | `sensor_msgs/Imu` |
+| `joint_states` | `/joint_states` | `sensor_msgs/JointState` |
+| `ouster/points` | `/ouster/points` | `sensor_msgs/PointCloud2` |
+| `camera_front/*` | `/camera_front/{image,depth_image,camera_info,points}` | Image / CameraInfo / PointCloud2 |
+| `camera_rear/*` | `/camera_rear/{image,depth_image,camera_info,points}` | Image / CameraInfo / PointCloud2 |
+| `clock` | `/clock` | `rosgraph_msgs/Clock` |
+
+## Key files
+
+- `launch/moon_yard.launch.py`: main simulation launch.
+- `worlds/`: SDF world files.
+- `models/`: custom Gazebo models (rocks, arena walls, AprilTag).
+- `config/`: bridge and plugin configuration.
+
+## macOS fallback
+
+On macOS the launch file automatically patches `ogre2` → `ogre` in the world
+SDF (Ogre2 is unsupported on macOS Metal). The patched file is written to a
+temp path and used transparently.
+
+## Notes
+
+- `GZ_SIM_RESOURCE_PATH` is prepended with the package's `models/` directory
+  at launch so Gazebo can find custom models.
+- The rover spawns at (0, 0, 0.5) and settles under gravity.
+- `use_sim_time: true` is set on `robot_state_publisher`.


### PR DESCRIPTION
## Summary
- Update main README repository layout to include all current packages (drivetrain, excavation, safety)
- Create concise READMEs for 5 packages that were missing them: `lunabot_drivetrain`, `lunabot_control`, `lunabot_description`, `lunabot_simulation`, `lunabot_safety`
- Update `lunabot_bringup` README with bounded retries and safety gating details
- Update `lunabot_interfaces` README with drivetrain message contracts (DrivetrainCommand/Status/Telemetry)

Wiki was updated separately (pushed directly to wiki repo):
- Fixed `/odometry/filtered` → `/odometry/local` in Operations
- Fixed `global EKF` → `RTAB-Map SLAM` in Sensors
- Updated Perception page repo divergence section
- Added historical snapshot banners to 5 research pages

## Test plan
- [ ] Verify READMEs render correctly on GitHub
- [ ] CI passes (docs-only change, no code impact)