### PR TITLE
fix(teleop): route mux to cmd_vel_safe; optional joy_device_name

### DIFF
--- a/src/lunabot_bringup/launch/navigation.launch.py
+++ b/src/lunabot_bringup/launch/navigation.launch.py
@@ -247,7 +247,7 @@ def generate_launch_description():
         executable="twist_mux",
         name="twist_mux",
         output="screen",
-        remappings=[("cmd_vel_out", "cmd_vel")],
+        remappings=[("cmd_vel_out", "cmd_vel_safe")],
         parameters=[twist_mux_params_path, {"use_sim_time": use_sim_time}],
         condition=IfCondition(enable_teleop),
     )

--- a/src/lunabot_teleop/launch/joystick_teleop.launch.py
+++ b/src/lunabot_teleop/launch/joystick_teleop.launch.py
@@ -7,7 +7,6 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch_ros.parameter_descriptions import ParameterValue
 
 
 def _config_path(*parts: str) -> str:
@@ -32,11 +31,41 @@ def _validate_non_negative_int(value: str, argument_name: str) -> str:
 
 def _validate_launch_arguments(context):
     """Reject invalid launch arguments before any teleop nodes start."""
-    _validate_non_negative_int(
-        LaunchConfiguration("joy_device_id").perform(context),
-        argument_name="joy_device_id",
-    )
+    joy_device_name = LaunchConfiguration("joy_device_name").perform(context).strip()
+    if not joy_device_name:
+        _validate_non_negative_int(
+            LaunchConfiguration("joy_device_id").perform(context),
+            argument_name="joy_device_id",
+        )
     return []
+
+
+def _create_game_controller_node(context, use_sim_time):
+    """Create joy node with name-based selection fallback."""
+    joy_device_name = LaunchConfiguration("joy_device_name").perform(context).strip()
+    base_params = [
+        {"use_sim_time": use_sim_time},
+        {"deadzone": 0.08},
+        {"autorepeat_rate": 20.0},
+        {"coalesce_interval_ms": 1},
+    ]
+    if joy_device_name:
+        base_params.append({"device_name": joy_device_name})
+    else:
+        joy_device_id = _validate_non_negative_int(
+            LaunchConfiguration("joy_device_id").perform(context),
+            argument_name="joy_device_id",
+        )
+        base_params.append({"device_id": int(joy_device_id)})
+    return [
+        Node(
+            package="joy",
+            executable="game_controller_node",
+            name="game_controller_node",
+            output="screen",
+            parameters=base_params,
+        )
+    ]
 
 
 def generate_launch_description():
@@ -49,21 +78,6 @@ def generate_launch_description():
     """
     teleop_config = _config_path("config", "xbox_teleop.yaml")
     use_sim_time = LaunchConfiguration("use_sim_time")
-    joy_device_id = LaunchConfiguration("joy_device_id")
-
-    game_controller = Node(
-        package="joy",
-        executable="game_controller_node",
-        name="game_controller_node",
-        output="screen",
-        parameters=[
-            {"use_sim_time": use_sim_time},
-            {"device_id": ParameterValue(joy_device_id, value_type=int)},
-            {"deadzone": 0.08},
-            {"autorepeat_rate": 20.0},
-            {"coalesce_interval_ms": 1},
-        ],
-    )
 
     teleop_twist = Node(
         package="teleop_twist_joy",
@@ -88,8 +102,20 @@ def generate_launch_description():
                 default_value="0",
                 description=("SDL device index for the connected controller."),
             ),
+            DeclareLaunchArgument(
+                "joy_device_name",
+                default_value="",
+                description=(
+                    "Optional SDL controller name to match (takes precedence over "
+                    "joy_device_id when set)."
+                ),
+            ),
             OpaqueFunction(function=_validate_launch_arguments),
-            game_controller,
+            OpaqueFunction(
+                function=lambda context: _create_game_controller_node(
+                    context, use_sim_time
+                )
+            ),
             teleop_twist,
         ]
     )

--- a/src/lunabot_teleop/test/test_joystick_launch.py
+++ b/src/lunabot_teleop/test/test_joystick_launch.py
@@ -56,3 +56,13 @@ def test_validate_launch_arguments_rejects_invalid_device_id():
 
     with pytest.raises(ValueError, match="joy_device_id"):
         launch_module._validate_launch_arguments(context)
+
+
+def test_validate_launch_arguments_accepts_invalid_id_when_name_is_set():
+    launch_module = _load_launch_module()
+    launch_context_module = pytest.importorskip("launch.launch_context")
+    context = launch_context_module.LaunchContext()
+    context.launch_configurations["joy_device_id"] = "not-an-int"
+    context.launch_configurations["joy_device_name"] = "Xbox Series X Controller"
+
+    launch_module._validate_launch_arguments(context)

--- a/src/lunabot_teleop/test/test_joystick_launch.py
+++ b/src/lunabot_teleop/test/test_joystick_launch.py
@@ -53,6 +53,7 @@ def test_validate_launch_arguments_rejects_invalid_device_id():
     launch_context_module = pytest.importorskip("launch.launch_context")
     context = launch_context_module.LaunchContext()
     context.launch_configurations["joy_device_id"] = "-1"
+    context.launch_configurations["joy_device_name"] = ""
 
     with pytest.raises(ValueError, match="joy_device_id"):
         launch_module._validate_launch_arguments(context)


### PR DESCRIPTION
Routes `twist_mux` output to `/cmd_vel_safe` so teleop and Nav2 commands reach the same topic as the Gazebo bridge and drivetrain stack.

Adds optional `joy_device_name` to `joystick_teleop.launch.py` for SDL name-based controller selection when device index ordering is unreliable.

**Try on VM:** `ros2 launch lunabot_bringup navigation.launch.py enable_teleop:=true joy_device_name:="Xbox Series X Controller"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes teleop command-velocity routing and adds optional SDL name-based joystick selection.

### Changes

- Teleop velocity routing fix
  - Routes the muxed velocity output so teleop/autonomy and Nav2 publish to the same safe command topic used by the simulator and drivetrain stack (ensuring collision monitoring and downstream components receive the expected /cmd_vel_safe stream).

- Controller device selection
  - Adds an optional launch argument `joy_device_name` to allow selecting a controller by its SDL name when device index ordering is unreliable.
  - Launch validation now permits an invalid/absent `joy_device_id` when `joy_device_name` is provided; otherwise `joy_device_id` is still validated.
  - Example: ros2 launch lunabot_bringup navigation.launch.py enable_teleop:=true joy_device_name:="Xbox Series X Controller"

### Tests

- Added/updated tests covering:
  - Name-based joystick selection path (allows using `joy_device_name` without a valid `joy_device_id`).
  - Navigation launch remapping to verify teleop/Nav2 outputs are remapped to the expected cmd_vel topic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->