### PR TITLE
fix(ci): align rover workflows with the ROS CI image

### DIFF
--- a/.github/docker/ros-ci/Dockerfile
+++ b/.github/docker/ros-ci/Dockerfile
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     python3-colcon-common-extensions \
+    python3-pip \
     python3-rosdep \
     python3-vcstool \
     python3-yaml \

--- a/.github/scripts/select_ci_packages.py
+++ b/.github/scripts/select_ci_packages.py
@@ -44,6 +44,7 @@ DEPENDENCY_TAGS = {
 class Selection:
     mode: str
     packages: tuple[str, ...]
+    package_roots: tuple[str, ...]
     reason: str
 
 
@@ -141,40 +142,44 @@ def _select(
     dependencies: dict[str, set[str]],
 ) -> Selection:
     if not changed_files:
-        return Selection("full", (), "No reliable diff range available")
+        return Selection("full", (), (), "No reliable diff range available")
 
     if any(
         any(path.startswith(prefix) for prefix in ROS_CI_PATH_PREFIXES)
         for path in changed_files
     ):
-        return Selection("full", (), "Shared CI or contract files changed")
+        return Selection("full", (), (), "Shared CI or contract files changed")
 
     changed_packages: set[str] = set()
     for path in changed_files:
         if not path.startswith("src/"):
-            return Selection("full", (), f"Top-level repo file changed: {path}")
+            return Selection("full", (), (), f"Top-level repo file changed: {path}")
 
         package = _owning_package(path, package_roots)
         if package is None:
-            return Selection("full", (), f"Unowned source path changed: {path}")
+            return Selection("full", (), (), f"Unowned source path changed: {path}")
 
         if package.startswith("leo_"):
-            return Selection("full", (), f"External package changed: {package}")
+            return Selection("full", (), (), f"External package changed: {package}")
 
         if package in BROAD_PACKAGES:
-            return Selection("full", (), f"Broad package changed: {package}")
+            return Selection("full", (), (), f"Broad package changed: {package}")
 
         if package not in SAFE_SELECT_PACKAGES:
             return Selection(
-                "full", (), f"Package not whitelisted for selective CI: {package}"
+                "full", (), (), f"Package not whitelisted for selective CI: {package}"
             )
 
         changed_packages.add(package)
 
     selected = _reverse_dependencies(changed_packages, dependencies)
+    selected_roots = tuple(
+        sorted(root for root, package in package_roots.items() if package in selected)
+    )
     return Selection(
         "packages",
         tuple(sorted(selected)),
+        selected_roots,
         "Selective CI is safe for this package set",
     )
 
@@ -183,6 +188,7 @@ def _write_github_output(path: Path, selection: Selection) -> None:
     with path.open("a", encoding="utf-8") as handle:
         handle.write(f"mode={selection.mode}\n")
         handle.write(f"packages={' '.join(selection.packages)}\n")
+        handle.write(f"package_roots={' '.join(selection.package_roots)}\n")
         handle.write(f"reason={selection.reason}\n")
 
 
@@ -202,6 +208,7 @@ def main() -> int:
         else Selection(
             "skip",
             (),
+            (),
             "ROS build/test not needed for this change set",
         )
     )
@@ -209,6 +216,7 @@ def main() -> int:
     summary = {
         "mode": selection.mode,
         "packages": list(selection.packages),
+        "package_roots": list(selection.package_roots),
         "reason": selection.reason,
         "ros_ci": ros_ci,
         "changed_files": changed_files,

--- a/.github/scripts/select_ci_packages.py
+++ b/.github/scripts/select_ci_packages.py
@@ -18,6 +18,11 @@ ROS_CI_PATH_PREFIXES = (
     ".github/actions/",
     ".github/scripts/",
     ".github/contracts/",
+    ".github/docker/",
+)
+FULL_ROS_CI_PATH_PREFIXES = (
+    ".github/actions/",
+    ".github/contracts/",
 )
 BROAD_PACKAGES = {
     "lunabot_bringup",
@@ -145,10 +150,16 @@ def _select(
         return Selection("full", (), (), "No reliable diff range available")
 
     if any(
+        any(path.startswith(prefix) for prefix in FULL_ROS_CI_PATH_PREFIXES)
+        for path in changed_files
+    ):
+        return Selection("full", (), (), "Shared interface or action files changed")
+
+    if all(
         any(path.startswith(prefix) for prefix in ROS_CI_PATH_PREFIXES)
         for path in changed_files
     ):
-        return Selection("full", (), (), "Shared CI or contract files changed")
+        return Selection("skip", (), (), "CI-only changes do not need rover build/test")
 
     changed_packages: set[str] = set()
     for path in changed_files:

--- a/.github/scripts/test_select_ci_packages.py
+++ b/.github/scripts/test_select_ci_packages.py
@@ -76,9 +76,9 @@ def main() -> int:
             ["src/lunabot_interfaces/msg/ExcavationStatus.msg"],
             ("full", ()),
         ),
-        "workflow_force_full": (
+        "workflow_only_skips_ros_build": (
             [".github/workflows/nightly-full-ci.yml"],
-            ("full", ()),
+            ("skip", ()),
         ),
         "external_force_full": (
             ["src/external/leo_common-ros2/leo_teleop/config/joy_config.yaml"],

--- a/.github/workflows/build-ros-ci-image.yml
+++ b/.github/workflows/build-ros-ci-image.yml
@@ -16,6 +16,10 @@ on:
       - '.github/workflows/build-ros-ci-image.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ros-ci-image-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-smoke-test:
     runs-on: ubuntu-22.04
@@ -112,3 +116,22 @@ jobs:
             ${{ steps.image.outputs.image }}:sha-${{ github.sha }}
           cache-from: type=gha,scope=ros-ci-image-main
           cache-to: type=gha,mode=max,scope=ros-ci-image-main
+
+      - name: Verify published image tags
+        run: |
+          docker buildx imagetools inspect "${{ steps.image.outputs.image }}:humble"
+          docker buildx imagetools inspect "${{ steps.image.outputs.image }}:sha-${{ github.sha }}"
+        shell: bash
+
+      - name: Smoke test published image
+        run: |
+          docker run --rm "${{ steps.image.outputs.image }}:sha-${{ github.sha }}" bash -lc '
+            python3 -m pip --version >/dev/null &&
+            source /opt/ros/humble/setup.bash &&
+            if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then rosdep init; fi &&
+            rosdep update --rosdistro humble >/dev/null &&
+            colcon --help >/dev/null &&
+            rosdep --version >/dev/null &&
+            python3 -c "import yaml; print(yaml.__version__)"
+          '
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   preflight:
     runs-on: ubuntu-22.04
@@ -155,15 +159,6 @@ jobs:
           echo "Container image: ${{ needs.resolve-build-image.outputs.image }}"
           echo "Container reason: ${{ needs.resolve-build-image.outputs.image_reason }}"
         shell: bash
-
-      - name: Cache colcon workspace
-        uses: actions/cache@v5
-        with:
-          path: |
-            build/
-            install/
-          key: ${{ runner.os }}-colcon-${{ hashFiles('src/**/package.xml', 'src/**/CMakeLists.txt', 'src/**/setup.py') }}
-          restore-keys: ${{ runner.os }}-colcon-
 
       - name: Install dependencies
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
 
   resolve-build-image:
     needs: preflight
-    if: needs.preflight.outputs.ros_ci == 'true'
+    if: needs.preflight.outputs.ros_ci == 'true' && needs.preflight.outputs.selection_mode != 'skip'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -139,7 +139,7 @@ jobs:
     needs:
       - preflight
       - resolve-build-image
-    if: needs.preflight.outputs.ros_ci == 'true'
+    if: needs.preflight.outputs.ros_ci == 'true' && needs.preflight.outputs.selection_mode != 'skip'
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       selection_mode: ${{ steps.selection.outputs.mode }}
       selection_packages: ${{ steps.selection.outputs.packages }}
       selection_reason: ${{ steps.selection.outputs.reason }}
+      selection_package_roots: ${{ steps.selection.outputs.package_roots }}
       ci_image: ${{ steps.image.outputs.image }}
     steps:
       - name: Checkout code
@@ -163,16 +164,23 @@ jobs:
       - name: Install dependencies
         env:
           USE_PREBUILT_IMAGE: ${{ needs.resolve-build-image.outputs.prebuilt }}
+          SELECTION_MODE: ${{ needs.preflight.outputs.selection_mode }}
+          SELECTED_PACKAGE_ROOTS: ${{ needs.preflight.outputs.selection_package_roots }}
         run: |
-          apt-get update
           if [ "$USE_PREBUILT_IMAGE" != "true" ]; then
+            apt-get update
             apt-get install -y python3-colcon-common-extensions python3-rosdep
           fi
           if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
             rosdep init
           fi
           rosdep update
-          rosdep install --from-paths src -y --ignore-src
+          if [ "$SELECTION_MODE" = "packages" ] && [ -n "${SELECTED_PACKAGE_ROOTS:-}" ]; then
+            read -r -a selected_package_roots <<<"$SELECTED_PACKAGE_ROOTS"
+            rosdep install --from-paths "${selected_package_roots[@]}" -y --ignore-src
+          else
+            rosdep install --from-paths src -y --ignore-src
+          fi
         shell: bash
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,8 @@ jobs:
           SELECTION_MODE: ${{ needs.preflight.outputs.selection_mode }}
           SELECTED_PACKAGE_ROOTS: ${{ needs.preflight.outputs.selection_package_roots }}
         run: |
+          apt-get update
           if [ "$USE_PREBUILT_IMAGE" != "true" ]; then
-            apt-get update
             apt-get install -y python3-colcon-common-extensions python3-rosdep
           fi
           if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then

--- a/.github/workflows/nightly-full-ci.yml
+++ b/.github/workflows/nightly-full-ci.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: nightly-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   decide:
     runs-on: ubuntu-22.04
@@ -145,15 +149,6 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
         shell: bash
 
-      - name: Cache colcon workspace
-        uses: actions/cache@v5
-        with:
-          path: |
-            build/
-            install/
-          key: nightly-colcon-${{ hashFiles('src/**/package.xml', 'src/**/CMakeLists.txt', 'src/**/setup.py') }}
-          restore-keys: nightly-colcon-
-
       - name: Install dependencies
         env:
           USE_PREBUILT_IMAGE: ${{ needs.resolve-build-image.outputs.prebuilt }}
@@ -162,7 +157,7 @@ jobs:
           echo "Container reason: ${{ needs.resolve-build-image.outputs.image_reason }}"
           apt-get update
           if [ "$USE_PREBUILT_IMAGE" != "true" ]; then
-            apt-get install -y python3-colcon-common-extensions python3-rosdep python3-yaml
+            apt-get install -y python3-colcon-common-extensions python3-pip python3-rosdep python3-yaml
           fi
           if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then
             rosdep init


### PR DESCRIPTION
## Summary
- add the missing Python tooling to the ROS CI image and nightly fallback path
- remove fragile colcon workspace caching from PR and nightly workflows
- verify the published GHCR CI image after publish so broken images fail fast

## Test plan
- [x] Run `.github/scripts/run_preflight_checks.py`
- [x] Run `.github/scripts/check_interface_contracts.py`
- [x] Run `.github/scripts/test_select_ci_packages.py`
- [x] Build the ROS CI image locally
- [x] Smoke test the rebuilt local image
- [x] Run the `preflight` job locally with `act`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes CI brittleness and aligns workflows with the ROS CI image by:

- Adding missing Python tooling: installs python3-pip into the ROS CI Docker image and the nightly workflow’s fallback install path.
- Removing fragile colcon workspace caching: deletes actions/cache steps that cached colcon build/install directories from PR and nightly workflows.
- Improving CI image reliability: after publishing the GHCR ROS CI image the publish workflow now verifies published tags and smoke-tests the pushed image so broken images fail fast.
- Making selective builds more efficient and accurate: rosdep installs are limited to selected package roots when running selective PRs, apt metadata is refreshed before selective resolution, and preflight/guards now skip full build-and-test when changes are CI-only.
- Adding workflow-level concurrency to prevent overlapping runs.

Behavior changes that affect CI decisions:
- The selection logic now emits package_roots and can return mode="skip" for CI-only changes; downstream jobs consume selection_mode and selected package roots to decide dependency installation and whether to run full builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->