### PR TITLE
fix(bringup): finish readiness gate coverage for localisation and autonomous attempts

### DIFF
--- a/src/lunabot_bringup/config/preflight_checks.yaml
+++ b/src/lunabot_bringup/config/preflight_checks.yaml
@@ -53,7 +53,7 @@ preflight:
     - name: /localisation/start_zone_status
       type: lunabot_interfaces/msg/LocalisationStartZoneStatus
       min_messages: 1
-      critical: false
+      critical: true
 
   required_tf_links:
     - parent: map

--- a/src/lunabot_bringup/config/preflight_checks_dry_run.yaml
+++ b/src/lunabot_bringup/config/preflight_checks_dry_run.yaml
@@ -54,7 +54,7 @@ preflight:
     - name: /localisation/start_zone_status
       type: lunabot_interfaces/msg/LocalisationStartZoneStatus
       min_messages: 1
-      critical: false
+      critical: true
     - name: /excavation/status
       type: lunabot_interfaces/msg/ExcavationStatus
       min_messages: 1

--- a/src/lunabot_bringup/lunabot_bringup/localisation_readiness.py
+++ b/src/lunabot_bringup/lunabot_bringup/localisation_readiness.py
@@ -3,6 +3,39 @@
 READY_STATE = "ready"
 READY_REASON = "LOCALISATION_READY"
 
+GATE_NO_STATUS = "GATE_NO_STATUS"
+GATE_STATUS_STALE = "GATE_STATUS_STALE"
+GATE_STATE_NOT_READY = "GATE_STATE_NOT_READY"
+
+
+def get_readiness_failure_reason(
+    status,
+    now_ns: int,
+    freshness_ns: int,
+) -> str | None:
+    """Return a GATE_* reason code for the first localisation failure, or None."""
+    if status is None:
+        return GATE_NO_STATUS
+
+    status_ns = int(status.stamp.sec) * 1_000_000_000 + int(status.stamp.nanosec)
+    if status_ns <= 0:
+        return GATE_NO_STATUS
+
+    if now_ns <= 0 or now_ns < status_ns:
+        return GATE_STATUS_STALE
+
+    if (now_ns - status_ns) > freshness_ns:
+        return GATE_STATUS_STALE
+
+    if (
+        not bool(status.ready)
+        or status.state != READY_STATE
+        or status.reason_code != READY_REASON
+    ):
+        return GATE_STATE_NOT_READY
+
+    return None
+
 
 def is_localisation_ready(
     status,
@@ -12,21 +45,4 @@ def is_localisation_ready(
 ) -> bool:
     """Return whether the latest status still counts as travel-ready."""
     del last_update_ns
-    if status is None:
-        return False
-
-    status_ns = int(status.stamp.sec) * 1_000_000_000 + int(status.stamp.nanosec)
-    if status_ns <= 0:
-        return False
-
-    if now_ns <= 0 or now_ns < status_ns:
-        return False
-
-    if (now_ns - status_ns) > freshness_ns:
-        return False
-
-    return (
-        bool(status.ready)
-        and status.state == READY_STATE
-        and status.reason_code == READY_REASON
-    )
+    return get_readiness_failure_reason(status, now_ns, freshness_ns) is None

--- a/src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py
+++ b/src/lunabot_bringup/lunabot_bringup/navigate_to_pose_gate.py
@@ -11,8 +11,14 @@ from rclpy.action import ActionClient, ActionServer, CancelResponse, GoalRespons
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile
+from std_msgs.msg import String
 
-from lunabot_bringup.localisation_readiness import is_localisation_ready
+from lunabot_bringup.localisation_readiness import (
+    GATE_NO_STATUS,
+    get_readiness_failure_reason,
+    is_localisation_ready,
+)
 from lunabot_interfaces.msg import LocalisationStartZoneStatus
 
 
@@ -51,6 +57,16 @@ class NavigateToPoseGate(Node):
 
         self._latest_status = None
         self._callback_group = ReentrantCallbackGroup()
+
+        latched_qos = QoSProfile(
+            depth=1,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        )
+        self._failure_reason_pub = self.create_publisher(
+            String,
+            "/mission/last_failure_reason",
+            latched_qos,
+        )
 
         self.create_subscription(
             LocalisationStartZoneStatus,
@@ -103,10 +119,20 @@ class NavigateToPoseGate(Node):
     def _on_goal(self, _goal) -> GoalResponse:
         """Accept travel goals only when localisation is ready and Nav2 is up."""
         if not self._ready_for_travel():
+            reason = GATE_NO_STATUS
+            if self.gate_enabled:
+                now_ns = self.get_clock().now().nanoseconds
+                failure = get_readiness_failure_reason(
+                    self._latest_status,
+                    now_ns,
+                    self.readiness_timeout_ns,
+                )
+                if failure is not None:
+                    reason = failure
             self.get_logger().warn(
-                "Rejecting NavigateToPose goal because start-zone localisation "
-                "is not ready."
+                f"Rejecting NavigateToPose goal: {reason}"
             )
+            self._failure_reason_pub.publish(String(data=reason))
             return GoalResponse.REJECT
 
         return GoalResponse.ACCEPT

--- a/src/lunabot_bringup/test/test_localisation_readiness.py
+++ b/src/lunabot_bringup/test/test_localisation_readiness.py
@@ -2,7 +2,13 @@
 
 from types import SimpleNamespace
 
-from lunabot_bringup.localisation_readiness import is_localisation_ready
+from lunabot_bringup.localisation_readiness import (
+    GATE_NO_STATUS,
+    GATE_STATE_NOT_READY,
+    GATE_STATUS_STALE,
+    get_readiness_failure_reason,
+    is_localisation_ready,
+)
 
 
 def _status(*, ready: bool, state: str, reason_code: str, stamp_ns: int):
@@ -95,3 +101,98 @@ def test_localisation_ready_rejects_missing_source_stamp():
         now_ns=3_000_000_000,
         freshness_ns=5_000_000_000,
     )
+
+
+# ---------------------------------------------------------------------------
+# get_readiness_failure_reason tests
+# ---------------------------------------------------------------------------
+
+
+def test_failure_reason_none_status_returns_gate_no_status():
+    """None status yields GATE_NO_STATUS."""
+    reason = get_readiness_failure_reason(None, now_ns=3_000_000_000, freshness_ns=5_000_000_000)
+    assert reason == GATE_NO_STATUS
+
+
+def test_failure_reason_zero_stamp_returns_gate_no_status():
+    """A zero timestamp (uninitialised) yields GATE_NO_STATUS."""
+    status = _status(
+        ready=True,
+        state="ready",
+        reason_code="LOCALISATION_READY",
+        stamp_ns=0,
+    )
+    reason = get_readiness_failure_reason(
+        status, now_ns=3_000_000_000, freshness_ns=5_000_000_000
+    )
+    assert reason == GATE_NO_STATUS
+
+
+def test_failure_reason_stale_status_returns_gate_status_stale():
+    """A status older than freshness_ns yields GATE_STATUS_STALE."""
+    status = _status(
+        ready=True,
+        state="ready",
+        reason_code="LOCALISATION_READY",
+        stamp_ns=2_000_000_000,
+    )
+    reason = get_readiness_failure_reason(
+        status, now_ns=8_000_000_000, freshness_ns=5_000_000_000
+    )
+    assert reason == GATE_STATUS_STALE
+
+
+def test_failure_reason_backwards_clock_returns_gate_status_stale():
+    """now_ns behind stamp_ns (backwards/zero clock) yields GATE_STATUS_STALE."""
+    status = _status(
+        ready=True,
+        state="ready",
+        reason_code="LOCALISATION_READY",
+        stamp_ns=2_000_000_000,
+    )
+    reason = get_readiness_failure_reason(
+        status, now_ns=1_500_000_000, freshness_ns=5_000_000_000
+    )
+    assert reason == GATE_STATUS_STALE
+
+
+def test_failure_reason_wrong_state_returns_gate_state_not_ready():
+    """Wrong state field yields GATE_STATE_NOT_READY."""
+    status = _status(
+        ready=True,
+        state="candidate_lock",
+        reason_code="LOCALISATION_READY",
+        stamp_ns=2_000_000_000,
+    )
+    reason = get_readiness_failure_reason(
+        status, now_ns=3_000_000_000, freshness_ns=5_000_000_000
+    )
+    assert reason == GATE_STATE_NOT_READY
+
+
+def test_failure_reason_wrong_reason_code_returns_gate_state_not_ready():
+    """Wrong reason_code field yields GATE_STATE_NOT_READY."""
+    status = _status(
+        ready=True,
+        state="ready",
+        reason_code="LOCALISATION_TAG_UNSTABLE",
+        stamp_ns=2_000_000_000,
+    )
+    reason = get_readiness_failure_reason(
+        status, now_ns=3_000_000_000, freshness_ns=5_000_000_000
+    )
+    assert reason == GATE_STATE_NOT_READY
+
+
+def test_failure_reason_ready_status_returns_none():
+    """A fully ready status yields None (no failure)."""
+    status = _status(
+        ready=True,
+        state="ready",
+        reason_code="LOCALISATION_READY",
+        stamp_ns=2_000_000_000,
+    )
+    reason = get_readiness_failure_reason(
+        status, now_ns=3_000_000_000, freshness_ns=5_000_000_000
+    )
+    assert reason is None

--- a/src/lunabot_bringup/test/test_navigate_to_pose_gate_rejection_launch.py
+++ b/src/lunabot_bringup/test/test_navigate_to_pose_gate_rejection_launch.py
@@ -1,0 +1,174 @@
+"""Launch test: gate rejects goals when gate_enabled=True and no status is published."""
+
+from __future__ import annotations
+
+import atexit
+import os
+import time
+import unittest
+from pathlib import Path
+
+import launch
+import launch_testing.actions
+import pytest
+import rclpy
+from launch.actions import (
+    SetEnvironmentVariable,
+    TimerAction,
+    UnsetEnvironmentVariable,
+)
+from launch_ros.actions import Node
+from nav2_msgs.action import NavigateToPose
+from rclpy.action import ActionClient
+from rclpy.node import Node as RclpyNode
+
+PUBLIC_ACTION_NAME = "/test_rejection_navigate_to_pose_gate"
+INTERNAL_ACTION_NAME = "/test_rejection_navigate_to_pose"
+TEST_ROS_DOMAIN_LOCK_FD = None
+TEST_ROS_DOMAIN_LOCK_PATH = None
+
+
+def _reserve_test_domain():
+    """Reserve a ROS domain id for this test run on the current machine."""
+    global TEST_ROS_DOMAIN_LOCK_FD
+    global TEST_ROS_DOMAIN_LOCK_PATH
+
+    domain_ids = list(range(1, 102)) + list(range(215, 233))
+    start_index = (os.getpid() + time.time_ns() + 7777) % len(domain_ids)
+
+    for offset in range(len(domain_ids)):
+        domain_id = domain_ids[(start_index + offset) % len(domain_ids)]
+        lock_path = Path(f"/tmp/lunabot_ros_domain_{domain_id}.lock")
+        try:
+            lock_fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+        except FileExistsError:
+            continue
+        TEST_ROS_DOMAIN_LOCK_FD = lock_fd
+        TEST_ROS_DOMAIN_LOCK_PATH = lock_path
+        return str(domain_id)
+
+    raise RuntimeError("No free ROS domain id available for launch test")
+
+
+def _release_test_domain_reservation():
+    """Release any reserved ROS domain id lock for this test run."""
+    global TEST_ROS_DOMAIN_LOCK_FD
+    global TEST_ROS_DOMAIN_LOCK_PATH
+
+    if TEST_ROS_DOMAIN_LOCK_FD is not None:
+        os.close(TEST_ROS_DOMAIN_LOCK_FD)
+        TEST_ROS_DOMAIN_LOCK_FD = None
+
+    if TEST_ROS_DOMAIN_LOCK_PATH is not None:
+        TEST_ROS_DOMAIN_LOCK_PATH.unlink(missing_ok=True)
+        TEST_ROS_DOMAIN_LOCK_PATH = None
+
+
+TEST_ROS_DOMAIN_ID = _reserve_test_domain()
+atexit.register(_release_test_domain_reservation)
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    """Launch the gate with gate_enabled=True and no status publisher."""
+    gate = Node(
+        package="lunabot_bringup",
+        executable="navigate_to_pose_gate",
+        name="navigate_to_pose_gate_rejection",
+        output="screen",
+        parameters=[
+            {
+                "gate_enabled": True,
+                "public_action_name": PUBLIC_ACTION_NAME,
+                "internal_action_name": INTERNAL_ACTION_NAME,
+                "readiness_timeout_s": 0.1,
+            }
+        ],
+    )
+
+    return (
+        launch.LaunchDescription(
+            [
+                SetEnvironmentVariable("ROS_DOMAIN_ID", TEST_ROS_DOMAIN_ID),
+                UnsetEnvironmentVariable("FASTRTPS_DEFAULT_PROFILES_FILE"),
+                UnsetEnvironmentVariable("RMW_FASTRTPS_USE_QOS_FROM_XML"),
+                gate,
+                TimerAction(
+                    period=2.0,
+                    actions=[launch_testing.actions.ReadyToTest()],
+                ),
+            ]
+        ),
+        {"gate": gate},
+    )
+
+
+class _RejectionTestClient(RclpyNode):
+    """Minimal action client for gate rejection tests."""
+
+    def __init__(self) -> None:
+        super().__init__("navigate_to_pose_gate_rejection_test_client")
+        self.client = ActionClient(
+            self,
+            NavigateToPose,
+            PUBLIC_ACTION_NAME,
+        )
+
+
+class TestNavigateToPoseGateRejectsWithNoStatus(unittest.TestCase):
+    """Verify the gate rejects goals when gate_enabled=True and no status is published."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Initialise rclpy with the reserved test domain."""
+        cls._original_env = {
+            "ROS_DOMAIN_ID": os.environ.get("ROS_DOMAIN_ID"),
+            "FASTRTPS_DEFAULT_PROFILES_FILE": os.environ.get(
+                "FASTRTPS_DEFAULT_PROFILES_FILE"
+            ),
+            "RMW_FASTRTPS_USE_QOS_FROM_XML": os.environ.get(
+                "RMW_FASTRTPS_USE_QOS_FROM_XML"
+            ),
+        }
+        os.environ["ROS_DOMAIN_ID"] = TEST_ROS_DOMAIN_ID
+        os.environ.pop("FASTRTPS_DEFAULT_PROFILES_FILE", None)
+        os.environ.pop("RMW_FASTRTPS_USE_QOS_FROM_XML", None)
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Shutdown rclpy and restore the environment."""
+        if rclpy.ok():
+            rclpy.shutdown()
+        for name, value in cls._original_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+        _release_test_domain_reservation()
+
+    def setUp(self):
+        """Create a test client node."""
+        self.node = _RejectionTestClient()
+        self.assertTrue(self.node.client.wait_for_server(timeout_sec=10.0))
+
+    def tearDown(self):
+        """Destroy the test client node."""
+        self.node.destroy_node()
+
+    def test_gate_rejects_goal_when_no_status_published(self):
+        """Gate with gate_enabled=True and no status publisher must reject goals."""
+        goal = NavigateToPose.Goal()
+        goal.pose.header.frame_id = ""
+
+        send_goal_future = self.node.client.send_goal_async(goal)
+        rclpy.spin_until_future_complete(self.node, send_goal_future, timeout_sec=5.0)
+
+        self.assertTrue(send_goal_future.done())
+        goal_handle = send_goal_future.result()
+        self.assertIsNotNone(goal_handle)
+        self.assertFalse(
+            goal_handle.accepted,
+            "Gate should reject the goal when no localisation status is available.",
+        )


### PR DESCRIPTION
Closes #72

## What changed
- `localisation_readiness.py` — added `get_readiness_failure_reason()` returning explicit reason codes (GATE_NO_STATUS, GATE_STATUS_STALE, GATE_STATE_NOT_READY, etc.) for each failure path
- `navigate_to_pose_gate.py` — calls the new helper on goal rejection, logs the reason code, and publishes it on `/mission/last_failure_reason` (latched std_msgs/String)
- `test_localisation_readiness.py` — added test cases covering all failure paths: None status, stale timestamp, zero/backwards stamp, wrong state, wrong reason_code
- `test_navigate_to_pose_gate_rejection_launch.py` — new launch integration test with gate_enabled=True and no status publisher, exercising the real rejection path
- `preflight_checks.yaml` — /localisation/start_zone_status promoted to critical: true
- `preflight_checks_dry_run.yaml` — same promotion

## Why
The gate was wired up but had three gaps: goal rejections were silent (no reason visible to operators or logs), the real gate_enabled=True path had no launch-level test coverage, and both preflight profiles allowed a silent localisation node to pass preflight. This closes those gaps so autonomous attempts are reliably blocked when localisation is not genuinely ready.

## Test plan
- [ ] colcon test --packages-select lunabot_bringup passes
- [ ] colcon test-result shows 0 failures
- [ ] Verify /mission/last_failure_reason publishes a reason code when localisation is not ready (dry-run or sim)

## Interface contracts
No contract changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR closes issue #72 by improving readiness gate coverage and visibility for autonomous attempt control when localisation prerequisites are not met.

## What's Fixed

**Silent goal rejections:** Goals are no longer silently rejected without observable reason. The gate now computes and publishes explicit failure reason codes (e.g., no status available, stale data, state mismatch) to `/mission/last_failure_reason` when rejecting navigation goals, making it visible to operators and logs why autonomy attempts are blocked.

**Test coverage gap:** Added launch-level integration test (`test_navigate_to_pose_gate_rejection_launch.py`) that exercises the real goal rejection path with gating enabled and no status publisher present, verifying gates actually reject as expected in dry-run/sim scenarios.

**Preflight allowance gap:** Promoted `/localisation/start_zone_status` to critical status in preflight check configurations, preventing silent localisation failures from being allowed during preflight validation.

## Changes Made

- **`localisation_readiness.py`:** Added `get_readiness_failure_reason()` helper that returns explicit reason codes for each failure path (no status, stale timestamp, state/reason_code mismatch) or `None` when ready.
- **`navigate_to_pose_gate.py`:** Updated goal rejection handler to derive and publish failure reason codes on a latched topic before rejecting goals.
- **`test_localisation_readiness.py`:** Added comprehensive test cases covering all failure paths from the new helper.
- **`test_navigate_to_pose_gate_rejection_launch.py`:** New launch test verifying goal rejection behavior when gate is enabled.
- **Preflight configs:** Changed `/localisation/start_zone_status` from `critical: false` to `critical: true` in both `preflight_checks.yaml` and `preflight_checks_dry_run.yaml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->