### PR TITLE
add: wire comment-triggered PR Agent review workflow

### DIFF
--- a/.github/workflows/pr-agent-review.yml
+++ b/.github/workflows/pr-agent-review.yml
@@ -1,0 +1,43 @@
+name: PR Agent Review
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  pr-agent-review:
+    name: Review on PR comment
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/review')
+      )
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Add eyes reaction to review request
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Run PR Agent review
+        uses: Codium-ai/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_KEY: ${{ secrets.PR_AGENT_OPENAI_KEY }}
+          OPENAI__API_BASE: ${{ secrets.PR_AGENT_OPENAI_API_BASE }}
+          CONFIG__MODEL: ${{ vars.PR_AGENT_MODEL || 'gpt-5.3-codex' }}

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,43 @@
+[config]
+git_provider = "github"
+publish_output = true
+publish_output_progress = true
+model = "gpt-5.3-codex"
+fallback_models = ["gpt-5-codex-mini"]
+response_language = "en-GB"
+
+[github_app]
+handle_push_trigger = false
+pr_commands = ["/review"]
+push_commands = []
+
+[pr_reviewer]
+persistent_comment = true
+final_update_message = true
+enable_help_text = false
+num_max_findings = 5
+extra_instructions = """
+Review only the changes introduced by this pull request.
+
+Write in British English. Use a clear, direct, human tone. Be firm when something is genuinely wrong, but do not sound hostile, smug, or patronising. The goal is to help the contributor understand the problem and fix it well.
+
+Keep the review focused on real issues in the changed code. Do not turn it into a style audit.
+
+Use this repository's context while reviewing:
+- ROS 2 Humble is the baseline ROS version
+- Gazebo Fortress is the simulation baseline
+- `ROVER_CODING_STANDARD.md` and `CONTRIBUTING.md` describe local expectations
+
+Prioritise high-signal issues such as correctness bugs, behavioural regressions, safety or mission-impacting failure modes, weak validation, unsafe defaults, unbounded loops or state growth, broken timeout or shutdown handling, and missing tests where the change adds real risk.
+
+Skip cosmetic remarks, naming bikeshedding, minor refactors with no clear payoff, and low-confidence speculation. Ignore issues outside the changed code unless this pull request clearly makes them worse.
+
+When you raise a finding, explain the problem in a way that teaches:
+- say what the code is doing now
+- say why that is a problem in practice
+- say what sort of runtime condition, input, or failure path would expose it
+
+Do not write long essays. Keep each finding concise, but include enough context that the contributor can learn from it.
+
+Prefer short paragraphs over bullet-heavy commentary where possible. Do not add unnecessary prose. If there are no material issues, say so plainly and briefly.
+"""

--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ If you rename a topic, action, or TF link, update the contract JSON in the same 
 - Operations: https://github.com/KJdotIO/innex1-rover/wiki/Operations
 - Contracts: https://github.com/KJdotIO/innex1-rover/wiki/Contracts
 
+## AI PR review
+
+A comment-triggered PR Agent skeleton is included for on-demand review workflows.
+
+- Trigger it from a pull request comment with `/review`
+- Configure GitHub Actions secrets `PR_AGENT_OPENAI_KEY` and `PR_AGENT_OPENAI_API_BASE` on the repository before use
+- Automatic PR review is intentionally disabled for now
+
 ## Contributing and licence
 
 - Contributing guide: [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
Set up an on-demand PR Agent workflow that runs from `/review` comments.