### PR TITLE
ci: faster ROS CI image workflow (single build on main)

### DIFF
--- a/.github/workflows/build-ros-ci-image.yml
+++ b/.github/workflows/build-ros-ci-image.yml
@@ -23,10 +23,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-smoke-test:
+  build:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -35,20 +36,63 @@ jobs:
         id: image
         run: |
           owner_lower=$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            cache_scope=ros-ci-image-pr
-          else
-            cache_scope=ros-ci-image-main
-          fi
           echo "image=ghcr.io/${owner_lower}/innex1-rover-ci" >> "$GITHUB_OUTPUT"
-          echo "cache_scope=${cache_scope}" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "cache_scope=ros-ci-image-pr" >> "$GITHUB_OUTPUT"
+          else
+            echo "cache_scope=ros-ci-image-main" >> "$GITHUB_OUTPUT"
+          fi
         shell: bash
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # main push: single build+push (was two full builds: smoke load + publish rebuild).
+      - name: Build and publish ROS CI image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/ros-ci/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.image.outputs.image }}:humble
+            ${{ steps.image.outputs.image }}:sha-${{ github.sha }}
+          cache-from: type=gha,scope=${{ steps.image.outputs.cache_scope }}
+          cache-to: type=gha,mode=max,scope=${{ steps.image.outputs.cache_scope }}
+
+      - name: Verify published image tags
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          docker buildx imagetools inspect "${{ steps.image.outputs.image }}:humble"
+          docker buildx imagetools inspect "${{ steps.image.outputs.image }}:sha-${{ github.sha }}"
+        shell: bash
+
+      - name: Smoke test published image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          docker run --rm "${{ steps.image.outputs.image }}:sha-${{ github.sha }}" bash -lc '
+            python3 -m pip --version >/dev/null &&
+            source /opt/ros/humble/setup.bash &&
+            if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then rosdep init; fi &&
+            rosdep update --rosdistro humble >/dev/null &&
+            colcon --help >/dev/null &&
+            rosdep --version >/dev/null &&
+            python3 -c "import yaml; print(yaml.__version__)"
+          '
+        shell: bash
+
+      # PR (same repo) or workflow_dispatch: load + smoke only (matches previous behavior).
       - name: Build ROS CI image for smoke testing
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -67,68 +111,10 @@ jobs:
           load: true
           tags: innex1-ros-ci:test
 
-      - name: Smoke test the image
+      - name: Smoke test local image
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
         run: |
           docker run --rm innex1-ros-ci:test bash -lc '
-            source /opt/ros/humble/setup.bash &&
-            if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then rosdep init; fi &&
-            rosdep update --rosdistro humble >/dev/null &&
-            colcon --help >/dev/null &&
-            rosdep --version >/dev/null &&
-            python3 -c "import yaml; print(yaml.__version__)"
-          '
-        shell: bash
-
-  publish:
-    runs-on: ubuntu-22.04
-    needs: build-and-smoke-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Derive image metadata
-        id: image
-        run: |
-          owner_lower=$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
-          echo "image=ghcr.io/${owner_lower}/innex1-rover-ci" >> "$GITHUB_OUTPUT"
-        shell: bash
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and publish ROS CI image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: .github/docker/ros-ci/Dockerfile
-          push: true
-          tags: |
-            ${{ steps.image.outputs.image }}:humble
-            ${{ steps.image.outputs.image }}:sha-${{ github.sha }}
-          cache-from: type=gha,scope=ros-ci-image-main
-          cache-to: type=gha,mode=max,scope=ros-ci-image-main
-
-      - name: Verify published image tags
-        run: |
-          docker buildx imagetools inspect "${{ steps.image.outputs.image }}:humble"
-          docker buildx imagetools inspect "${{ steps.image.outputs.image }}:sha-${{ github.sha }}"
-        shell: bash
-
-      - name: Smoke test published image
-        run: |
-          docker run --rm "${{ steps.image.outputs.image }}:sha-${{ github.sha }}" bash -lc '
-            python3 -m pip --version >/dev/null &&
             source /opt/ros/humble/setup.bash &&
             if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then rosdep init; fi &&
             rosdep update --rosdistro humble >/dev/null &&


### PR DESCRIPTION
## Why

After baking `rosdep install` into the Dockerfile, each image build is heavier (~8m). The previous workflow also ran **two** full Docker builds on `main`: one `load:` smoke build, then a second `push:` publish build — so pushes effectively paid ~2× that cost.

## What changed

- **Push to `main`**: one `docker build-push-action` with `push: true`, then verify tags + smoke the published `:sha-` image.
- **PR / `workflow_dispatch`**: unchanged idea — build with `load: true`, smoke locally (no publish).

Net: **main** image workflow wall time should drop by roughly one full image build (often ~half of total before), while the per-build time for the heavy Dockerfile is unchanged.