### PR TITLE
Add Jetson Sabertooth drivetrain bench bring-up

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -176,6 +176,7 @@ jobs:
             rosdep init
           fi
           rosdep update --rosdistro humble
+          apt-get update
           if [ "$SELECTION_MODE" = "packages" ] && [ -n "${SELECTED_PACKAGE_ROOTS:-}" ]; then
             read -r -a selected_package_roots <<<"$SELECTED_PACKAGE_ROOTS"
             rosdep install --from-paths "${selected_package_roots[@]}" -y --ignore-src

--- a/docs/jetson_sabertooth_bringup.md
+++ b/docs/jetson_sabertooth_bringup.md
@@ -1,0 +1,131 @@
+# Jetson to Sabertooth Bring-up
+
+Use this when the Sabertooth motor controllers are wired to the Jetson and you
+want a careful first-motion test.
+
+## Wiring check
+
+Before applying motor power, check:
+
+- Jetson UART TX is connected to each Sabertooth `S1` serial input.
+- Jetson ground and Sabertooth `0V/GND` share a common signal ground.
+- Sabertooth DIP switches are set for Legacy Simplified Serial at `9600` baud.
+- Sabertooth `5V OUT` is not powering the Jetson. Use the compute power rail.
+- The rover is lifted, restrained, or otherwise unable to drive away.
+- The main motor-power E-stop is reachable.
+
+The electrical CDR keeps motor power and compute power separate. That is the
+right architecture: the E-stop should cut motive power while the Jetson stays
+alive for logs, telemetry, and recovery.
+
+## Jetson setup
+
+Install the serial dependency and allow the logged-in user to open the UART:
+
+```bash
+sudo apt install python3-serial
+sudo usermod -aG dialout $USER
+```
+
+Log out and back in after changing groups.
+
+Build and source the workspace:
+
+```bash
+cd ~/innex1-rover
+colcon build --symlink-install --packages-select lunabot_interfaces lunabot_teleop lunabot_bringup lunabot_drivetrain
+source /opt/ros/humble/setup.bash
+source install/setup.bash
+```
+
+If the Jetson workspace lives somewhere else, use that path instead of
+`~/innex1-rover`.
+
+## Start the drivetrain bridge
+
+Start with a low throttle cap:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py max_throttle:=0.2
+```
+
+If the Sabertooth UART is not `/dev/ttyTHS1`, pass the actual device:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py serial_port:=/dev/ttyTHS0 max_throttle:=0.2
+```
+
+The CDR calls this Simplified Serial. In the Sabertooth 2x32 manual, the
+byte-based Arduino-style mode is Legacy Simplified Serial, so the launch file
+uses `serial_protocol:=legacy_simplified` by default. Use
+`serial_protocol:=packetized` only if the Sabertooth DIP switches are set for
+Packet Serial instead.
+
+## Send a tiny motion command
+
+In a second terminal:
+
+```bash
+source /opt/ros/humble/setup.bash
+source ~/innex1-rover/install/setup.bash
+ros2 topic pub --once /cmd_vel_safe geometry_msgs/msg/Twist "{linear: {x: 0.05}, angular: {z: 0.0}}"
+```
+
+The bridge automatically stops the motors if it does not receive another command
+within `command_timeout_s`.
+
+Send an explicit stop:
+
+```bash
+ros2 topic pub --once /cmd_vel_safe geometry_msgs/msg/Twist "{linear: {x: 0.0}, angular: {z: 0.0}}"
+```
+
+Watch the drivetrain state:
+
+```bash
+ros2 topic echo /drivetrain/status
+ros2 topic echo /drivetrain/telemetry
+```
+
+## Use a controller
+
+Plug in the controller, then launch teleop through the same bench file:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py enable_teleop:=true max_throttle:=0.2
+```
+
+If the controller is not device `0`, try:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py enable_teleop:=true joy_device_id:=1 max_throttle:=0.2
+```
+
+The signal path is:
+
+```text
+game_controller_node
+  -> /joy
+  -> teleop_twist_joy
+  -> /cmd_vel_teleop
+  -> twist_mux
+  -> /cmd_vel_safe
+  -> drivetrain_bridge
+  -> Jetson UART TX
+  -> Sabertooth S1
+```
+
+## micro-ROS?
+
+Not for first motion.
+
+micro-ROS is useful if an Arduino is staying in the robot as a ROS-aware
+microcontroller for encoder counting, watchdogs, hard real-time IO, or extra
+sensors. For this drivetrain bring-up, the shortest reliable chain is:
+
+```text
+Jetson ROS 2 node -> UART -> Sabertooth motor controller
+```
+
+Keep the Arduino out of the path until there is a specific job that the Jetson
+should not be doing directly.

--- a/src/lunabot_drivetrain/README.md
+++ b/src/lunabot_drivetrain/README.md
@@ -1,16 +1,17 @@
 # lunabot_drivetrain
 
 Drivetrain bridge for the INNEX-1 four-wheel skid-steer rover. Converts
-`cmd_vel` to Sabertooth Packetized Serial commands over UART and publishes
+`cmd_vel` to Sabertooth serial commands over UART and publishes
 encoder-derived odometry and telemetry.
 
 ## Hardware
 
 - **Motors**: 4x GR-WM4-V4 brushed DC with Hall-sensor quadrature encoders.
-- **Controllers**: 2x Sabertooth 2x32 on a single UART (`/dev/ttyTHS1`,
-  9600 baud). DIP-switch addresses 128 (FL+FR) and 129 (RL+RR).
-- **Protocol**: Packetized Serial — 4-byte frames
-  `[address, command, data, checksum]`.
+- **Controllers**: 2x Sabertooth 2x32 on Jetson UART (`/dev/ttyTHS1`,
+  9600 baud).
+- **Default protocol**: Legacy Simplified Serial, matching the electrical CDR's
+  "Simplified Serial" wiring. Packet Serial is also supported by setting
+  `serial_protocol:=packetized`.
 
 If the serial port is unavailable at startup the bridge enters **dry-run
 mode**: no motor output, but all ROS interfaces remain active. This allows
@@ -42,6 +43,107 @@ State machine: `UNINITIALISED → READY ⇄ DRIVING → FAULT` and `ESTOP`.
 - **Command timeout**: if no `cmd_vel` arrives within `command_timeout_s`, motors
   are stopped.
 
+## Jetson bench bring-up
+
+Use this path when the Sabertooths are wired to the Jetson and you want a small,
+controlled first-motion test.
+
+For the electrician-friendly checklist, see
+`docs/jetson_sabertooth_bringup.md` from the repository root.
+
+Before powering motor voltage, confirm:
+
+- Sabertooth `0V/GND` is tied to Jetson ground.
+- Jetson UART TX goes to each Sabertooth serial input (`S1`) as shown in the
+  electrical CDR.
+- The Sabertooth DIP switches are set for Legacy Simplified Serial at `9600`
+  baud, or `serial_protocol` and `baud_rate` are changed to match the hardware.
+- The rover is lifted or restrained for the first test, with motor power ready
+  to isolate immediately.
+
+On the Jetson, install the serial dependency and give the user access to the
+UART:
+
+```bash
+sudo apt install python3-serial
+sudo usermod -aG dialout $USER
+```
+
+Log out and back in after changing groups. If `/dev/ttyTHS1` is not the wired
+UART, pass the actual device as `serial_port:=...`.
+
+Build and source the workspace:
+
+```bash
+cd ~/innex1-rover
+colcon build --symlink-install --packages-select lunabot_interfaces lunabot_teleop lunabot_bringup lunabot_drivetrain
+source /opt/ros/humble/setup.bash
+source install/setup.bash
+```
+
+Start the bridge with a low throttle cap:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py max_throttle:=0.2
+```
+
+In a second terminal, send a short forward command:
+
+```bash
+source /opt/ros/humble/setup.bash
+source ~/innex1-rover/install/setup.bash
+ros2 topic pub --once /cmd_vel_safe geometry_msgs/msg/Twist "{linear: {x: 0.05}, angular: {z: 0.0}}"
+```
+
+The bridge will stop the motors automatically after `command_timeout_s` if no
+new command arrives. To send an explicit stop:
+
+```bash
+ros2 topic pub --once /cmd_vel_safe geometry_msgs/msg/Twist "{linear: {x: 0.0}, angular: {z: 0.0}}"
+```
+
+Watch status while testing:
+
+```bash
+ros2 topic echo /drivetrain/status
+ros2 topic echo /drivetrain/telemetry
+```
+
+For controller testing, plug in the gamepad and start the same launch file with
+teleop enabled:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py enable_teleop:=true max_throttle:=0.2
+```
+
+The joystick path is:
+
+`game_controller_node` → `/joy` → `teleop_twist_joy` → `/cmd_vel_teleop` →
+`twist_mux` → `/cmd_vel_safe` → `drivetrain_bridge` → Sabertooth serial.
+
+If the controller is not picked up as device `0`, try:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py enable_teleop:=true joy_device_id:=1
+```
+
+or match it by SDL name:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py enable_teleop:=true joy_device_name:="Xbox Wireless Controller"
+```
+
+## micro-ROS?
+
+micro-ROS is useful when the Arduino is staying in the system as a ROS-aware
+microcontroller. For this drivetrain, it is not the simplest first step: the
+Jetson can already publish ROS 2 velocity commands and this package already
+speaks Sabertooth serial.
+
+Use micro-ROS later if the Arduino needs to remain responsible for hard
+real-time IO, encoder counting, watchdogs, or extra sensors. For first motion,
+keep the chain shorter: Jetson ROS 2 node → UART → Sabertooth.
+
 ### `velocity_gate`
 
 Safety filter between the navigation stack and the drivetrain. Forwards
@@ -60,13 +162,13 @@ zero twist.
 
 - `config/drivetrain.yaml`: all tuneable parameters (kinematics, encoder CPR,
   stall thresholds, control/telemetry rates).
-- `lunabot_drivetrain/sabertooth_serial.py`: low-level Packetized Serial
-  framing and `send_throttle`/`send_stop` helpers.
+- `lunabot_drivetrain/sabertooth_serial.py`: low-level Simplified Serial and
+  Packet Serial framing helpers.
 
 ## Common failure modes
 
 - Serial port permission denied on Jetson (`sudo usermod -aG dialout $USER`).
-- Wrong Sabertooth DIP-switch address — bridge writes succeed but motors don't
-  respond.
+- Wrong Sabertooth DIP-switch protocol or baud rate: bridge writes succeed but
+  motors don't respond.
 - Stall false-positives during bringup if encoder GPIO pins are not wired
   (reduce `max_throttle` or raise `stall_throttle_threshold` for bench tests).

--- a/src/lunabot_drivetrain/config/bench_twist_mux.yaml
+++ b/src/lunabot_drivetrain/config/bench_twist_mux.yaml
@@ -1,0 +1,7 @@
+twist_mux:
+  ros__parameters:
+    topics:
+      joystick:
+        topic: cmd_vel_teleop
+        timeout: 0.5
+        priority: 100

--- a/src/lunabot_drivetrain/config/drivetrain.yaml
+++ b/src/lunabot_drivetrain/config/drivetrain.yaml
@@ -1,7 +1,7 @@
 # Drivetrain bridge configuration for the INNEX-1 rover.
 #
 # Hardware: 4x GR-WM4-V4 brushed DC motors driven by 2x Sabertooth 2x32
-# motor controllers via Packetized Serial (one UART, addresses 128 and 129).
+# motor controllers via Legacy Simplified Serial at 9600 baud.
 # Feedback: Hall-sensor quadrature encoders on Jetson GPIO pins.
 #
 # Wheel order: [FL, FR, RL, RR]
@@ -12,8 +12,13 @@ drivetrain_bridge:
     serial_port: "/dev/ttyTHS1"
     baud_rate: 9600
 
-    # Sabertooth Packetized Serial addresses (DIP-switch configured).
-    # Controller 0 drives FL + FR, controller 1 drives RL + RR.
+    # The CDR calls this Simplified Serial. In the Sabertooth 2x32 manual this
+    # byte protocol is Legacy Simplified Serial: Jetson UART TX to S1, with
+    # Jetson and Sabertooth sharing a logic ground.
+    # Use "packetized" only if the Sabertooths are set for Packet Serial.
+    serial_protocol: "legacy_simplified"
+
+    # Packet Serial addresses. Used only when serial_protocol is "packetized".
     sabertooth_addresses: [128, 129]
 
     # --- Kinematics ---
@@ -27,7 +32,7 @@ drivetrain_bridge:
     encoder_counts_per_rev: 720
     # Jetson GPIO pin numbers for encoder channels [A, B] per wheel.
     # [FL_A, FL_B, FR_A, FR_B, RL_A, RL_B, RR_A, RR_B]
-    # Placeholder pins — update to match the actual PCB wiring.
+    # Placeholder pins. Update to match the actual PCB wiring.
     encoder_gpio_pins: [7, 11, 13, 15, 29, 31, 33, 35]
 
     # --- Safety ---

--- a/src/lunabot_drivetrain/launch/drivetrain_bench.launch.py
+++ b/src/lunabot_drivetrain/launch/drivetrain_bench.launch.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Launch the drivetrain bridge for first-motion bench tests."""
 
 from pathlib import Path

--- a/src/lunabot_drivetrain/launch/drivetrain_bench.launch.py
+++ b/src/lunabot_drivetrain/launch/drivetrain_bench.launch.py
@@ -1,0 +1,130 @@
+"""Launch the drivetrain bridge for first-motion bench tests."""
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def _share_path(package: str, *parts: str) -> str:
+    """Return a path inside a package share directory."""
+    return str(Path(get_package_share_directory(package)).joinpath(*parts))
+
+
+def _is_truthy(value: str) -> bool:
+    """Return whether a launch string means true."""
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _create_optional_teleop_nodes(context):
+    """Create joystick teleop and mux nodes only when requested."""
+    if not _is_truthy(LaunchConfiguration("enable_teleop").perform(context)):
+        return []
+
+    teleop_launch_path = _share_path(
+        "lunabot_teleop", "launch", "joystick_teleop.launch.py"
+    )
+    mux_config_path = _share_path(
+        "lunabot_drivetrain", "config", "bench_twist_mux.yaml"
+    )
+
+    joystick_teleop = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(teleop_launch_path),
+        launch_arguments={
+            "joy_device_id": LaunchConfiguration("joy_device_id"),
+            "joy_device_name": LaunchConfiguration("joy_device_name"),
+            "use_sim_time": "false",
+        }.items(),
+    )
+
+    twist_mux = Node(
+        package="twist_mux",
+        executable="twist_mux",
+        name="twist_mux",
+        output="screen",
+        remappings=[("cmd_vel_out", "cmd_vel_safe")],
+        parameters=[mux_config_path],
+    )
+
+    return [joystick_teleop, twist_mux]
+
+
+def generate_launch_description():
+    """Generate the drivetrain bench launch description."""
+    config_path = _share_path("lunabot_drivetrain", "config", "drivetrain.yaml")
+
+    serial_port = LaunchConfiguration("serial_port")
+    baud_rate = LaunchConfiguration("baud_rate")
+    serial_protocol = LaunchConfiguration("serial_protocol")
+    max_throttle = LaunchConfiguration("max_throttle")
+
+    drivetrain_bridge = Node(
+        package="lunabot_drivetrain",
+        executable="drivetrain_bridge",
+        name="drivetrain_bridge",
+        output="screen",
+        parameters=[
+            config_path,
+            {
+                "serial_port": ParameterValue(serial_port, value_type=str),
+                "baud_rate": ParameterValue(baud_rate, value_type=int),
+                "serial_protocol": ParameterValue(
+                    serial_protocol, value_type=str
+                ),
+                "max_throttle": ParameterValue(max_throttle, value_type=float),
+            },
+        ],
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "serial_port",
+                default_value="/dev/ttyTHS1",
+                description="Jetson UART device connected to the Sabertooth S1 pins.",
+            ),
+            DeclareLaunchArgument(
+                "baud_rate",
+                default_value="9600",
+                description="Sabertooth serial baud rate.",
+            ),
+            DeclareLaunchArgument(
+                "serial_protocol",
+                default_value="legacy_simplified",
+                description=(
+                    "Sabertooth protocol: legacy_simplified or packetized."
+                ),
+            ),
+            DeclareLaunchArgument(
+                "max_throttle",
+                default_value="0.2",
+                description="Temporary throttle cap for first-motion tests.",
+            ),
+            DeclareLaunchArgument(
+                "enable_teleop",
+                default_value="false",
+                description="Start joystick teleop and route it to cmd_vel_safe.",
+            ),
+            DeclareLaunchArgument(
+                "joy_device_id",
+                default_value="0",
+                description="SDL device index for the connected controller.",
+            ),
+            DeclareLaunchArgument(
+                "joy_device_name",
+                default_value="",
+                description="Optional SDL controller name to match.",
+            ),
+            drivetrain_bridge,
+            OpaqueFunction(function=_create_optional_teleop_nodes),
+        ]
+    )

--- a/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
@@ -46,6 +46,9 @@ _INHIBIT_QOS = QoSProfile(
 )
 
 _WHEEL_NAMES = ["wheel_fl", "wheel_fr", "wheel_rl", "wheel_rr"]
+_LEGACY_SIMPLIFIED_PROTOCOLS = {"simplified", "legacy_simplified"}
+_PACKETIZED_PROTOCOLS = {"packetized", "packet_serial"}
+_SUPPORTED_PROTOCOLS = _LEGACY_SIMPLIFIED_PROTOCOLS | _PACKETIZED_PROTOCOLS
 
 
 class DrivetrainBridge(Node):
@@ -62,6 +65,7 @@ class DrivetrainBridge(Node):
         self.get_logger().info(
             f"Drivetrain bridge started — "
             f"port={self._serial_port}, "
+            f"protocol={self._serial_protocol}, "
             f"addresses={self._addresses}"
         )
 
@@ -69,6 +73,7 @@ class DrivetrainBridge(Node):
         """Declare all node parameters with defaults."""
         self.declare_parameter("serial_port", "/dev/ttyTHS1")
         self.declare_parameter("baud_rate", 9600)
+        self.declare_parameter("serial_protocol", "legacy_simplified")
         self.declare_parameter("sabertooth_addresses", [128, 129])
         self.declare_parameter("track_width_m", 0.44)
         self.declare_parameter("wheel_radius_m", 0.065)
@@ -85,6 +90,9 @@ class DrivetrainBridge(Node):
         """Read and validate all parameters.  Fail fast on invalid config."""
         self._serial_port = self.get_parameter("serial_port").value
         self._baud_rate = self.get_parameter("baud_rate").value
+        self._serial_protocol = str(
+            self.get_parameter("serial_protocol").value
+        ).strip().lower()
         self._addresses = list(
             self.get_parameter("sabertooth_addresses").value
         )
@@ -109,9 +117,19 @@ class DrivetrainBridge(Node):
         ctrl_hz = self.get_parameter("control_loop_hz").value
         self._telem_hz = self.get_parameter("telemetry_publish_hz").value
 
+        if not str(self._serial_port).strip():
+            raise ValueError("serial_port must not be empty")
+        if self._baud_rate <= 0:
+            raise ValueError(f"baud_rate must be positive: {self._baud_rate}")
         if len(self._addresses) != 2:
             raise ValueError(
                 f"Expected 2 Sabertooth addresses, got {len(self._addresses)}"
+            )
+        if self._serial_protocol not in _SUPPORTED_PROTOCOLS:
+            raise ValueError(
+                "serial_protocol must be one of "
+                f"{sorted(_SUPPORTED_PROTOCOLS)}, "
+                f"got {self._serial_protocol!r}"
             )
         if self._track_width <= 0.0:
             raise ValueError(
@@ -132,6 +150,30 @@ class DrivetrainBridge(Node):
             raise ValueError(
                 f"max_throttle must be in (0, 1]: "
                 f"{self._max_throttle}"
+            )
+        if self._cmd_timeout <= 0.0:
+            raise ValueError(
+                f"command_timeout_s must be positive: {self._cmd_timeout}"
+            )
+        if self._stall_thresh < 0.0:
+            raise ValueError(
+                "stall_throttle_threshold must be zero or positive: "
+                f"{self._stall_thresh}"
+            )
+        if self._stall_min_vel < 0.0:
+            raise ValueError(
+                "stall_min_velocity_rps must be zero or positive: "
+                f"{self._stall_min_vel}"
+            )
+        if self._stall_timeout <= 0.0:
+            raise ValueError(
+                f"stall_timeout_s must be positive: {self._stall_timeout}"
+            )
+        if ctrl_hz <= 0.0:
+            raise ValueError(f"control_loop_hz must be positive: {ctrl_hz}")
+        if self._telem_hz <= 0.0:
+            raise ValueError(
+                f"telemetry_publish_hz must be positive: {self._telem_hz}"
             )
 
         self._control_period = 1.0 / ctrl_hz
@@ -339,7 +381,13 @@ class DrivetrainBridge(Node):
         if self._serial is None:
             return
         try:
-            from lunabot_drivetrain.sabertooth_serial import send_throttle
+            from lunabot_drivetrain.sabertooth_serial import (
+                send_simplified_throttle,
+                send_throttle,
+            )
+            if self._serial_protocol in _LEGACY_SIMPLIFIED_PROTOCOLS:
+                send_simplified_throttle(self._serial, left, right)
+                return
             send_throttle(self._serial, self._addresses[0], left, right)
             send_throttle(self._serial, self._addresses[1], left, right)
         except Exception as exc:
@@ -352,7 +400,13 @@ class DrivetrainBridge(Node):
         if self._serial is None:
             return
         try:
-            from lunabot_drivetrain.sabertooth_serial import send_stop
+            from lunabot_drivetrain.sabertooth_serial import (
+                send_simplified_stop,
+                send_stop,
+            )
+            if self._serial_protocol in _LEGACY_SIMPLIFIED_PROTOCOLS:
+                send_simplified_stop(self._serial)
+                return
             for addr in self._addresses:
                 send_stop(self._serial, addr)
         except Exception as exc:

--- a/src/lunabot_drivetrain/lunabot_drivetrain/sabertooth_serial.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/sabertooth_serial.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Sabertooth 2x32 Packetized Serial protocol driver."""
+"""Sabertooth 2x32 serial protocol helpers."""
 
 from __future__ import annotations
 
@@ -27,6 +27,16 @@ _CMD_M1_FORWARD = 0
 _CMD_M1_REVERSE = 1
 _CMD_M2_FORWARD = 4
 _CMD_M2_REVERSE = 5
+
+
+def _throttle_to_simplified_byte(
+    throttle: float, reverse: int, stop: int, forward: int
+) -> int:
+    """Convert a throttle value to one Legacy Simplified Serial byte."""
+    clamped = max(-1.0, min(1.0, throttle))
+    if clamped >= 0.0:
+        return int(round(stop + clamped * (forward - stop)))
+    return int(round(stop + abs(clamped) * (reverse - stop)))
 
 
 def _pack_command(address: int, command: int, data: int) -> bytes:
@@ -54,6 +64,32 @@ def throttle_to_bytes(
         cmd = fwd_cmd if clamped >= 0.0 else rev_cmd
         frames.extend(_pack_command(address, cmd, data))
     return bytes(frames)
+
+
+def simplified_throttle_to_bytes(
+    m1_throttle: float, m2_throttle: float
+) -> bytes:
+    """Convert two throttles to Sabertooth Legacy Simplified Serial bytes."""
+    return bytes(
+        [
+            _throttle_to_simplified_byte(m1_throttle, 1, 64, 127),
+            _throttle_to_simplified_byte(m2_throttle, 128, 192, 255),
+        ]
+    )
+
+
+def send_simplified_stop(port: serial.Serial) -> None:
+    """Send a full stop using Legacy Simplified Serial."""
+    port.write(simplified_throttle_to_bytes(0.0, 0.0))
+
+
+def send_simplified_throttle(
+    port: serial.Serial,
+    m1_throttle: float,
+    m2_throttle: float,
+) -> None:
+    """Send two motor throttles using Legacy Simplified Serial."""
+    port.write(simplified_throttle_to_bytes(m1_throttle, m2_throttle))
 
 
 def send_stop(port: serial.Serial, address: int) -> None:

--- a/src/lunabot_drivetrain/package.xml
+++ b/src/lunabot_drivetrain/package.xml
@@ -14,6 +14,13 @@
   <depend>std_msgs</depend>
   <depend>lunabot_interfaces</depend>
 
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>lunabot_teleop</exec_depend>
+  <exec_depend>python3-serial</exec_depend>
+  <exec_depend>twist_mux</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/src/lunabot_drivetrain/setup.py
+++ b/src/lunabot_drivetrain/setup.py
@@ -1,8 +1,11 @@
 """Package configuration for lunabot_drivetrain."""
 
+from pathlib import Path
+
 from setuptools import find_packages, setup
 
 package_name = "lunabot_drivetrain"
+package_root = Path(__file__).resolve().parent
 
 setup(
     name=package_name,
@@ -16,7 +19,17 @@ setup(
         ("share/" + package_name, ["package.xml"]),
         (
             "share/" + package_name + "/config",
-            ["config/drivetrain.yaml"],
+            [
+                str(path.relative_to(package_root))
+                for path in package_root.joinpath("config").glob("*.yaml")
+            ],
+        ),
+        (
+            "share/" + package_name + "/launch",
+            [
+                str(path.relative_to(package_root))
+                for path in package_root.joinpath("launch").glob("*.launch.py")
+            ],
         ),
     ],
     install_requires=["setuptools"],

--- a/src/lunabot_drivetrain/test/test_sabertooth_serial.py
+++ b/src/lunabot_drivetrain/test/test_sabertooth_serial.py
@@ -12,15 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for the Sabertooth Packetized Serial encoder."""
+"""Unit tests for the Sabertooth serial encoders."""
+
+import sys
+import types
 
 import pytest
 
-from lunabot_drivetrain.sabertooth_serial import _pack_command, throttle_to_bytes
+import lunabot_drivetrain.sabertooth_serial as sabertooth_serial
+from lunabot_drivetrain.sabertooth_serial import (
+    _pack_command,
+    simplified_throttle_to_bytes,
+    throttle_to_bytes,
+)
+
+try:
+    from lunabot_interfaces.msg import DrivetrainStatus, DrivetrainTelemetry
+except ModuleNotFoundError:
+    fake_msg = types.ModuleType("lunabot_interfaces.msg")
+
+    class DrivetrainStatus:
+        STATE_UNINITIALISED = 0
+        STATE_READY = 1
+        STATE_DRIVING = 2
+        STATE_FAULT = 3
+        STATE_ESTOP = 4
+        FAULT_NONE = 0
+        FAULT_CONTROLLER_OFFLINE = 2
+        FAULT_ENCODER_STALL = 3
+
+    class DrivetrainTelemetry:
+        pass
+
+    fake_msg.DrivetrainStatus = DrivetrainStatus
+    fake_msg.DrivetrainTelemetry = DrivetrainTelemetry
+    sys.modules.setdefault("lunabot_interfaces", types.ModuleType("lunabot_interfaces"))
+    sys.modules["lunabot_interfaces.msg"] = fake_msg
 
 
 class TestPackCommand:
-    """Verify the four-byte Packetized Serial frame encoding."""
+    """Verify the four-byte Packet Serial frame encoding."""
 
     def test_checksum_calculation(self):
         frame = _pack_command(128, 0, 64)
@@ -92,6 +123,22 @@ class TestThrottleToBytes:
             assert cksum == (addr + cmd + data) & 0x7F
 
 
+class TestSimplifiedThrottleToBytes:
+    """Verify Sabertooth Legacy Simplified Serial byte encoding."""
+
+    def test_stop(self):
+        assert simplified_throttle_to_bytes(0.0, 0.0) == bytes([64, 192])
+
+    def test_full_forward_both_motors(self):
+        assert simplified_throttle_to_bytes(1.0, 1.0) == bytes([127, 255])
+
+    def test_full_reverse_both_motors(self):
+        assert simplified_throttle_to_bytes(-1.0, -1.0) == bytes([1, 128])
+
+    def test_half_throttle(self):
+        assert simplified_throttle_to_bytes(0.5, -0.5) == bytes([96, 160])
+
+
 class TestDrivetrainBridgeTwistConversion:
     """Verify the differential drive kinematics (twist → wheel throttles)."""
 
@@ -127,3 +174,97 @@ class TestDrivetrainBridgeTwistConversion:
         left, right = bridge._twist_to_wheel_speeds(10.0, 0.0)
         assert abs(left) <= 0.5
         assert abs(right) <= 0.5
+
+
+class TestDrivetrainBridgeSerialDispatch:
+    """Verify the bridge chooses the configured Sabertooth protocol."""
+
+    def _make_bridge(self, protocol):
+        from lunabot_drivetrain.drivetrain_bridge import DrivetrainBridge
+
+        bridge = object.__new__(DrivetrainBridge)
+        bridge._serial = object()
+        bridge._serial_protocol = protocol
+        bridge._addresses = [128, 129]
+        return bridge
+
+    def test_legacy_simplified_throttle_path(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(
+            sabertooth_serial,
+            "send_simplified_throttle",
+            lambda port, left, right: calls.append((port, left, right)),
+        )
+        monkeypatch.setattr(
+            sabertooth_serial,
+            "send_throttle",
+            lambda *args: pytest.fail(f"unexpected packet call: {args}"),
+        )
+
+        bridge = self._make_bridge("legacy_simplified")
+        bridge._send_wheel_throttles(0.2, -0.1)
+
+        assert calls == [(bridge._serial, 0.2, -0.1)]
+
+    def test_packetized_throttle_path(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(
+            sabertooth_serial,
+            "send_simplified_throttle",
+            lambda *args: pytest.fail(f"unexpected simplified call: {args}"),
+        )
+        monkeypatch.setattr(
+            sabertooth_serial,
+            "send_throttle",
+            lambda port, address, left, right: calls.append(
+                (port, address, left, right)
+            ),
+        )
+
+        bridge = self._make_bridge("packetized")
+        bridge._send_wheel_throttles(0.2, -0.1)
+
+        assert calls == [
+            (bridge._serial, 128, 0.2, -0.1),
+            (bridge._serial, 129, 0.2, -0.1),
+        ]
+
+    def test_legacy_simplified_stop_path(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(
+            sabertooth_serial,
+            "send_simplified_stop",
+            lambda port: calls.append(port),
+        )
+        monkeypatch.setattr(
+            sabertooth_serial,
+            "send_stop",
+            lambda *args: pytest.fail(f"unexpected packet stop: {args}"),
+        )
+
+        bridge = self._make_bridge("simplified")
+        bridge._send_stop()
+
+        assert calls == [bridge._serial]
+
+    def test_packetized_stop_path(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(
+            sabertooth_serial,
+            "send_simplified_stop",
+            lambda *args: pytest.fail(f"unexpected simplified stop: {args}"),
+        )
+        monkeypatch.setattr(
+            sabertooth_serial,
+            "send_stop",
+            lambda port, address: calls.append((port, address)),
+        )
+
+        bridge = self._make_bridge("packet_serial")
+        bridge._send_stop()
+
+        assert calls == [(bridge._serial, 128), (bridge._serial, 129)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Adds Jetson Sabertooth drivetrain bench bring-up support, enabling hands-on testing and development of the drivetrain system with comprehensive documentation and launch infrastructure.

## Key Changes

### Documentation & Configuration
- Added new dedicated bring-up guide (`jetson_sabertooth_bringup.md`) with step-by-step instructions for Jetson setup, workspace building, and motion testing
- Updated drivetrain README with Jetson bench bring-up section and revised hardware/protocol guidance
- Switched default motor control protocol to Legacy Simplified Serial while maintaining Packet Serial support
- Added joystick-based twist_mux configuration for teleoperation testing

### Bench Testing Infrastructure
- New bench launch file with configurable options for drivetrain bridge startup, optional teleop control, and throttle settings
- Dynamic discovery system for launch and config files in setup.py

### Protocol Support & Serial Communication
- Extended drivetrain bridge to support multiple Sabertooth serial protocols (Legacy Simplified and Packet Serial)
- Added Legacy Simplified Serial helper functions for throttle encoding and stop commands
- Expanded parameter validation for protocol selection, serial configuration, and hardware parameters

### Testing & Dependencies
- Expanded test suite with simplified throttle encoding tests and serial dispatch behavior verification
- Added runtime dependencies: launch infrastructure, teleop support, twist_mux, serial communication, and indexing utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->