### PR TITLE
Move Nexy runner setup off external drives

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - rover-review

--- a/.github/workflows/rover-codex-review.yml
+++ b/.github/workflows/rover-codex-review.yml
@@ -21,6 +21,7 @@ concurrency:
       (
         github.event_name == 'issue_comment' &&
         github.actor != 'innex1-reviewer[bot]' &&
+        (contains(github.event.comment.body, '/innex') || contains(github.event.comment.body, '/nexy')) &&
         contains(github.event.comment.body, '/innex status') == false &&
         contains(github.event.comment.body, '/innex help') == false &&
         contains(github.event.comment.body, '/nexy status') == false &&
@@ -36,7 +37,7 @@ jobs:
       github.event.issue.pull_request &&
       (contains(github.event.comment.body, '/innex help') || contains(github.event.comment.body, '/nexy help')) &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, rover-review]
     permissions:
       issues: write
       contents: read
@@ -103,7 +104,7 @@ jobs:
       contains(github.event.comment.body, '/innex help') == false &&
       contains(github.event.comment.body, '/nexy help') == false &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, rover-review]
     permissions:
       issues: write
       pull-requests: read
@@ -183,7 +184,7 @@ jobs:
         contains(github.event.comment.body, '/nexy status') == false &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       )
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, rover-review]
     permissions:
       contents: read
       pull-requests: write

--- a/docs/innex-review-app.md
+++ b/docs/innex-review-app.md
@@ -69,6 +69,40 @@ model: openai/gpt-5.2
 
 That is the normal review model. Keep heavier models for a future explicit deep-review mode if we decide the extra cost is worth it.
 
+## Laptop-Local Runtime
+
+Run the Nexy worker from the laptop's internal disk, not from an external SSD. GitHub Actions keeps runner state, job locks and checkouts under the runner install directory; if that directory disappears mid-job, GitHub can be left with an offline-but-busy runner and a review stuck in progress.
+
+Set up the stable local runtime with:
+
+```bash
+scripts/setup_nexy_laptop_runtime.sh --configure-runner
+```
+
+By default this creates:
+
+```text
+~/nexy/innex1-rover-review
+~/actions-runners/innex1-rover
+```
+
+Start LiteLLM in one terminal:
+
+```bash
+~/nexy/innex1-rover-review/start_litellm_rover_review.sh
+```
+
+Start the runner in another terminal:
+
+```bash
+cd ~/actions-runners/innex1-rover
+./run.sh
+```
+
+The workflow targets runners labelled `rover-review`, so this worker must keep that label. The setup script configures it automatically.
+
+The job still checks out the PR and automation code into the runner workspace. The important bit is that the workspace is now under `~/actions-runners/innex1-rover/_work`, so closing or unplugging an external drive does not remove the running job from underneath GitHub Actions.
+
 ## Local Cleanup
 
 After local experiments, run:

--- a/scripts/setup_nexy_laptop_runtime.sh
+++ b/scripts/setup_nexy_laptop_runtime.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${NEXY_REPO:-KJdotIO/innex1-rover}"
+nexy_home="${NEXY_HOME:-${HOME}/nexy/innex1-rover-review}"
+runner_home="${NEXY_RUNNER_HOME:-${HOME}/actions-runners/innex1-rover}"
+runner_name="${NEXY_RUNNER_NAME:-$(hostname -s)-rover-review}"
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--configure-runner]
+
+Installs the laptop-local Nexy runtime outside any external-drive checkout.
+
+Environment overrides:
+  NEXY_REPO          GitHub repo, default: ${repo}
+  NEXY_HOME          LiteLLM wrapper/config directory, default: ${nexy_home}
+  NEXY_RUNNER_HOME   GitHub runner install directory, default: ${runner_home}
+  NEXY_RUNNER_NAME   Runner name, default: ${runner_name}
+
+Options:
+  --configure-runner  Download/configure the GitHub Actions runner.
+  -h, --help          Show this help.
+USAGE
+}
+
+configure_runner=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --configure-runner)
+      configure_runner=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_command gh
+require_command python3
+require_command curl
+require_command tar
+
+gh auth status >/dev/null
+
+mkdir -p "${nexy_home}"
+cp .github/codex/litellm-config.yaml "${nexy_home}/litellm-config.yaml"
+
+cat > "${nexy_home}/start_litellm_rover_review.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export VIBEPROXY_API_KEY="${VIBEPROXY_API_KEY:-sk-vibeproxy-local}"
+export LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-local-rover-review}"
+
+uvx --from 'litellm[proxy]' litellm \
+  --config "${script_dir}/litellm-config.yaml" \
+  --host 127.0.0.1 \
+  --port 4000
+SH
+chmod +x "${nexy_home}/start_litellm_rover_review.sh"
+
+if [ "${configure_runner}" = "1" ]; then
+  require_command uname
+  arch="$(uname -m)"
+  if [ "${arch}" != "arm64" ]; then
+    echo "This installer currently expects macOS arm64; got ${arch}." >&2
+    exit 1
+  fi
+
+  mkdir -p "${runner_home}"
+
+  if [ ! -x "${runner_home}/config.sh" ]; then
+    tmp_dir="$(mktemp -d)"
+    cleanup() {
+      rm -rf "${tmp_dir}"
+    }
+    trap cleanup EXIT
+
+    asset_url="$(python3 - <<'PY'
+import json
+import urllib.request
+
+with urllib.request.urlopen("https://api.github.com/repos/actions/runner/releases/latest") as response:
+    release = json.load(response)
+
+for asset in release["assets"]:
+    name = asset["name"]
+    if name.startswith("actions-runner-osx-arm64-") and name.endswith(".tar.gz"):
+        print(asset["browser_download_url"])
+        break
+else:
+    raise SystemExit("No osx-arm64 runner asset found in latest release")
+PY
+)"
+    curl -L "${asset_url}" -o "${tmp_dir}/actions-runner-osx-arm64.tar.gz"
+    tar -xzf "${tmp_dir}/actions-runner-osx-arm64.tar.gz" -C "${runner_home}"
+  fi
+
+  token="$(gh api -X POST "repos/${repo}/actions/runners/registration-token" --jq .token)"
+  (
+    cd "${runner_home}"
+    ./config.sh \
+      --unattended \
+      --url "https://github.com/${repo}" \
+      --token "${token}" \
+      --name "${runner_name}" \
+      --work _work \
+      --labels rover-review \
+      --replace
+  )
+fi
+
+cat <<EOF
+Nexy laptop runtime is ready.
+
+LiteLLM:
+  ${nexy_home}/start_litellm_rover_review.sh
+
+Runner:
+  cd ${runner_home}
+  ./run.sh
+
+The runner workspace will live under:
+  ${runner_home}/_work
+EOF


### PR DESCRIPTION
## What changed

This moves the local Nexy review runtime away from external-drive paths:

- adds `scripts/setup_nexy_laptop_runtime.sh` to install LiteLLM config/wrappers under `~/nexy/innex1-rover-review` and optionally configure the GitHub Actions runner under `~/actions-runners/innex1-rover`
- documents the laptop-local runtime flow in `docs/innex-review-app.md`
- targets Nexy jobs at the `rover-review` runner label
- tightens workflow concurrency so unrelated PR comments do not cancel an active Nexy review

## Why

The previous local runner lived under `/Volumes/externalssd`. If that drive was unplugged mid-job, GitHub could be left with a runner that was offline but still busy, and a review run stuck in progress. Keeping the runner install and `_work` directory on the laptop's internal disk removes that failure mode.

## Validation

```text
bash -n scripts/setup_nexy_laptop_runtime.sh scripts/start_litellm_rover_review.sh scripts/run_rover_review_local.sh scripts/clean_innex_review_artifacts.sh
ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "ok #{p}" }' .github/workflows/rover-codex-review.yml .github/codex/litellm-config.yaml
git diff --check
scripts/setup_nexy_laptop_runtime.sh
NEXY_RUNNER_NAME=dot-macbook-rover-review scripts/setup_nexy_laptop_runtime.sh --configure-runner
```

Smoke state before opening this PR:

```text
LiteLLM serving on 127.0.0.1:4000
GitHub runner dot-macbook-rover-review online with labels self-hosted, macOS, ARM64, rover-review
```
