### PR TITLE
fix(drivetrain): fail closed before gated motion

### DIFF
--- a/docs/jetson_sabertooth_bringup.md
+++ b/docs/jetson_sabertooth_bringup.md
@@ -49,6 +49,11 @@ Start with a low throttle cap:
 ros2 launch lunabot_drivetrain drivetrain_bench.launch.py max_throttle:=0.2
 ```
 
+This launch starts the drivetrain bridge and velocity gate. Keep
+`dry_run:=false` for real first-motion tests: if the serial controller is
+missing, the bridge faults and the gate stays closed. Use `dry_run:=true` only
+when you deliberately want a no-motor-output dry run.
+
 If the Sabertooth UART is not `/dev/ttyTHS1`, pass the actual device:
 
 ```bash
@@ -110,6 +115,8 @@ game_controller_node
   -> /cmd_vel_teleop
   -> twist_mux
   -> /cmd_vel_safe
+  -> velocity_gate
+  -> /cmd_vel_gated
   -> drivetrain_bridge
   -> Jetson UART TX
   -> Sabertooth S1

--- a/src/lunabot_drivetrain/README.md
+++ b/src/lunabot_drivetrain/README.md
@@ -13,9 +13,9 @@ encoder-derived odometry and telemetry.
   "Simplified Serial" wiring. Packet Serial is also supported by setting
   `serial_protocol:=packetized`.
 
-If the serial port is unavailable at startup the bridge enters **dry-run
-mode**: no motor output, but all ROS interfaces remain active. This allows
-desktop testing without hardware.
+Real hardware launches fail closed if the serial port is unavailable. For
+desktop or Jetson dry-runs without motor output, set `dry_run:=true`
+explicitly.
 
 ## Nodes
 
@@ -26,7 +26,7 @@ them to both Sabertooth controllers, and publishes status/telemetry.
 
 | Direction | Topic | Type |
 |-----------|-------|------|
-| Subscribe | `/cmd_vel_safe` | `geometry_msgs/Twist` |
+| Subscribe | `/cmd_vel_gated` | `geometry_msgs/Twist` |
 | Subscribe | `/safety/motion_inhibit` | `std_msgs/Bool` (transient-local) |
 | Subscribe | `/safety/estop` | `std_msgs/Bool` |
 | Publish | `/drivetrain/status` | `lunabot_interfaces/DrivetrainStatus` |
@@ -119,7 +119,8 @@ ros2 launch lunabot_drivetrain drivetrain_bench.launch.py enable_teleop:=true ma
 The joystick path is:
 
 `game_controller_node` → `/joy` → `teleop_twist_joy` → `/cmd_vel_teleop` →
-`twist_mux` → `/cmd_vel_safe` → `drivetrain_bridge` → Sabertooth serial.
+`twist_mux` → `/cmd_vel_safe` → `velocity_gate` → `/cmd_vel_gated` →
+`drivetrain_bridge` → Sabertooth serial.
 
 If the controller is not picked up as device `0`, try:
 

--- a/src/lunabot_drivetrain/config/drivetrain.yaml
+++ b/src/lunabot_drivetrain/config/drivetrain.yaml
@@ -18,6 +18,14 @@ drivetrain_bridge:
     # Use "packetized" only if the Sabertooths are set for Packet Serial.
     serial_protocol: "legacy_simplified"
 
+    # Real hardware should fail closed if the serial controller is missing.
+    # Set true only for explicit desktop/Jetson dry-runs with no motor output.
+    dry_run: false
+
+    # Consume the safety-gated command stream, not the raw collision-monitor
+    # output. The velocity_gate publishes zero when drivetrain health is bad.
+    cmd_vel_topic: "/cmd_vel_gated"
+
     # Packet Serial addresses. Used only when serial_protocol is "packetized".
     sabertooth_addresses: [128, 129]
 

--- a/src/lunabot_drivetrain/launch/drivetrain_bench.launch.py
+++ b/src/lunabot_drivetrain/launch/drivetrain_bench.launch.py
@@ -80,6 +80,7 @@ def generate_launch_description():
     baud_rate = LaunchConfiguration("baud_rate")
     serial_protocol = LaunchConfiguration("serial_protocol")
     max_throttle = LaunchConfiguration("max_throttle")
+    dry_run = LaunchConfiguration("dry_run")
 
     drivetrain_bridge = Node(
         package="lunabot_drivetrain",
@@ -95,8 +96,16 @@ def generate_launch_description():
                     serial_protocol, value_type=str
                 ),
                 "max_throttle": ParameterValue(max_throttle, value_type=float),
+                "dry_run": ParameterValue(dry_run, value_type=bool),
             },
         ],
+    )
+
+    velocity_gate = Node(
+        package="lunabot_drivetrain",
+        executable="velocity_gate",
+        name="velocity_gate",
+        output="screen",
     )
 
     return LaunchDescription(
@@ -124,9 +133,17 @@ def generate_launch_description():
                 description="Temporary throttle cap for first-motion tests.",
             ),
             DeclareLaunchArgument(
+                "dry_run",
+                default_value="false",
+                description=(
+                    "Allow launch without a serial controller. Keep false for "
+                    "real first-motion tests so missing hardware fails closed."
+                ),
+            ),
+            DeclareLaunchArgument(
                 "enable_teleop",
                 default_value="false",
-                description="Start joystick teleop and route it to cmd_vel_safe.",
+                description="Start joystick teleop and route it through the safety gate.",
             ),
             DeclareLaunchArgument(
                 "joy_device_id",
@@ -138,6 +155,7 @@ def generate_launch_description():
                 default_value="",
                 description="Optional SDL controller name to match.",
             ),
+            velocity_gate,
             drivetrain_bridge,
             OpaqueFunction(function=_create_optional_teleop_nodes),
         ]

--- a/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
@@ -66,6 +66,8 @@ class DrivetrainBridge(Node):
             f"Drivetrain bridge started — "
             f"port={self._serial_port}, "
             f"protocol={self._serial_protocol}, "
+            f"dry_run={self._dry_run}, "
+            f"cmd_vel_topic={self._cmd_vel_topic}, "
             f"addresses={self._addresses}"
         )
 
@@ -74,6 +76,8 @@ class DrivetrainBridge(Node):
         self.declare_parameter("serial_port", "/dev/ttyTHS1")
         self.declare_parameter("baud_rate", 9600)
         self.declare_parameter("serial_protocol", "legacy_simplified")
+        self.declare_parameter("dry_run", False)
+        self.declare_parameter("cmd_vel_topic", "/cmd_vel_gated")
         self.declare_parameter("sabertooth_addresses", [128, 129])
         self.declare_parameter("track_width_m", 0.44)
         self.declare_parameter("wheel_radius_m", 0.065)
@@ -93,6 +97,10 @@ class DrivetrainBridge(Node):
         self._serial_protocol = str(
             self.get_parameter("serial_protocol").value
         ).strip().lower()
+        self._dry_run = bool(self.get_parameter("dry_run").value)
+        self._cmd_vel_topic = str(
+            self.get_parameter("cmd_vel_topic").value
+        ).strip()
         self._addresses = list(
             self.get_parameter("sabertooth_addresses").value
         )
@@ -131,6 +139,8 @@ class DrivetrainBridge(Node):
                 f"{sorted(_SUPPORTED_PROTOCOLS)}, "
                 f"got {self._serial_protocol!r}"
             )
+        if not self._cmd_vel_topic:
+            raise ValueError("cmd_vel_topic must not be empty")
         if self._track_width <= 0.0:
             raise ValueError(
                 f"track_width_m must be positive: "
@@ -197,7 +207,7 @@ class DrivetrainBridge(Node):
         self._serial: Any = None
 
     def _init_serial(self) -> None:
-        """Open the UART serial port.  Logs a warning if unavailable."""
+        """Open the UART serial port, failing closed unless dry-run is explicit."""
         try:
             import serial as pyserial
             self._serial = pyserial.Serial(
@@ -209,18 +219,33 @@ class DrivetrainBridge(Node):
             self._state = DrivetrainStatus.STATE_READY
             self.get_logger().info(f"Serial port {self._serial_port} opened")
         except Exception as exc:
-            self.get_logger().warn(
-                f"Serial port {self._serial_port} unavailable: {exc}. "
-                f"Running in dry-run mode (no motor output)."
-            )
             self._serial = None
             self._controller_online = [False, False]
+            self._handle_serial_unavailable(exc)
+
+    def _handle_serial_unavailable(self, exc: Exception) -> None:
+        """Put the bridge in the configured no-serial state."""
+        if self._dry_run:
+            self.get_logger().warn(
+                f"Serial port {self._serial_port} unavailable: {exc}. "
+                "Explicit dry-run enabled, so motor output is disabled "
+                "but ROS interfaces stay active."
+            )
             self._state = DrivetrainStatus.STATE_READY
+            return
+
+        self.get_logger().error(
+            f"Serial port {self._serial_port} unavailable: {exc}. "
+            "dry_run is false, so drivetrain bridge is FAULTED and "
+            "will not accept motion commands."
+        )
+        self._fault_code = DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
+        self._state = DrivetrainStatus.STATE_FAULT
 
     def _init_ros(self) -> None:
         """Set up publishers, subscribers, and timers."""
         self._cmd_vel_sub = self.create_subscription(
-            Twist, "/cmd_vel_safe", self._cmd_vel_callback, 10
+            Twist, self._cmd_vel_topic, self._cmd_vel_callback, 10
         )
         self._inhibit_sub = self.create_subscription(
             Bool,

--- a/src/lunabot_drivetrain/test/test_velocity_gate.py
+++ b/src/lunabot_drivetrain/test/test_velocity_gate.py
@@ -84,3 +84,38 @@ class TestStallDetection:
         bridge._wheel_velocity_rps = [0.1, 0.1, 0.1, 0.1]
         bridge._check_encoder_stall(1.0, 0.5, 0.5)
         assert bridge._stall_start_time is None
+
+
+class TestDrivetrainBridgeReadiness:
+    """Verify hardware readiness defaults fail closed."""
+
+    def _make_bridge(self, dry_run):
+        from unittest.mock import MagicMock
+
+        from lunabot_drivetrain.drivetrain_bridge import DrivetrainBridge
+
+        bridge = object.__new__(DrivetrainBridge)
+        bridge._dry_run = dry_run
+        bridge._serial_port = "/dev/missing"
+        bridge._fault_code = DrivetrainStatus.FAULT_NONE
+        bridge._state = DrivetrainStatus.STATE_UNINITIALISED
+        bridge.get_logger = MagicMock()
+        return bridge
+
+    def test_missing_serial_faults_when_not_dry_run(self):
+        bridge = self._make_bridge(dry_run=False)
+
+        bridge._handle_serial_unavailable(RuntimeError("missing"))
+
+        assert bridge._state == DrivetrainStatus.STATE_FAULT
+        assert bridge._fault_code == DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
+        bridge.get_logger().error.assert_called_once()
+
+    def test_missing_serial_stays_ready_when_dry_run_is_explicit(self):
+        bridge = self._make_bridge(dry_run=True)
+
+        bridge._handle_serial_unavailable(RuntimeError("missing"))
+
+        assert bridge._state == DrivetrainStatus.STATE_READY
+        assert bridge._fault_code == DrivetrainStatus.FAULT_NONE
+        bridge.get_logger().warn.assert_called_once()


### PR DESCRIPTION
## Summary
- route drivetrain bench motion through `velocity_gate` and `/cmd_vel_gated`
- make missing Sabertooth serial fail closed unless `dry_run:=true` is explicit
- document the hardware/dry-run split and add unit coverage for missing-serial readiness

## Testing
- `ruff check src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py src/lunabot_drivetrain/lunabot_drivetrain/velocity_gate.py src/lunabot_drivetrain/launch/drivetrain_bench.launch.py src/lunabot_drivetrain/test/test_velocity_gate.py`
- `python3 -m py_compile src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py src/lunabot_drivetrain/lunabot_drivetrain/velocity_gate.py src/lunabot_drivetrain/launch/drivetrain_bench.launch.py`
- Jetson: `colcon build --symlink-install --packages-select lunabot_interfaces lunabot_drivetrain`
- Jetson: `colcon test --packages-select lunabot_drivetrain --event-handlers console_direct+ && colcon test-result --verbose` (37 passed)
- Jetson runtime: `drivetrain_bench.launch.py dry_run:=false` publishes `state: FAULT`, `fault_code: CONTROLLER_OFFLINE` when serial is unavailable
- Jetson runtime: `drivetrain_bench.launch.py dry_run:=true` publishes `state: READY`, `fault_code: NONE` with no controller online

No Nexy review run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR introduces a velocity gate in the drivetrain control pipeline and implements fail-closed behavior for missing hardware serial connections, ensuring safe defaults for real hardware deployments.

## Key Changes

### Fail-Closed Behavior for Missing Serial
- `DrivetrainBridge` now defaults to fail-closed mode: when the Sabertooth serial port is unavailable, the node enters a `FAULT` state with an offline controller error instead of silently continuing
- This behavior can be overridden with an explicit `dry_run:=true` parameter for desktop/simulation testing without motor output

### Velocity Gate Integration
- Introduced a new `velocity_gate` node in the drivetrain launch pipeline that sits between motion planning and the actual drivetrain bridge
- The drivetrain bridge now subscribes to `/cmd_vel_gated` (the safety-gated command stream) instead of directly consuming raw commands
- The velocity gate is always launched as part of the bench bringup

### Configuration Updates
- Added `dry_run` parameter (defaults to `false`) to distinguish between real hardware and simulation/dry-run modes
- Added configurable `cmd_vel_topic` parameter pointing to the gated command stream (`/cmd_vel_gated`)

### Test Coverage
- Added unit tests validating the fail-closed behavior: when the serial port is missing and `dry_run=false`, the bridge faults; when `dry_run=true`, it stays ready

### Documentation
- Updated documentation to clarify the hardware/dry-run split and when each mode should be used
- Updated signal path diagrams and node descriptions to reflect the new velocity gate component in the control chain

<!-- end of auto-generated comment: release notes by coderabbit.ai -->