### PR TITLE
feat(mission): publish passive operator telemetry

### DIFF
--- a/.github/contracts/interface_contracts.json
+++ b/.github/contracts/interface_contracts.json
@@ -11,6 +11,41 @@
       "type": "lunabot_interfaces/action/Deposit",
       "kind": "action_server",
       "source": "src/lunabot_control/lunabot_control/material_action_server.py"
+    },
+    {
+      "name": "/mission/state",
+      "type": "std_msgs/msg/String",
+      "kind": "publisher",
+      "source": "src/lunabot_bringup/lunabot_bringup/mission_manager.py",
+      "phases": ["runtime"]
+    },
+    {
+      "name": "/mission/autonomy_mode",
+      "type": "std_msgs/msg/String",
+      "kind": "publisher",
+      "source": "src/lunabot_bringup/lunabot_bringup/mission_manager.py",
+      "phases": ["runtime"]
+    },
+    {
+      "name": "/mission/time_remaining_s",
+      "type": "std_msgs/msg/Float32",
+      "kind": "publisher",
+      "source": "src/lunabot_bringup/lunabot_bringup/mission_manager.py",
+      "phases": ["runtime"]
+    },
+    {
+      "name": "/mission/cycle_count",
+      "type": "std_msgs/msg/Int32",
+      "kind": "publisher",
+      "source": "src/lunabot_bringup/lunabot_bringup/mission_manager.py",
+      "phases": ["runtime"]
+    },
+    {
+      "name": "/mission/last_failure_reason",
+      "type": "std_msgs/msg/String",
+      "kind": "publisher",
+      "source": "src/lunabot_bringup/lunabot_bringup/mission_manager.py",
+      "phases": ["runtime"]
     }
   ],
   "tf_links": [
@@ -42,11 +77,6 @@
   ],
   "deferred_topics": [
     "/ouster/points",
-    "/mission/state",
-    "/mission/autonomy_mode",
-    "/mission/time_remaining_s",
-    "/mission/cycle_count",
-    "/mission/last_failure_reason",
     "/drivetrain/command",
     "/drivetrain/telemetry",
     "/drivetrain/status"

--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -59,6 +59,21 @@ The mission manager subscribes to `/safety/estop` and `/safety/motion_inhibit`
 signals — if either is active the attempt is short-circuited with a safety-stop
 failure, and no action goal is sent.
 
+### Passive operator telemetry
+
+The mission manager publishes a small Foxglove-friendly state contract:
+
+| Topic | Type | Meaning |
+|-------|------|---------|
+| `/mission/state` | `std_msgs/String` | Current FSM state, lower-case |
+| `/mission/autonomy_mode` | `std_msgs/String` | `idle`, `autonomous`, `motion_inhibited`, `estop`, `safe_fail`, or `halted` |
+| `/mission/time_remaining_s` | `std_msgs/Float32` | Remaining time from the 1200 s mission budget |
+| `/mission/cycle_count` | `std_msgs/Int32` | Completed excavation/deposition cycles |
+| `/mission/last_failure_reason` | `std_msgs/String` | Last terminal or safety failure reason |
+
+These topics are passive telemetry only. They are safe to show in Foxglove
+during autonomy because they do not provide a command path back into the rover.
+
 ## Mission Dry Run
 
 Use the dry-run launch when you want one bounded operator-facing regression pass in sim:

--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -16,7 +16,7 @@ from rclpy.qos import (
     QoSProfile,
     ReliabilityPolicy,
 )
-from std_msgs.msg import Bool
+from std_msgs.msg import Bool, Float32, Int32, String
 
 from lunabot_bringup.mission_timer import MissionTimer
 from lunabot_interfaces.action import Deposit, Excavate
@@ -27,6 +27,15 @@ _INHIBIT_QOS = QoSProfile(
     reliability=ReliabilityPolicy.RELIABLE,
     durability=DurabilityPolicy.TRANSIENT_LOCAL,
 )
+
+_OPERATOR_STATE_QOS = QoSProfile(
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    reliability=ReliabilityPolicy.RELIABLE,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
+)
+
+MISSION_LIMIT_S = 1200.0
 
 
 class MissionState(IntEnum):
@@ -64,7 +73,6 @@ class MissionManager(Node):
         """Initialise the node, declare parameters, and create action clients."""
         super().__init__("mission_manager")
 
-        self.declare_parameter("use_sim_time", False)
         self.declare_parameter("prehoc_v_estimated_mps", 0.3)
         self.declare_parameter("prehoc_t_margin_s", 60.0)
         self.declare_parameter("prehoc_s_start_exc_m", 5.0)
@@ -101,6 +109,8 @@ class MissionManager(Node):
         self._cycle_count = 0
         self._estop_active = False
         self._motion_inhibited = False
+        self._last_failure_reason = ""
+        self._mission_active = False
 
         self._state: MissionState = MissionState.INITIALIZE_MISSION
         self._timer: MissionTimer | None = None
@@ -130,6 +140,25 @@ class MissionManager(Node):
         self._estop_sub = self.create_subscription(
             Bool, "/safety/estop", self._estop_cb, 10
         )
+        self._mission_state_pub = self.create_publisher(
+            String, "/mission/state", _OPERATOR_STATE_QOS
+        )
+        self._autonomy_mode_pub = self.create_publisher(
+            String, "/mission/autonomy_mode", _OPERATOR_STATE_QOS
+        )
+        self._time_remaining_pub = self.create_publisher(
+            Float32, "/mission/time_remaining_s", _OPERATOR_STATE_QOS
+        )
+        self._cycle_count_pub = self.create_publisher(
+            Int32, "/mission/cycle_count", _OPERATOR_STATE_QOS
+        )
+        self._failure_reason_pub = self.create_publisher(
+            String, "/mission/last_failure_reason", _OPERATOR_STATE_QOS
+        )
+        self._operator_state_timer = self.create_timer(
+            1.0, self._publish_operator_state
+        )
+        self._publish_operator_state()
 
     def _inhibit_cb(self, msg: Bool) -> None:
         """Track motion inhibit for safety gating."""
@@ -142,6 +171,64 @@ class MissionManager(Node):
     def _is_safe(self) -> bool:
         """Return True if the rover is safe to operate."""
         return not self._estop_active and not self._motion_inhibited
+
+    def _state_text(self) -> str:
+        """Return the current mission state as lower-case operator text."""
+        return self._state.name.lower()
+
+    def _autonomy_mode_text(self) -> str:
+        """Return a passive operator-facing autonomy mode."""
+        if self._estop_active:
+            return "estop"
+        if self._motion_inhibited:
+            return "motion_inhibited"
+        if self._state == MissionState.HALT_MISSION:
+            return "halted"
+        if self._state == MissionState.SAFE_FAIL:
+            return "safe_fail"
+        if self._mission_active:
+            return "autonomous"
+        return "idle"
+
+    def _time_remaining_s(self) -> float:
+        """Return remaining competition mission time in seconds."""
+        if self._timer is None:
+            return MISSION_LIMIT_S
+        try:
+            elapsed = float(self._timer.elapsedMissionTime())
+        except (AttributeError, TypeError, ValueError):
+            return MISSION_LIMIT_S
+        if not math.isfinite(elapsed):
+            return MISSION_LIMIT_S
+        elapsed = max(0.0, elapsed)
+        return max(0.0, MISSION_LIMIT_S - elapsed)
+
+    def _publish_operator_state(self) -> None:
+        """Publish passive mission telemetry for Foxglove and bags."""
+        state_msg = String()
+        state_msg.data = self._state_text()
+        self._mission_state_pub.publish(state_msg)
+
+        mode_msg = String()
+        mode_msg.data = self._autonomy_mode_text()
+        self._autonomy_mode_pub.publish(mode_msg)
+
+        time_msg = Float32()
+        time_msg.data = float(self._time_remaining_s())
+        self._time_remaining_pub.publish(time_msg)
+
+        cycle_msg = Int32()
+        cycle_msg.data = int(self._cycle_count)
+        self._cycle_count_pub.publish(cycle_msg)
+
+        failure_msg = String()
+        failure_msg.data = self._last_failure_reason
+        self._failure_reason_pub.publish(failure_msg)
+
+    def _set_failure_reason(self, reason: str) -> None:
+        """Record the latest mission failure reason and publish it."""
+        self._last_failure_reason = reason
+        self._publish_operator_state()
 
     def _retry_action(
         self,
@@ -168,15 +255,20 @@ class MissionManager(Node):
 
     def run_mission(self) -> None:
         """Advance the FSM until HALT_MISSION is reached."""
+        self._mission_active = True
+        self._publish_operator_state()
         while self._state != MissionState.HALT_MISSION:
             if not self._is_safe():
-                self.get_logger().error(
-                    "Safety stop during mission — halting"
-                )
+                reason = "Safety stop during mission"
+                self.get_logger().error(f"{reason} — halting")
+                self._set_failure_reason(reason)
                 self._state = MissionState.HALT_MISSION
+                self._publish_operator_state()
                 break
             self._step()
 
+        self._mission_active = False
+        self._publish_operator_state()
         self.get_logger().info(
             f"Mission halted after {self._cycle_count} cycles."
         )
@@ -208,7 +300,10 @@ class MissionManager(Node):
             self._state = MissionState.HALT_MISSION
             return
 
-        self._state = handler()
+        next_state = handler()
+        if next_state != self._state:
+            self._state = next_state
+            self._publish_operator_state()
 
     # ------------------------------------------------------------------
     # State handlers
@@ -282,13 +377,16 @@ class MissionManager(Node):
             or s_start_exc is None
             or s_exc_dep is None
         ):
+            self._set_failure_reason("Invalid pre-hoc traversal parameters")
             return MissionState.HALT_MISSION
 
         if not math.isfinite(v) or v <= 0.0:
-            self.get_logger().error(
+            reason = (
                 "Invalid pre-hoc traversal parameter "
                 "'prehoc_v_estimated_mps'; expected a finite value > 0.0."
             )
+            self.get_logger().error(reason)
+            self._set_failure_reason(reason)
             return MissionState.HALT_MISSION
 
         invalid_non_negative_params = []
@@ -301,10 +399,12 @@ class MissionManager(Node):
 
         if invalid_non_negative_params:
             invalid_param_names = ", ".join(invalid_non_negative_params)
-            self.get_logger().error(
+            reason = (
                 "Invalid pre-hoc traversal parameter(s) "
                 f"{invalid_param_names}; expected finite values >= 0.0."
             )
+            self.get_logger().error(reason)
+            self._set_failure_reason(reason)
             return MissionState.HALT_MISSION
 
         t_prehoc = (s_start_exc / v) + (s_exc_dep / v) + t_margin
@@ -319,6 +419,9 @@ class MissionManager(Node):
 
         self.get_logger().info(
             f"Pre-hoc estimate {t_prehoc:.1f}s would exceed budget; halting."
+        )
+        self._set_failure_reason(
+            f"Pre-hoc estimate {t_prehoc:.1f}s would exceed mission budget"
         )
         return MissionState.HALT_MISSION
 
@@ -336,9 +439,9 @@ class MissionManager(Node):
             self._max_nav_retries,
         )
         if not success:
-            self.get_logger().error(
-                f"Navigation to excavation failed: {detail}"
-            )
+            reason = f"Navigation to excavation failed: {detail}"
+            self.get_logger().error(reason)
+            self._set_failure_reason(reason)
             return MissionState.SAFE_FAIL
         return MissionState.EXCAVATE
 
@@ -351,9 +454,9 @@ class MissionManager(Node):
             self._max_exc_retries,
         )
         if not success:
-            self.get_logger().error(
-                f"Excavation failed: {detail}"
-            )
+            reason = f"Excavation failed: {detail}"
+            self.get_logger().error(reason)
+            self._set_failure_reason(reason)
             return MissionState.SAFE_FAIL
         return MissionState.TURN_TO_DEPOSITION
 
@@ -371,9 +474,9 @@ class MissionManager(Node):
             self._max_nav_retries,
         )
         if not success:
-            self.get_logger().error(
-                f"Navigation to deposition failed: {detail}"
-            )
+            reason = f"Navigation to deposition failed: {detail}"
+            self.get_logger().error(reason)
+            self._set_failure_reason(reason)
             return MissionState.SAFE_FAIL
         return MissionState.DEPOSIT
 
@@ -386,9 +489,9 @@ class MissionManager(Node):
             self._max_dep_retries,
         )
         if not success:
-            self.get_logger().error(
-                f"Deposit failed: {detail}"
-            )
+            reason = f"Deposit failed: {detail}"
+            self.get_logger().error(reason)
+            self._set_failure_reason(reason)
             return MissionState.SAFE_FAIL
         return MissionState.CHECK_NEXT_CYCLE_TIME
 

--- a/src/lunabot_bringup/lunabot_bringup/mission_timer.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_timer.py
@@ -39,6 +39,10 @@ class MissionTimer:
         self.completedCycles += 1
         return duration
 
+    def elapsedMissionTime(self) -> float:
+        """Return elapsed mission time in seconds."""
+        return time.monotonic() - self.missionStartTime
+
     def canStartCycle(self, pre_hoc_time_s: float | None = None) -> bool:
         """
         Return whether there is enough time budget to start another cycle.
@@ -53,7 +57,7 @@ class MissionTimer:
         cycle time is used as the budget estimate and ``pre_hoc_time_s`` is
         ignored.
         """
-        elapsed_mission_time: float = time.monotonic() - self.missionStartTime
+        elapsed_mission_time: float = self.elapsedMissionTime()
 
         if self.completedCycles == 0:
             if pre_hoc_time_s is None:

--- a/src/lunabot_bringup/test/test_mission_manager.py
+++ b/src/lunabot_bringup/test/test_mission_manager.py
@@ -18,6 +18,14 @@ def _fake_logger():
     )
 
 
+def _fake_publisher():
+    """Return a publisher stub that records messages."""
+    publisher = MagicMock()
+    publisher.messages = []
+    publisher.publish.side_effect = publisher.messages.append
+    return publisher
+
+
 def _make_manager(monkeypatch):
     """Construct a MissionManager without spinning a real ROS node."""
     monkeypatch.setattr(
@@ -38,6 +46,13 @@ def _make_manager(monkeypatch):
     manager._cycle_count = 0
     manager._estop_active = False
     manager._motion_inhibited = False
+    manager._last_failure_reason = ""
+    manager._mission_active = False
+    manager._mission_state_pub = _fake_publisher()
+    manager._autonomy_mode_pub = _fake_publisher()
+    manager._time_remaining_pub = _fake_publisher()
+    manager._cycle_count_pub = _fake_publisher()
+    manager._failure_reason_pub = _fake_publisher()
     return manager
 
 
@@ -50,6 +65,46 @@ def test_initial_state_is_initialize_mission(monkeypatch):
     """Initial FSM state must be INITIALIZE_MISSION."""
     manager = _make_manager(monkeypatch)
     assert manager._state == MissionState.INITIALIZE_MISSION
+
+
+def test_operator_state_publishers_emit_current_snapshot(monkeypatch):
+    """Mission manager should publish passive operator telemetry."""
+    manager = _make_manager(monkeypatch)
+    manager._state = MissionState.NAV_TO_EXCAVATION
+    manager._cycle_count = 2
+    manager._last_failure_reason = "none"
+
+    manager._publish_operator_state()
+
+    assert manager._mission_state_pub.messages[-1].data == "nav_to_excavation"
+    assert manager._autonomy_mode_pub.messages[-1].data == "idle"
+    assert manager._time_remaining_pub.messages[-1].data == 1200.0
+    assert manager._cycle_count_pub.messages[-1].data == 2
+    assert manager._failure_reason_pub.messages[-1].data == "none"
+
+
+def test_autonomy_mode_reports_safety_states(monkeypatch):
+    """Operator mode should surface inhibit and E-stop states."""
+    manager = _make_manager(monkeypatch)
+    manager._mission_active = True
+
+    assert manager._autonomy_mode_text() == "autonomous"
+
+    manager._motion_inhibited = True
+    assert manager._autonomy_mode_text() == "motion_inhibited"
+
+    manager._estop_active = True
+    assert manager._autonomy_mode_text() == "estop"
+
+
+def test_set_failure_reason_updates_operator_topic(monkeypatch):
+    """Failure reasons should be visible without waiting for another state change."""
+    manager = _make_manager(monkeypatch)
+
+    manager._set_failure_reason("Navigation failed")
+
+    assert manager._last_failure_reason == "Navigation failed"
+    assert manager._failure_reason_pub.messages[-1].data == "Navigation failed"
 
 
 # ------------------------------------------------------------------

--- a/src/lunabot_bringup/test/test_mission_timer.py
+++ b/src/lunabot_bringup/test/test_mission_timer.py
@@ -30,6 +30,15 @@ def test_begin_cycle_resets_cycle_start_time():
     assert timer.cycleStartTime >= old_start
 
 
+def test_elapsed_mission_time_uses_monotonic_clock(monkeypatch):
+    """Elapsed mission time is exposed for passive operator telemetry."""
+    timer = MissionTimer()
+    timer.missionStartTime = 100.0
+    monkeypatch.setattr("time.monotonic", lambda: 112.5)
+
+    assert timer.elapsedMissionTime() == 12.5
+
+
 def test_record_cycle_time_returns_positive_float_and_increments_counter():
     """Verify recordCycleTime() returns a non-negative duration and increments completedCycles."""
     timer = MissionTimer()


### PR DESCRIPTION
## Summary
- publish passive mission telemetry for Foxglove and bags: state, autonomy mode, time remaining, cycle count, and last failure reason
- move those mission topics from deferred contract entries into typed publisher contracts
- document the operator-facing telemetry contract in `lunabot_bringup`
- fix `mission_manager.launch.py` startup by avoiding a duplicate `use_sim_time` declaration in the node

## Testing
- `ruff check src/lunabot_bringup/lunabot_bringup/mission_manager.py src/lunabot_bringup/lunabot_bringup/mission_timer.py src/lunabot_bringup/test/test_mission_manager.py src/lunabot_bringup/test/test_mission_timer.py`
- `python3 -m py_compile src/lunabot_bringup/lunabot_bringup/mission_manager.py src/lunabot_bringup/lunabot_bringup/mission_timer.py`
- `python3 -m json.tool .github/contracts/interface_contracts.json >/dev/null`
- Jetson: `colcon build --symlink-install --packages-select lunabot_interfaces lunabot_bringup`
- Jetson: `colcon test --packages-select lunabot_bringup --event-handlers console_direct+ --pytest-args test/test_mission_manager.py test/test_mission_timer.py && colcon test-result --verbose` (40 passed)
- Jetson runtime: launched `mission_manager.launch.py` and verified `/mission/state`, `/mission/autonomy_mode`, `/mission/time_remaining_s`, `/mission/cycle_count`, and `/mission/last_failure_reason` are discoverable; sampled state=`nav_to_excavation`, mode=`autonomous`, cycle_count=`0`

No Nexy review run.
