### PR TITLE
feat(bringup): publish rover diagnostics

### DIFF
--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -18,6 +18,8 @@ Use bring-up launches when validating end-to-end behaviour. Avoid debugging subs
 - `launch/`: stack launch entrypoints (navigation and related orchestration paths).
 - `launch/mission_manager.launch.py`: starts the standalone mission supervisor node.
 - `launch/mission_dry_run.launch.py`: one-command sim dry run for travel, excavate, and deposit.
+- `launch/rover_diagnostics.launch.py`: publishes standard `/diagnostics`
+  summaries for operator and bag review.
 
 ## Mission Manager
 
@@ -81,6 +83,24 @@ For a direct shell exit code without the composed sim launch, run the harness en
 ```bash
 ros2 run lunabot_bringup mission_dry_run
 ```
+
+## Runtime Diagnostics
+
+Start the diagnostics aggregator with:
+
+```bash
+ros2 launch lunabot_bringup rover_diagnostics.launch.py
+```
+
+It publishes `diagnostic_msgs/DiagnosticArray` on `/diagnostics` for:
+
+- safety command state
+- drivetrain status
+- start-zone localisation readiness
+- excavation status
+
+Each item uses standard `OK`, `WARN`, `ERROR`, and `STALE` levels so Foxglove,
+bags, and future preflight tooling can show health without scraping logs.
 
 ## Common failure modes
 

--- a/src/lunabot_bringup/launch/rover_diagnostics.launch.py
+++ b/src/lunabot_bringup/launch/rover_diagnostics.launch.py
@@ -1,0 +1,44 @@
+"""Launch the rover diagnostics aggregator."""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def generate_launch_description():
+    """Generate the rover diagnostics launch description."""
+    stale_timeout_s = LaunchConfiguration("stale_timeout_s")
+    publish_hz = LaunchConfiguration("publish_hz")
+
+    diagnostics = Node(
+        package="lunabot_bringup",
+        executable="rover_diagnostics",
+        name="rover_diagnostics",
+        output="screen",
+        parameters=[
+            {
+                "stale_timeout_s": ParameterValue(
+                    stale_timeout_s, value_type=float
+                ),
+                "publish_hz": ParameterValue(publish_hz, value_type=float),
+            }
+        ],
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "stale_timeout_s",
+                default_value="2.5",
+                description="Seconds before a monitored topic is STALE.",
+            ),
+            DeclareLaunchArgument(
+                "publish_hz",
+                default_value="1.0",
+                description="DiagnosticArray publish rate.",
+            ),
+            diagnostics,
+        ]
+    )

--- a/src/lunabot_bringup/lunabot_bringup/rover_diagnostics.py
+++ b/src/lunabot_bringup/lunabot_bringup/rover_diagnostics.py
@@ -1,0 +1,421 @@
+"""Publish standard ROS diagnostics for rover runtime readiness."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import rclpy
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
+from rclpy.node import Node
+from std_msgs.msg import Bool
+
+from lunabot_interfaces import msg as lunabot_msgs
+
+LEVEL_OK = DiagnosticStatus.OK
+LEVEL_WARN = DiagnosticStatus.WARN
+LEVEL_ERROR = DiagnosticStatus.ERROR
+LEVEL_STALE = DiagnosticStatus.STALE
+
+DRIVETRAIN_STATE_FAULT = 4
+DRIVETRAIN_STATE_ESTOP = 5
+EXCAVATION_STATE_FAULT = 6
+EXCAVATION_FAULT_NONE = 0
+
+DrivetrainStatus: Any = lunabot_msgs.__dict__["DrivetrainStatus"]
+ExcavationStatus: Any = lunabot_msgs.__dict__["ExcavationStatus"]
+LocalisationStartZoneStatus: Any = lunabot_msgs.__dict__[
+    "LocalisationStartZoneStatus"
+]
+
+
+@dataclass
+class TopicSample:
+    """Latest message and wall-clock receipt time for one monitored topic."""
+
+    msg: Any | None = None
+    received_at_s: float | None = None
+
+
+def _key_value(key: str, value: object) -> KeyValue:
+    item = KeyValue()
+    item.key = key
+    item.value = str(value)
+    return item
+
+
+def _status(
+    name: str,
+    level: int,
+    message: str,
+    *,
+    hardware_id: str = "innex1_rover",
+    values: Mapping[str, object] | None = None,
+) -> DiagnosticStatus:
+    status = DiagnosticStatus()
+    status.name = name
+    status.hardware_id = hardware_id
+    status.level = level
+    status.message = message
+    status.values = [
+        _key_value(key, value) for key, value in (values or {}).items()
+    ]
+    return status
+
+
+def _sample_age_s(sample: TopicSample, now_s: float) -> float | None:
+    if sample.received_at_s is None:
+        return None
+    return max(0.0, now_s - sample.received_at_s)
+
+
+def _is_stale(sample: TopicSample, now_s: float, timeout_s: float) -> bool:
+    age_s = _sample_age_s(sample, now_s)
+    return age_s is None or age_s > timeout_s
+
+
+def drivetrain_diagnostic(
+    sample: TopicSample,
+    *,
+    now_s: float,
+    timeout_s: float,
+) -> DiagnosticStatus:
+    """Build drivetrain health from the latest status message."""
+    age_s = _sample_age_s(sample, now_s)
+    if _is_stale(sample, now_s, timeout_s):
+        return _status(
+            "drivetrain/status",
+            LEVEL_STALE,
+            "No fresh drivetrain status",
+            values={"age_s": age_s if age_s is not None else "never"},
+        )
+
+    msg = sample.msg
+    if msg is None:
+        return _status(
+            "drivetrain/status",
+            LEVEL_STALE,
+            "No fresh drivetrain status",
+            values={"age_s": age_s if age_s is not None else "never"},
+        )
+
+    values = {
+        "state": msg.state,
+        "fault_code": msg.fault_code,
+        "controller_online": list(msg.controller_online),
+        "age_s": f"{age_s:.2f}",
+    }
+    if msg.state in {
+        DRIVETRAIN_STATE_FAULT,
+        DRIVETRAIN_STATE_ESTOP,
+    } or msg.estop_active:
+        return _status(
+            "drivetrain/status",
+            LEVEL_ERROR,
+            "Drivetrain fault or E-stop active",
+            values=values,
+        )
+    if msg.motion_inhibited:
+        return _status(
+            "drivetrain/status",
+            LEVEL_WARN,
+            "Motion inhibited",
+            values=values,
+        )
+    if not all(msg.controller_online):
+        return _status(
+            "drivetrain/status",
+            LEVEL_WARN,
+            "One or more drivetrain controllers offline",
+            values=values,
+        )
+    return _status(
+        "drivetrain/status",
+        LEVEL_OK,
+        "Drivetrain ready",
+        values=values,
+    )
+
+
+def safety_diagnostic(
+    estop: TopicSample,
+    inhibit: TopicSample,
+    *,
+    now_s: float,
+    timeout_s: float,
+) -> DiagnosticStatus:
+    """Build safety health from E-stop and motion-inhibit topics."""
+    estop_age = _sample_age_s(estop, now_s)
+    inhibit_age = _sample_age_s(inhibit, now_s)
+    values = {
+        "estop_age_s": estop_age if estop_age is not None else "never",
+        "motion_inhibit_age_s": (
+            inhibit_age if inhibit_age is not None else "never"
+        ),
+    }
+    if _is_stale(estop, now_s, timeout_s) or _is_stale(
+        inhibit, now_s, timeout_s
+    ):
+        return _status(
+            "safety/command_state",
+            LEVEL_STALE,
+            "No fresh safety state",
+            values=values,
+        )
+
+    estop_msg = estop.msg
+    inhibit_msg = inhibit.msg
+    if estop_msg is None or inhibit_msg is None:
+        return _status(
+            "safety/command_state",
+            LEVEL_STALE,
+            "No fresh safety state",
+            values=values,
+        )
+
+    estop_active = bool(estop_msg.data)
+    motion_inhibited = bool(inhibit_msg.data)
+    values.update(
+        {
+            "estop_active": estop_active,
+            "motion_inhibited": motion_inhibited,
+        }
+    )
+    if estop_active:
+        return _status(
+            "safety/command_state",
+            LEVEL_ERROR,
+            "E-stop active",
+            values=values,
+        )
+    if motion_inhibited:
+        return _status(
+            "safety/command_state",
+            LEVEL_WARN,
+            "Motion inhibited",
+            values=values,
+        )
+    return _status(
+        "safety/command_state",
+        LEVEL_OK,
+        "Safety state clear",
+        values=values,
+    )
+
+
+def localisation_diagnostic(
+    sample: TopicSample,
+    *,
+    now_s: float,
+    timeout_s: float,
+) -> DiagnosticStatus:
+    """Build start-zone localisation health."""
+    age_s = _sample_age_s(sample, now_s)
+    if _is_stale(sample, now_s, timeout_s):
+        return _status(
+            "localisation/start_zone",
+            LEVEL_STALE,
+            "No fresh start-zone localisation status",
+            values={"age_s": age_s if age_s is not None else "never"},
+        )
+
+    msg = sample.msg
+    if msg is None:
+        return _status(
+            "localisation/start_zone",
+            LEVEL_STALE,
+            "No fresh start-zone localisation status",
+            values={"age_s": age_s if age_s is not None else "never"},
+        )
+
+    values = {
+        "state": msg.state,
+        "ready": msg.ready,
+        "reason_code": msg.reason_code,
+        "stable_lock_age_s": f"{msg.stable_lock_age_s:.2f}",
+        "age_s": f"{age_s:.2f}",
+    }
+    if msg.ready:
+        return _status(
+            "localisation/start_zone",
+            LEVEL_OK,
+            "Start-zone localisation ready",
+            values=values,
+        )
+    return _status(
+        "localisation/start_zone",
+        LEVEL_WARN,
+        msg.reason_detail or "Start-zone localisation not ready",
+        values=values,
+    )
+
+
+def excavation_diagnostic(
+    sample: TopicSample,
+    *,
+    now_s: float,
+    timeout_s: float,
+) -> DiagnosticStatus:
+    """Build excavation subsystem health."""
+    age_s = _sample_age_s(sample, now_s)
+    if _is_stale(sample, now_s, timeout_s):
+        return _status(
+            "excavation/status",
+            LEVEL_STALE,
+            "No fresh excavation status",
+            values={"age_s": age_s if age_s is not None else "never"},
+        )
+
+    msg = sample.msg
+    if msg is None:
+        return _status(
+            "excavation/status",
+            LEVEL_STALE,
+            "No fresh excavation status",
+            values={"age_s": age_s if age_s is not None else "never"},
+        )
+
+    values = {
+        "state": msg.state,
+        "fault_code": msg.fault_code,
+        "estop_active": msg.estop_active,
+        "driver_fault": msg.driver_fault,
+        "homed": msg.homed,
+        "motor_enabled": msg.motor_enabled,
+        "motor_current_a": f"{msg.motor_current_a:.2f}",
+        "age_s": f"{age_s:.2f}",
+    }
+    if (
+        msg.state == EXCAVATION_STATE_FAULT
+        or msg.fault_code != EXCAVATION_FAULT_NONE
+        or msg.estop_active
+        or msg.driver_fault
+    ):
+        return _status(
+            "excavation/status",
+            LEVEL_ERROR,
+            "Excavation fault active",
+            values=values,
+        )
+    if not msg.homed:
+        return _status(
+            "excavation/status",
+            LEVEL_WARN,
+            "Excavation not homed",
+            values=values,
+        )
+    return _status(
+        "excavation/status",
+        LEVEL_OK,
+        "Excavation ready",
+        values=values,
+    )
+
+
+class RoverDiagnostics(Node):
+    """Aggregate rover health into `/diagnostics`."""
+
+    def __init__(self) -> None:
+        super().__init__("rover_diagnostics")
+        self.declare_parameter("stale_timeout_s", 2.5)
+        self.declare_parameter("publish_hz", 1.0)
+
+        self._stale_timeout_s = float(
+            self.get_parameter("stale_timeout_s").value
+        )
+        publish_hz = float(self.get_parameter("publish_hz").value)
+        if self._stale_timeout_s <= 0.0:
+            raise ValueError("stale_timeout_s must be positive")
+        if publish_hz <= 0.0:
+            raise ValueError("publish_hz must be positive")
+
+        self._drivetrain = TopicSample()
+        self._estop = TopicSample()
+        self._motion_inhibit = TopicSample()
+        self._localisation = TopicSample()
+        self._excavation = TopicSample()
+
+        self.create_subscription(
+            DrivetrainStatus,
+            "/drivetrain/status",
+            lambda msg: self._store(self._drivetrain, msg),
+            10,
+        )
+        self.create_subscription(
+            Bool,
+            "/safety/estop",
+            lambda msg: self._store(self._estop, msg),
+            10,
+        )
+        self.create_subscription(
+            Bool,
+            "/safety/motion_inhibit",
+            lambda msg: self._store(self._motion_inhibit, msg),
+            10,
+        )
+        self.create_subscription(
+            LocalisationStartZoneStatus,
+            "/localisation/start_zone_status",
+            lambda msg: self._store(self._localisation, msg),
+            10,
+        )
+        self.create_subscription(
+            ExcavationStatus,
+            "/excavation/status",
+            lambda msg: self._store(self._excavation, msg),
+            10,
+        )
+        self._publisher = self.create_publisher(
+            DiagnosticArray, "/diagnostics", 10
+        )
+        self.create_timer(1.0 / publish_hz, self._publish)
+        self.get_logger().info("Rover diagnostics publishing on /diagnostics")
+
+    def _store(self, sample: TopicSample, msg: Any) -> None:
+        sample.msg = msg
+        sample.received_at_s = time.monotonic()
+
+    def _publish(self) -> None:
+        now_s = time.monotonic()
+        msg = DiagnosticArray()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.status = [
+            safety_diagnostic(
+                self._estop,
+                self._motion_inhibit,
+                now_s=now_s,
+                timeout_s=self._stale_timeout_s,
+            ),
+            drivetrain_diagnostic(
+                self._drivetrain,
+                now_s=now_s,
+                timeout_s=self._stale_timeout_s,
+            ),
+            localisation_diagnostic(
+                self._localisation,
+                now_s=now_s,
+                timeout_s=self._stale_timeout_s,
+            ),
+            excavation_diagnostic(
+                self._excavation,
+                now_s=now_s,
+                timeout_s=self._stale_timeout_s,
+            ),
+        ]
+        self._publisher.publish(msg)
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = RoverDiagnostics()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lunabot_bringup/package.xml
+++ b/src/lunabot_bringup/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>robot_localization</exec_depend>
   <exec_depend>action_msgs</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>

--- a/src/lunabot_bringup/setup.py
+++ b/src/lunabot_bringup/setup.py
@@ -52,6 +52,7 @@ setup(
             "mission_dry_run = lunabot_bringup.mission_dry_run:main",
             "mission_manager = lunabot_bringup.mission_manager:main",
             "preflight_check = lunabot_bringup.preflight_check:main",
+            "rover_diagnostics = lunabot_bringup.rover_diagnostics:main",
         ],
     },
 )

--- a/src/lunabot_bringup/test/test_rover_diagnostics.py
+++ b/src/lunabot_bringup/test/test_rover_diagnostics.py
@@ -1,0 +1,128 @@
+"""Unit tests for rover diagnostics status mapping."""
+
+from std_msgs.msg import Bool
+
+from lunabot_bringup.rover_diagnostics import (
+    LEVEL_ERROR,
+    LEVEL_OK,
+    LEVEL_STALE,
+    LEVEL_WARN,
+    TopicSample,
+    drivetrain_diagnostic,
+    excavation_diagnostic,
+    localisation_diagnostic,
+    safety_diagnostic,
+)
+from lunabot_interfaces.msg import (
+    DrivetrainStatus,
+    ExcavationStatus,
+    LocalisationStartZoneStatus,
+)
+
+
+def _sample(msg, received_at_s=10.0):
+    return TopicSample(msg=msg, received_at_s=received_at_s)
+
+
+def test_drivetrain_diagnostic_is_stale_without_status():
+    status = drivetrain_diagnostic(
+        TopicSample(), now_s=20.0, timeout_s=2.5
+    )
+
+    assert status.level == LEVEL_STALE
+    assert "No fresh drivetrain" in status.message
+
+
+def test_drivetrain_diagnostic_reports_fault_as_error():
+    msg = DrivetrainStatus()
+    msg.state = DrivetrainStatus.STATE_FAULT
+    msg.fault_code = DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
+    msg.controller_online = [False, False]
+
+    status = drivetrain_diagnostic(
+        _sample(msg), now_s=10.1, timeout_s=2.5
+    )
+
+    assert status.level == LEVEL_ERROR
+
+
+def test_drivetrain_diagnostic_reports_ready_as_ok():
+    msg = DrivetrainStatus()
+    msg.state = DrivetrainStatus.STATE_READY
+    msg.fault_code = DrivetrainStatus.FAULT_NONE
+    msg.controller_online = [True, True]
+
+    status = drivetrain_diagnostic(
+        _sample(msg), now_s=10.1, timeout_s=2.5
+    )
+
+    assert status.level == LEVEL_OK
+
+
+def test_safety_diagnostic_reports_estop_as_error():
+    estop = Bool()
+    estop.data = True
+    inhibit = Bool()
+    inhibit.data = False
+
+    status = safety_diagnostic(
+        _sample(estop), _sample(inhibit), now_s=10.1, timeout_s=2.5
+    )
+
+    assert status.level == LEVEL_ERROR
+    assert status.message == "E-stop active"
+
+
+def test_safety_diagnostic_reports_clear_as_ok():
+    estop = Bool()
+    estop.data = False
+    inhibit = Bool()
+    inhibit.data = False
+
+    status = safety_diagnostic(
+        _sample(estop), _sample(inhibit), now_s=10.1, timeout_s=2.5
+    )
+
+    assert status.level == LEVEL_OK
+
+
+def test_localisation_diagnostic_reports_not_ready_as_warn():
+    msg = LocalisationStartZoneStatus()
+    msg.ready = False
+    msg.state = "searching"
+    msg.reason_code = "no_tag"
+    msg.reason_detail = "No tag lock"
+
+    status = localisation_diagnostic(
+        _sample(msg), now_s=10.1, timeout_s=2.5
+    )
+
+    assert status.level == LEVEL_WARN
+    assert status.message == "No tag lock"
+
+
+def test_excavation_diagnostic_reports_unhomed_as_warn():
+    msg = ExcavationStatus()
+    msg.state = ExcavationStatus.STATE_IDLE
+    msg.fault_code = ExcavationStatus.FAULT_NONE
+    msg.homed = False
+
+    status = excavation_diagnostic(
+        _sample(msg), now_s=10.1, timeout_s=2.5
+    )
+
+    assert status.level == LEVEL_WARN
+    assert status.message == "Excavation not homed"
+
+
+def test_excavation_diagnostic_reports_fault_as_error():
+    msg = ExcavationStatus()
+    msg.state = ExcavationStatus.STATE_FAULT
+    msg.fault_code = ExcavationStatus.FAULT_DRIVER
+    msg.homed = True
+
+    status = excavation_diagnostic(
+        _sample(msg), now_s=10.1, timeout_s=2.5
+    )
+
+    assert status.level == LEVEL_ERROR


### PR DESCRIPTION
## Summary
- add a standalone `rover_diagnostics` node that publishes standard `diagnostic_msgs/DiagnosticArray` on `/diagnostics`
- monitor safety command state, drivetrain status, start-zone localisation readiness, and excavation status
- expose OK/WARN/ERROR/STALE mapping with useful key/value details for Foxglove, bags, and future preflight tooling
- add a launch file and docs for running the diagnostics aggregator

## Testing
- `ruff check src/lunabot_bringup/lunabot_bringup/rover_diagnostics.py src/lunabot_bringup/test/test_rover_diagnostics.py src/lunabot_bringup/launch/rover_diagnostics.launch.py`
- `python3 -m py_compile src/lunabot_bringup/lunabot_bringup/rover_diagnostics.py src/lunabot_bringup/launch/rover_diagnostics.launch.py`
- Jetson: `colcon build --symlink-install --packages-select lunabot_interfaces lunabot_bringup`
- Jetson: `colcon test --packages-select lunabot_bringup --event-handlers console_direct+ --pytest-args test/test_rover_diagnostics.py && colcon test-result --verbose` (8 passed)
- Jetson runtime: launched `rover_diagnostics.launch.py` and verified `/diagnostics` publishes STALE entries for safety, drivetrain, localisation, and excavation when those topics are absent

No Nexy review run.
