### PR TITLE
feat(bringup): add mission rosbag evidence packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ log/
 .envrc
 .dev/
 /innex1_mission_*
+/mission_evidence/
 frames_*.gv
 frames_*.pdf
 __pycache__/

--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -82,6 +82,49 @@ For a direct shell exit code without the composed sim launch, run the harness en
 ros2 run lunabot_bringup mission_dry_run
 ```
 
+## Mission Evidence Packs
+
+Use `mission_evidence` when you want a repeatable rosbag capture with the
+run context kept next to it. The default profile is intentionally lean: mission
+state, safety state, subsystem status, TF and command topics. Raw images and
+point clouds only live in the `heavy` profile so normal dry runs do not quietly
+turn into a disk and bandwidth test.
+
+Create a dry-run evidence pack and record around a mission command:
+
+```bash
+ros2 run lunabot_bringup mission_evidence \
+  --profile minimal \
+  --label sim-dry-run \
+  --use-sim-time \
+  -- ros2 launch lunabot_bringup mission_dry_run.launch.py
+```
+
+The helper creates `~/innex1_mission_evidence/<timestamp>_<label>/` with:
+
+- `bag/`: the rosbag2 recording.
+- `logs/rosbag_record.log`: recorder output.
+- `logs/mission_command.log`: mission command output when one is provided.
+- `config/`: copied bring-up configs used to understand the run later.
+- `manifest.json`: git SHA, profile, topic allowlist, commands and exit codes.
+
+For a command preview without starting `ros2 bag record`, run:
+
+```bash
+ros2 run lunabot_bringup mission_evidence --plan-only --profile debug
+```
+
+Replay a saved pack with the command written in `manifest.json`, normally:
+
+```bash
+ros2 bag play ~/innex1_mission_evidence/<pack>/bag
+```
+
+The helper passes `--max-bag-duration` and `--max-bag-size` to rosbag2 so long
+runs split cleanly instead of producing one awkward file. On the Jetson Humble
+image the available storage backend is `sqlite3`; keep that as the default
+unless `ros2 bag record --help` shows MCAP has been installed.
+
 ## Common failure modes
 
 - Launch starts successfully but one critical node crashes shortly after (dependency mismatch).

--- a/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
+++ b/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
@@ -1,0 +1,75 @@
+profiles:
+  minimal:
+    description: Lean operator and mission-state evidence for normal dry runs.
+    topics:
+      - /clock
+      - /tf
+      - /tf_static
+      - /mission/state
+      - /mission/autonomy_mode
+      - /mission/time_remaining_s
+      - /mission/cycle_count
+      - /mission/last_failure_reason
+      - /safety/estop
+      - /safety/motion_inhibit
+      - /drivetrain/status
+      - /localisation/start_zone_status
+      - /excavation/status
+      - /cmd_vel_gated
+      - /cmd_vel_safe
+  debug:
+    description: Mission evidence plus navigation state for failed or borderline runs.
+    topics:
+      - /clock
+      - /tf
+      - /tf_static
+      - /mission/state
+      - /mission/autonomy_mode
+      - /mission/time_remaining_s
+      - /mission/cycle_count
+      - /mission/last_failure_reason
+      - /safety/estop
+      - /safety/motion_inhibit
+      - /drivetrain/status
+      - /drivetrain/telemetry
+      - /localisation/start_zone_status
+      - /excavation/status
+      - /excavation/telemetry
+      - /cmd_vel_gated
+      - /cmd_vel_safe
+      - /odom
+      - /scan
+      - /map
+      - /global_costmap/costmap
+      - /local_costmap/costmap
+      - /navigate_to_pose_gate/_action/status
+  heavy:
+    description: Deliberate high-bandwidth capture for short perception investigations only.
+    topics:
+      - /clock
+      - /tf
+      - /tf_static
+      - /mission/state
+      - /mission/autonomy_mode
+      - /mission/time_remaining_s
+      - /mission/cycle_count
+      - /mission/last_failure_reason
+      - /safety/estop
+      - /safety/motion_inhibit
+      - /drivetrain/status
+      - /drivetrain/telemetry
+      - /localisation/start_zone_status
+      - /excavation/status
+      - /excavation/telemetry
+      - /cmd_vel_gated
+      - /cmd_vel_safe
+      - /odom
+      - /scan
+      - /map
+      - /global_costmap/costmap
+      - /local_costmap/costmap
+      - /navigate_to_pose_gate/_action/status
+      - /camera/image_raw
+      - /camera/depth/image_raw
+      - /camera/camera_info
+      - /ouster/points

--- a/src/lunabot_bringup/lunabot_bringup/mission_evidence.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_evidence.py
@@ -1,0 +1,451 @@
+"""Create repeatable rosbag evidence packs for mission dry runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_OUTPUT_ROOT = Path("~/innex1_mission_evidence").expanduser()
+DEFAULT_STORAGE = "sqlite3"
+DEFAULT_MAX_BAG_DURATION_S = 300
+DEFAULT_MAX_BAG_SIZE_BYTES = 2_000_000_000
+DEFAULT_PROFILE = "minimal"
+DEFAULT_SNAPSHOT_RELATIVE_PATHS = (
+    "config/arena_waypoints.yaml",
+    "config/preflight_checks_dry_run.yaml",
+    "config/rosbag_evidence_profiles.yaml",
+)
+SUMMARY_STEPS = ("travel", "excavate", "deposit", "overall")
+
+
+@dataclass(frozen=True)
+class EvidenceProfile:
+    """Topic allowlist for one evidence recording mode."""
+
+    name: str
+    description: str
+    topics: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class EvidencePlan:
+    """Resolved paths and commands for one evidence pack."""
+
+    pack_dir: Path
+    bag_dir: Path
+    logs_dir: Path
+    config_dir: Path
+    manifest_path: Path
+    record_command: tuple[str, ...]
+    replay_command: tuple[str, ...]
+    mission_command: tuple[str, ...]
+    profile: EvidenceProfile
+
+
+def _utc_stamp() -> str:
+    """Return a filesystem-safe UTC timestamp."""
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _slug(value: str) -> str:
+    """Return a conservative folder-name fragment."""
+    cleaned = "".join(
+        char.lower() if char.isalnum() else "-" for char in value.strip()
+    ).strip("-")
+    while "--" in cleaned:
+        cleaned = cleaned.replace("--", "-")
+    return cleaned or "mission"
+
+
+def default_profiles_path() -> Path:
+    """Return the installed evidence profile config path."""
+    from ament_index_python.packages import get_package_share_directory
+
+    share_dir = Path(get_package_share_directory("lunabot_bringup"))
+    return share_dir / "config" / "rosbag_evidence_profiles.yaml"
+
+
+def load_profiles(path: Path) -> dict[str, EvidenceProfile]:
+    """Load evidence profiles from YAML."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("profiles"), dict):
+        raise ValueError(f"invalid evidence profile file: {path}")
+
+    profiles: dict[str, EvidenceProfile] = {}
+    for name, raw_profile in data["profiles"].items():
+        if not isinstance(name, str) or not isinstance(raw_profile, dict):
+            raise ValueError(f"invalid evidence profile entry in {path}")
+
+        raw_topics = raw_profile.get("topics")
+        if not isinstance(raw_topics, list) or not raw_topics:
+            raise ValueError(f"profile {name!r} must list at least one topic")
+
+        topics = tuple(str(topic) for topic in raw_topics)
+        if any(not topic.startswith("/") for topic in topics):
+            raise ValueError(f"profile {name!r} contains a non-absolute topic")
+
+        profiles[name] = EvidenceProfile(
+            name=name,
+            description=str(raw_profile.get("description", "")),
+            topics=topics,
+        )
+    return profiles
+
+
+def git_sha(cwd: Path | None = None) -> str:
+    """Return the current git SHA, or `unknown` outside a checkout."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def build_record_command(
+    profile: EvidenceProfile,
+    bag_dir: Path,
+    *,
+    storage: str = DEFAULT_STORAGE,
+    max_bag_duration_s: int = DEFAULT_MAX_BAG_DURATION_S,
+    max_bag_size_bytes: int = DEFAULT_MAX_BAG_SIZE_BYTES,
+    use_sim_time: bool = False,
+) -> tuple[str, ...]:
+    """Build the rosbag2 record command for one evidence profile."""
+    command = [
+        "ros2",
+        "bag",
+        "record",
+        "-o",
+        str(bag_dir),
+        "-s",
+        storage,
+        "--max-bag-duration",
+        str(max_bag_duration_s),
+        "--max-bag-size",
+        str(max_bag_size_bytes),
+    ]
+    if use_sim_time:
+        command.append("--use-sim-time")
+    command.extend(profile.topics)
+    return tuple(command)
+
+
+def create_evidence_plan(
+    *,
+    profile: EvidenceProfile,
+    output_root: Path,
+    label: str,
+    storage: str = DEFAULT_STORAGE,
+    max_bag_duration_s: int = DEFAULT_MAX_BAG_DURATION_S,
+    max_bag_size_bytes: int = DEFAULT_MAX_BAG_SIZE_BYTES,
+    use_sim_time: bool = False,
+    mission_command: Sequence[str] = (),
+    timestamp: str | None = None,
+) -> EvidencePlan:
+    """Resolve the folder layout and commands for one evidence pack."""
+    stamp = timestamp or _utc_stamp()
+    pack_dir = output_root.expanduser() / f"{stamp}_{_slug(label)}"
+    bag_dir = pack_dir / "bag"
+    logs_dir = pack_dir / "logs"
+    config_dir = pack_dir / "config"
+    record_command = build_record_command(
+        profile,
+        bag_dir,
+        storage=storage,
+        max_bag_duration_s=max_bag_duration_s,
+        max_bag_size_bytes=max_bag_size_bytes,
+        use_sim_time=use_sim_time,
+    )
+    return EvidencePlan(
+        pack_dir=pack_dir,
+        bag_dir=bag_dir,
+        logs_dir=logs_dir,
+        config_dir=config_dir,
+        manifest_path=pack_dir / "manifest.json",
+        record_command=record_command,
+        replay_command=("ros2", "bag", "play", str(bag_dir)),
+        mission_command=tuple(mission_command),
+        profile=profile,
+    )
+
+
+def initialise_pack(plan: EvidencePlan) -> None:
+    """Create the evidence-pack directory layout."""
+    plan.logs_dir.mkdir(parents=True, exist_ok=False)
+    plan.config_dir.mkdir(parents=True, exist_ok=False)
+
+
+def snapshot_configs(
+    *,
+    plan: EvidencePlan,
+    package_share: Path,
+    relative_paths: Sequence[str] = DEFAULT_SNAPSHOT_RELATIVE_PATHS,
+) -> list[str]:
+    """Copy useful run configs into the evidence pack."""
+    copied: list[str] = []
+    for relative_path in relative_paths:
+        source = package_share / relative_path
+        if not source.exists():
+            continue
+
+        destination = plan.config_dir / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        copied.append(relative_path)
+    return copied
+
+
+def write_manifest(
+    *,
+    plan: EvidencePlan,
+    git_revision: str,
+    config_snapshots: Sequence[str],
+    started_at_utc: str,
+    completed_at_utc: str | None = None,
+    mission_return_code: int | None = None,
+    recording_return_code: int | None = None,
+    mission_summary: dict[str, Any] | None = None,
+) -> None:
+    """Write a machine-readable summary for the evidence pack."""
+    manifest: dict[str, Any] = {
+        "schema_version": 1,
+        "started_at_utc": started_at_utc,
+        "completed_at_utc": completed_at_utc,
+        "git_sha": git_revision,
+        "profile": {
+            "name": plan.profile.name,
+            "description": plan.profile.description,
+            "topics": list(plan.profile.topics),
+        },
+        "paths": {
+            "bag": str(plan.bag_dir),
+            "logs": str(plan.logs_dir),
+            "config": str(plan.config_dir),
+        },
+        "commands": {
+            "record": list(plan.record_command),
+            "replay": list(plan.replay_command),
+            "mission": list(plan.mission_command),
+        },
+        "config_snapshots": list(config_snapshots),
+        "results": {
+            "mission_return_code": mission_return_code,
+            "recording_return_code": recording_return_code,
+            "mission_summary": mission_summary or {},
+        },
+    }
+    plan.manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_mission_summary(log_path: Path) -> dict[str, Any]:
+    """Extract flat dry-run result lines from a mission command log."""
+    if not log_path.exists():
+        return {}
+
+    step_results: dict[str, str] = {}
+    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if ": " not in line:
+            continue
+
+        name, value = line.split(": ", 1)
+        if name in SUMMARY_STEPS and value in {"pass", "fail"}:
+            step_results[name] = value
+
+    if not step_results:
+        return {}
+
+    failed_steps = [
+        step
+        for step in SUMMARY_STEPS
+        if step != "overall" and step_results.get(step) == "fail"
+    ]
+    failure_reason = ""
+    if step_results.get("overall") == "fail":
+        if failed_steps:
+            failure_reason = f"{failed_steps[0]} failed"
+        else:
+            failure_reason = "mission failed"
+
+    return {
+        "step_results": step_results,
+        "overall": step_results.get("overall", "unknown"),
+        "failure_reason": failure_reason,
+    }
+
+
+def _terminate(process: subprocess.Popen[Any]) -> int:
+    """Terminate one process group and return the final code."""
+    if process.poll() is not None:
+        return int(process.returncode)
+
+    os.killpg(process.pid, signal.SIGINT)
+    try:
+        return int(process.wait(timeout=10.0))
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGTERM)
+        try:
+            return int(process.wait(timeout=5.0))
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            return int(process.wait(timeout=5.0))
+
+
+def run_recording(plan: EvidencePlan) -> tuple[int | None, int]:
+    """Run rosbag recording, optionally around a mission command."""
+    record_log = (plan.logs_dir / "rosbag_record.log").open(
+        "w",
+        encoding="utf-8",
+    )
+    try:
+        recorder = subprocess.Popen(
+            plan.record_command,
+            stdout=record_log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        time.sleep(2.0)
+
+        mission_return_code: int | None = None
+        if plan.mission_command:
+            mission_log = mission_log_path(plan).open(
+                "w",
+                encoding="utf-8",
+            )
+            try:
+                mission = subprocess.run(
+                    plan.mission_command,
+                    stdout=mission_log,
+                    stderr=subprocess.STDOUT,
+                    check=False,
+                )
+                mission_return_code = int(mission.returncode)
+            finally:
+                mission_log.close()
+        else:
+            recorder.wait()
+
+        recording_return_code = _terminate(recorder)
+        return mission_return_code, recording_return_code
+    finally:
+        record_log.close()
+
+
+def mission_log_path(plan: EvidencePlan) -> Path:
+    """Return the standard mission command log path."""
+    return plan.logs_dir / "mission_command.log"
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create a rosbag-backed mission evidence pack.",
+    )
+    parser.add_argument("mission_command", nargs=argparse.REMAINDER)
+    parser.add_argument("--profile", default=DEFAULT_PROFILE)
+    parser.add_argument("--profiles-file", type=Path, default=None)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--label", default="dry-run")
+    parser.add_argument("--storage", default=DEFAULT_STORAGE)
+    parser.add_argument(
+        "--max-bag-duration-s",
+        type=int,
+        default=DEFAULT_MAX_BAG_DURATION_S,
+    )
+    parser.add_argument(
+        "--max-bag-size-bytes",
+        type=int,
+        default=DEFAULT_MAX_BAG_SIZE_BYTES,
+    )
+    parser.add_argument("--use-sim-time", action="store_true")
+    parser.add_argument(
+        "--plan-only",
+        action="store_true",
+        help="Create the evidence pack and manifest without starting rosbag.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Create and optionally record a mission evidence pack."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    profiles_path = args.profiles_file or default_profiles_path()
+    profiles = load_profiles(profiles_path)
+    if args.profile not in profiles:
+        print(f"unknown evidence profile: {args.profile}", file=sys.stderr)
+        return 2
+
+    mission_command = tuple(args.mission_command)
+    if mission_command and mission_command[0] == "--":
+        mission_command = mission_command[1:]
+
+    plan = create_evidence_plan(
+        profile=profiles[args.profile],
+        output_root=args.output_root,
+        label=args.label,
+        storage=args.storage,
+        max_bag_duration_s=args.max_bag_duration_s,
+        max_bag_size_bytes=args.max_bag_size_bytes,
+        use_sim_time=args.use_sim_time,
+        mission_command=mission_command,
+    )
+    initialise_pack(plan)
+
+    package_share = profiles_path.parent.parent
+    config_snapshots = snapshot_configs(
+        plan=plan,
+        package_share=package_share,
+    )
+    started_at_utc = datetime.now(timezone.utc).isoformat()
+    write_manifest(
+        plan=plan,
+        git_revision=git_sha(Path.cwd()),
+        config_snapshots=config_snapshots,
+        started_at_utc=started_at_utc,
+    )
+
+    print(f"evidence_pack: {plan.pack_dir}")
+    print("record_command:", " ".join(plan.record_command))
+    print("replay_command:", " ".join(plan.replay_command))
+
+    if args.plan_only:
+        return 0
+
+    mission_code, recording_code = run_recording(plan)
+    write_manifest(
+        plan=plan,
+        git_revision=git_sha(Path.cwd()),
+        config_snapshots=config_snapshots,
+        started_at_utc=started_at_utc,
+        completed_at_utc=datetime.now(timezone.utc).isoformat(),
+        mission_return_code=mission_code,
+        recording_return_code=recording_code,
+        mission_summary=parse_mission_summary(mission_log_path(plan)),
+    )
+    if mission_code not in (None, 0):
+        return mission_code
+    return 0 if recording_code in (0, -2, 130) else recording_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lunabot_bringup/package.xml
+++ b/src/lunabot_bringup/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
+  <exec_depend>ros2bag</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>nav2_bringup</exec_depend>

--- a/src/lunabot_bringup/setup.py
+++ b/src/lunabot_bringup/setup.py
@@ -49,6 +49,7 @@ setup(
     entry_points={
         "console_scripts": [
             "navigate_to_pose_gate = lunabot_bringup.navigate_to_pose_gate:main",
+            "mission_evidence = lunabot_bringup.mission_evidence:main",
             "mission_dry_run = lunabot_bringup.mission_dry_run:main",
             "mission_manager = lunabot_bringup.mission_manager:main",
             "preflight_check = lunabot_bringup.preflight_check:main",

--- a/src/lunabot_bringup/test/test_mission_evidence.py
+++ b/src/lunabot_bringup/test/test_mission_evidence.py
@@ -1,0 +1,173 @@
+"""Unit tests for mission evidence pack helpers."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lunabot_bringup.mission_evidence import (
+    DEFAULT_MAX_BAG_DURATION_S,
+    EvidenceProfile,
+    build_record_command,
+    create_evidence_plan,
+    load_profiles,
+    parse_mission_summary,
+    snapshot_configs,
+    write_manifest,
+)
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_load_profiles_rejects_non_absolute_topics(tmp_path):
+    profiles_path = tmp_path / "profiles.yaml"
+    profiles_path.write_text(
+        "profiles:\n"
+        "  bad:\n"
+        "    description: bad\n"
+        "    topics:\n"
+        "      - relative_topic\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="non-absolute"):
+        load_profiles(profiles_path)
+
+
+def test_load_profiles_reads_minimal_topic_allowlist():
+    profiles = load_profiles(PACKAGE_ROOT / "config/rosbag_evidence_profiles.yaml")
+
+    minimal = profiles["minimal"]
+
+    assert "/mission/state" in minimal.topics
+    assert "/ouster/points" not in minimal.topics
+    assert profiles["heavy"].topics[-1] == "/ouster/points"
+
+
+def test_build_record_command_uses_splitting_and_sim_time():
+    profile = EvidenceProfile(
+        name="minimal",
+        description="test",
+        topics=("/clock", "/mission/state"),
+    )
+
+    command = build_record_command(
+        profile,
+        Path("/tmp/pack/bag"),
+        max_bag_duration_s=60,
+        max_bag_size_bytes=1000,
+        use_sim_time=True,
+    )
+
+    assert command[:5] == ("ros2", "bag", "record", "-o", "/tmp/pack/bag")
+    assert "--max-bag-duration" in command
+    assert "60" in command
+    assert "--max-bag-size" in command
+    assert "1000" in command
+    assert "--use-sim-time" in command
+    assert command[-2:] == ("/clock", "/mission/state")
+
+
+def test_create_evidence_plan_uses_stable_layout(tmp_path):
+    profile = EvidenceProfile(
+        name="minimal",
+        description="test",
+        topics=("/clock",),
+    )
+
+    plan = create_evidence_plan(
+        profile=profile,
+        output_root=tmp_path,
+        label="Good Dry Run!",
+        timestamp="20260508T120000Z",
+    )
+
+    assert plan.pack_dir == tmp_path / "20260508T120000Z_good-dry-run"
+    assert plan.bag_dir == plan.pack_dir / "bag"
+    assert plan.logs_dir == plan.pack_dir / "logs"
+    assert plan.config_dir == plan.pack_dir / "config"
+    assert str(DEFAULT_MAX_BAG_DURATION_S) in plan.record_command
+    assert plan.replay_command == ("ros2", "bag", "play", str(plan.bag_dir))
+
+
+def test_snapshot_configs_copies_existing_files_only(tmp_path):
+    package_share = tmp_path / "share"
+    source = package_share / "config" / "arena_waypoints.yaml"
+    source.parent.mkdir(parents=True)
+    source.write_text("waypoints: {}\n", encoding="utf-8")
+    profile = EvidenceProfile("minimal", "test", ("/clock",))
+    plan = create_evidence_plan(
+        profile=profile,
+        output_root=tmp_path / "out",
+        label="run",
+        timestamp="20260508T120000Z",
+    )
+    plan.config_dir.mkdir(parents=True)
+
+    copied = snapshot_configs(
+        plan=plan,
+        package_share=package_share,
+        relative_paths=("config/arena_waypoints.yaml", "config/missing.yaml"),
+    )
+
+    assert copied == ["config/arena_waypoints.yaml"]
+    assert (plan.config_dir / "config" / "arena_waypoints.yaml").exists()
+
+
+def test_write_manifest_records_commands_and_results(tmp_path):
+    profile = EvidenceProfile("minimal", "test", ("/clock",))
+    plan = create_evidence_plan(
+        profile=profile,
+        output_root=tmp_path,
+        label="run",
+        mission_command=("ros2", "launch", "lunabot_bringup", "mission.py"),
+        timestamp="20260508T120000Z",
+    )
+    plan.pack_dir.mkdir(parents=True)
+
+    write_manifest(
+        plan=plan,
+        git_revision="abc123",
+        config_snapshots=("config/arena_waypoints.yaml",),
+        started_at_utc="2026-05-08T12:00:00+00:00",
+        completed_at_utc="2026-05-08T12:01:00+00:00",
+        mission_return_code=0,
+        recording_return_code=130,
+        mission_summary={"overall": "pass"},
+    )
+
+    manifest = json.loads(plan.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["git_sha"] == "abc123"
+    assert manifest["profile"]["topics"] == ["/clock"]
+    assert manifest["commands"]["replay"] == [
+        "ros2",
+        "bag",
+        "play",
+        str(plan.bag_dir),
+    ]
+    assert manifest["results"] == {
+        "mission_return_code": 0,
+        "mission_summary": {"overall": "pass"},
+        "recording_return_code": 130,
+    }
+
+
+def test_parse_mission_summary_extracts_flat_dry_run_results(tmp_path):
+    log_path = tmp_path / "mission_command.log"
+    log_path.write_text(
+        "noise before\ntravel: pass\nexcavate: fail\ndeposit: fail\noverall: fail\n",
+        encoding="utf-8",
+    )
+
+    summary = parse_mission_summary(log_path)
+
+    assert summary == {
+        "step_results": {
+            "travel": "pass",
+            "excavate": "fail",
+            "deposit": "fail",
+            "overall": "fail",
+        },
+        "overall": "fail",
+        "failure_reason": "excavate failed",
+    }


### PR DESCRIPTION
## Summary
- add minimal/debug/heavy rosbag evidence profiles for dry-run and investigation captures
- add a mission_evidence CLI that creates a manifest, logs, config snapshots, split rosbag command, and replay command
- document the evidence-pack workflow and add focused helper tests

## Validation
- Local: ruff check for changed Python paths, ruff format check for changed Python paths, pyright, py_compile
- Local: PYTHONPATH=src/lunabot_bringup pytest -q src/lunabot_bringup/test/test_mission_evidence.py
- Jetson: clean temp clone, colcon build --packages-up-to lunabot_bringup
- Jetson: colcon test --packages-select lunabot_bringup --pytest-args test/test_mission_evidence.py
- Jetson: ros2 run lunabot_bringup mission_evidence --profile minimal --plan-only produced a valid manifest
- Jetson: ros2 run lunabot_bringup mission_evidence recorded one /mission/state message; ros2 bag info read the sqlite3 bag successfully

Linear: INX-44, INX-17, INX-24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Adds mission evidence pack recording for repeatable rosbag captures

This PR adds a repeatable "mission evidence" workflow and CLI to create rosbag evidence packs for dry-run and investigation captures.

### What changed / fixes
- Adds a mission_evidence CLI that plans and produces an evidence pack directory containing:
  - a rosbag2 recording (with split-by-duration/size support and selectable storage backend),
  - recorder and mission logs,
  - snapshots of relevant configuration files,
  - a manifest.json capturing metadata (UTC timestamps, git SHA, selected profile/topics, record/replay/mission commands, and exit/result codes).
- Introduces three named evidence profiles (minimal, debug, heavy) as a YAML configuration to control topic allowlists for lightweight to heavy captures.
- Adds README documentation describing the evidence-pack workflow, examples for plan-only previews and replay, and guidance for Jetson storage backends.
- Adds focused unit tests for profile loading, command construction, plan layout, config snapshotting, manifest contents, and mission-summary parsing.
- Updates packaging to expose the new CLI entry point and add ros2bag as a runtime dependency.
- Adds /mission_evidence/ to .gitignore so generated packs aren't committed.

### User-visible behavior
- New CLI: mission_evidence (entry point installed) supports:
  - --profile {minimal,debug,heavy}
  - --plan-only to preview manifest and commands without recording
  - options for bag splitting, storage backend, and mission command execution
  - outputs a replay command written into the manifest for later playback
- Default "minimal" profile provides lean captures for routine dry runs; "debug" and "heavy" increase captured topics for troubleshooting or in-depth investigations.

### Validation
- Static checks: ruff, pyright, py_compile on changed Python.
- Tests: unit tests run locally and on Jetson (colcon build/test for lunabot_bringup).
- Runtime: on Jetson, plan-only produced a valid manifest; recording captured a /mission/state message and ros2 bag info read the sqlite3 bag successfully.

### Related issues
- Linear: INX-44, INX-17, INX-24

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/288)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->