### PR TITLE
feat(bringup): define Jetson runtime profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ Exit codes:
 - `1`: warnings present
 - `2`: failures present
 
+## Jetson runtime profile
+
+Before a scored-run rehearsal, check that the runtime/comms profile is still
+lean:
+
+```bash
+ros2 run lunabot_bringup runtime_profile check
+ros2 run lunabot_bringup runtime_profile show --profile hardware_competition
+```
+
+The profile rules live in
+[`docs/jetson_runtime_profiles.md`](docs/jetson_runtime_profiles.md).
+
 ## Visualisation options
 
 | Tool | Purpose | Command |

--- a/docs/jetson_runtime_profiles.md
+++ b/docs/jetson_runtime_profiles.md
@@ -1,0 +1,103 @@
+# Jetson Runtime Profiles
+
+The competition communications rule that matters most for software is simple:
+average data utilisation must stay at or below **4,000 Kbps**. There is no peak
+limit, but treating that as permission to stream raw sensors would be a small
+masterclass in missing the point.
+
+The default competition posture is:
+
+- run autonomy and safety locally on the Jetson;
+- expose only operator telemetry and health topics to Foxglove;
+- keep raw images, point clouds, RViz, Gazebo and heavy rosbag captures off by
+  default;
+- record evidence locally with the minimal rosbag profile unless debugging
+  requires more.
+
+The machine-readable source of truth is:
+
+```bash
+ros2 run lunabot_bringup runtime_profile check
+ros2 run lunabot_bringup runtime_profile show --profile hardware_competition
+```
+
+## Profiles
+
+| Profile | Use it for | Default posture |
+|---|---|---|
+| `sim_debug` | Local simulation debugging | Visual tools and selected heavy topics allowed. |
+| `sim_competition` | Dress rehearsal | Same telemetry rules as competition, with sim time. |
+| `hardware_bringup` | Bench checks | Hardware bridges on, debug tools explicit, raw streams off. |
+| `hardware_competition` | Competition run | Lean telemetry only, no raw sensor streams. |
+
+## Foxglove Exposure
+
+For `hardware_competition`, expose only:
+
+- `/mission/state`
+- `/mission/autonomy_mode`
+- `/mission/time_remaining_s`
+- `/mission/cycle_count`
+- `/mission/last_failure_reason`
+- `/safety/estop`
+- `/safety/motion_inhibit`
+- `/drivetrain/status`
+- `/excavation/status`
+- `/localisation/start_zone_status`
+- `/diagnostics`
+
+Do not expose raw camera images, point clouds, debug costmap panels or the heavy
+rosbag profile during a scored run. If a raw stream is needed for diagnosis, use
+`hardware_bringup` or `sim_debug`, say why, and turn it back off before the run.
+
+## Measurement Commands
+
+Run these on the Jetson during a representative dry mission:
+
+```bash
+ros2 run lunabot_bringup runtime_profile check
+ros2 run lunabot_bringup runtime_profile show --profile hardware_competition --json
+ros2 topic bw /mission/state
+ros2 topic bw /drivetrain/status
+ros2 topic bw /excavation/status
+ros2 topic hz /diagnostics
+top -b -n 1 | head -n 20
+free -h
+du -sh ~/innex1_mission_evidence 2>/dev/null || true
+```
+
+For Foxglove traffic, measure at the network edge as well as ROS:
+
+```bash
+ip -s link
+sar -n DEV 1 10
+```
+
+If `sar` is not installed, use `ifstat`, `nload`, router counters, or the access
+point dashboard. The number that matters is average utilisation on the robot
+communications link, not only the estimated ROS payload.
+
+## Launch Defaults
+
+Competition launch arguments should match the checked profile:
+
+```bash
+ros2 launch lunabot_bringup navigation.launch.py \
+  use_sim_time:=false \
+  launch_rviz:=false \
+  enable_teleop:=false \
+  lidar_costmap_phase:=false \
+  enable_apriltag_debug:=false
+```
+
+Evidence capture should stay lean:
+
+```bash
+ros2 run lunabot_bringup mission_evidence \
+  --profile minimal \
+  --label hardware-competition \
+  -- ros2 launch lunabot_bringup mission_manager.launch.py
+```
+
+Use `debug` or `heavy` evidence profiles only for short investigations. They are
+not the default scored-run posture.

--- a/src/lunabot_bringup/config/runtime_profiles.yaml
+++ b/src/lunabot_bringup/config/runtime_profiles.yaml
@@ -1,0 +1,290 @@
+profiles:
+  sim_debug:
+    description: Full local simulation debugging with visual tools enabled.
+    budget_kbps: 6000
+    target_kbps: 6000
+    launch_arguments:
+      navigation:
+        use_sim_time: true
+        launch_rviz: true
+        enable_teleop: true
+        lidar_costmap_phase: true
+        enable_apriltag_debug: true
+      moon_yard:
+        use_sim_time: true
+    required_processes:
+      - ros_gz_sim
+      - ros_gz_bridge
+      - nav2
+      - localisation
+    optional_tools:
+      - rviz2
+      - foxglove_bridge
+      - rosbag record --profile debug
+    off_by_default:
+      - hardware motor bridges
+    foxglove_allowlist:
+      - /mission/state
+      - /mission/autonomy_mode
+      - /mission/time_remaining_s
+      - /mission/cycle_count
+      - /mission/last_failure_reason
+      - /safety/estop
+      - /safety/motion_inhibit
+      - /drivetrain/status
+      - /excavation/status
+      - /localisation/start_zone_status
+      - /map
+      - /local_costmap/costmap
+      - /global_costmap/costmap
+      - /ouster/points
+      - /camera_front/points
+    telemetry_topics:
+      - name: /mission/state
+        max_hz: 1.0
+        estimated_bytes: 64
+      - name: /mission/autonomy_mode
+        max_hz: 1.0
+        estimated_bytes: 64
+      - name: /mission/time_remaining_s
+        max_hz: 1.0
+        estimated_bytes: 32
+      - name: /mission/cycle_count
+        max_hz: 1.0
+        estimated_bytes: 32
+      - name: /mission/last_failure_reason
+        max_hz: 1.0
+        estimated_bytes: 128
+      - name: /drivetrain/status
+        max_hz: 10.0
+        estimated_bytes: 128
+      - name: /excavation/status
+        max_hz: 10.0
+        estimated_bytes: 128
+      - name: /map
+        max_hz: 1.0
+        estimated_bytes: 320000
+      - name: /local_costmap/costmap
+        max_hz: 2.0
+        estimated_bytes: 80000
+      - name: /global_costmap/costmap
+        max_hz: 1.0
+        estimated_bytes: 160000
+
+  sim_competition:
+    description: Simulation dress rehearsal using competition telemetry rules.
+    budget_kbps: 4000
+    target_kbps: 1000
+    launch_arguments:
+      navigation:
+        use_sim_time: true
+        launch_rviz: false
+        enable_teleop: false
+        lidar_costmap_phase: false
+        enable_apriltag_debug: false
+      moon_yard:
+        use_sim_time: true
+    required_processes:
+      - ros_gz_sim
+      - ros_gz_bridge
+      - nav2
+      - localisation
+      - mission_manager
+    optional_tools:
+      - mission_evidence --profile minimal
+    off_by_default:
+      - rviz2
+      - foxglove raw image panels
+      - raw pointcloud streaming
+      - heavy rosbag profile
+    foxglove_allowlist:
+      - /mission/state
+      - /mission/autonomy_mode
+      - /mission/time_remaining_s
+      - /mission/cycle_count
+      - /mission/last_failure_reason
+      - /safety/estop
+      - /safety/motion_inhibit
+      - /drivetrain/status
+      - /excavation/status
+      - /localisation/start_zone_status
+      - /diagnostics
+    telemetry_topics:
+      - name: /mission/state
+        max_hz: 1.0
+        estimated_bytes: 64
+      - name: /mission/autonomy_mode
+        max_hz: 1.0
+        estimated_bytes: 64
+      - name: /mission/time_remaining_s
+        max_hz: 1.0
+        estimated_bytes: 32
+      - name: /mission/cycle_count
+        max_hz: 1.0
+        estimated_bytes: 32
+      - name: /mission/last_failure_reason
+        max_hz: 1.0
+        estimated_bytes: 128
+      - name: /safety/estop
+        max_hz: 2.0
+        estimated_bytes: 24
+      - name: /safety/motion_inhibit
+        max_hz: 2.0
+        estimated_bytes: 24
+      - name: /drivetrain/status
+        max_hz: 5.0
+        estimated_bytes: 128
+      - name: /excavation/status
+        max_hz: 5.0
+        estimated_bytes: 128
+      - name: /localisation/start_zone_status
+        max_hz: 2.0
+        estimated_bytes: 256
+      - name: /diagnostics
+        max_hz: 1.0
+        estimated_bytes: 1024
+
+  hardware_bringup:
+    description: Bench profile for hardware checkout before competition mode.
+    budget_kbps: 4000
+    target_kbps: 1500
+    launch_arguments:
+      navigation:
+        use_sim_time: false
+        launch_rviz: false
+        enable_teleop: true
+        lidar_costmap_phase: false
+        enable_apriltag_debug: false
+      drivetrain_bench:
+        dry_run: false
+      material_actions:
+        use_mock_telemetry: false
+    required_processes:
+      - velocity_gate
+      - drivetrain_bridge
+      - deposition_bridge
+      - excavation_controller
+      - localisation
+    optional_tools:
+      - rviz2 on operator laptop
+      - foxglove_bridge with competition allowlist
+      - mission_evidence --profile minimal
+    off_by_default:
+      - Gazebo
+      - raw image streaming
+      - raw pointcloud streaming
+      - heavy rosbag profile
+    foxglove_allowlist:
+      - /mission/state
+      - /mission/autonomy_mode
+      - /mission/time_remaining_s
+      - /mission/cycle_count
+      - /mission/last_failure_reason
+      - /safety/estop
+      - /safety/motion_inhibit
+      - /drivetrain/status
+      - /drivetrain/telemetry
+      - /excavation/status
+      - /excavation/telemetry
+      - /localisation/start_zone_status
+      - /diagnostics
+    telemetry_topics:
+      - name: /drivetrain/status
+        max_hz: 5.0
+        estimated_bytes: 128
+      - name: /drivetrain/telemetry
+        max_hz: 5.0
+        estimated_bytes: 192
+      - name: /excavation/status
+        max_hz: 5.0
+        estimated_bytes: 128
+      - name: /excavation/telemetry
+        max_hz: 5.0
+        estimated_bytes: 192
+      - name: /localisation/start_zone_status
+        max_hz: 2.0
+        estimated_bytes: 256
+      - name: /diagnostics
+        max_hz: 1.0
+        estimated_bytes: 1024
+
+  hardware_competition:
+    description: Lean default for the competition run.
+    budget_kbps: 4000
+    target_kbps: 800
+    launch_arguments:
+      navigation:
+        use_sim_time: false
+        launch_rviz: false
+        enable_teleop: false
+        lidar_costmap_phase: false
+        enable_apriltag_debug: false
+      drivetrain_bench:
+        dry_run: false
+      material_actions:
+        use_mock_telemetry: false
+    required_processes:
+      - velocity_gate
+      - drivetrain_bridge
+      - deposition_bridge
+      - excavation_controller
+      - localisation
+      - nav2
+      - mission_manager
+      - rover_diagnostics
+    optional_tools:
+      - mission_evidence --profile minimal
+    off_by_default:
+      - rviz2
+      - Gazebo
+      - raw image streaming
+      - raw pointcloud streaming
+      - foxglove raw panels
+      - heavy rosbag profile
+      - debug costmap panels
+    foxglove_allowlist:
+      - /mission/state
+      - /mission/autonomy_mode
+      - /mission/time_remaining_s
+      - /mission/cycle_count
+      - /mission/last_failure_reason
+      - /safety/estop
+      - /safety/motion_inhibit
+      - /drivetrain/status
+      - /excavation/status
+      - /localisation/start_zone_status
+      - /diagnostics
+    telemetry_topics:
+      - name: /mission/state
+        max_hz: 1.0
+        estimated_bytes: 64
+      - name: /mission/autonomy_mode
+        max_hz: 1.0
+        estimated_bytes: 64
+      - name: /mission/time_remaining_s
+        max_hz: 1.0
+        estimated_bytes: 32
+      - name: /mission/cycle_count
+        max_hz: 1.0
+        estimated_bytes: 32
+      - name: /mission/last_failure_reason
+        max_hz: 1.0
+        estimated_bytes: 128
+      - name: /safety/estop
+        max_hz: 2.0
+        estimated_bytes: 24
+      - name: /safety/motion_inhibit
+        max_hz: 2.0
+        estimated_bytes: 24
+      - name: /drivetrain/status
+        max_hz: 2.0
+        estimated_bytes: 128
+      - name: /excavation/status
+        max_hz: 2.0
+        estimated_bytes: 128
+      - name: /localisation/start_zone_status
+        max_hz: 1.0
+        estimated_bytes: 256
+      - name: /diagnostics
+        max_hz: 1.0
+        estimated_bytes: 1024

--- a/src/lunabot_bringup/lunabot_bringup/runtime_profile.py
+++ b/src/lunabot_bringup/lunabot_bringup/runtime_profile.py
@@ -1,0 +1,275 @@
+"""Validate lean Jetson runtime and communications profiles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+COMPETITION_BUDGET_KBPS = 4000.0
+RAW_STREAM_MARKERS = ("image", "points", "pointcloud", "camera")
+COMPETITION_PROFILES = ("sim_competition", "hardware_competition")
+
+
+@dataclass(frozen=True)
+class TelemetryTopic:
+    """Expected topic rate and approximate payload size."""
+
+    name: str
+    max_hz: float
+    estimated_bytes: int
+
+    @property
+    def estimated_kbps(self) -> float:
+        """Return estimated average wire payload in Kbps."""
+        return self.max_hz * self.estimated_bytes * 8.0 / 1000.0
+
+
+@dataclass(frozen=True)
+class RuntimeProfile:
+    """One named runtime/comms profile."""
+
+    name: str
+    description: str
+    budget_kbps: float
+    target_kbps: float
+    launch_arguments: dict[str, dict[str, Any]]
+    required_processes: tuple[str, ...]
+    optional_tools: tuple[str, ...]
+    off_by_default: tuple[str, ...]
+    foxglove_allowlist: tuple[str, ...]
+    telemetry_topics: tuple[TelemetryTopic, ...]
+
+    @property
+    def estimated_kbps(self) -> float:
+        """Return estimated average telemetry load in Kbps."""
+        return sum(topic.estimated_kbps for topic in self.telemetry_topics)
+
+    @property
+    def budget_margin_kbps(self) -> float:
+        """Return remaining budget after estimated telemetry load."""
+        return self.budget_kbps - self.estimated_kbps
+
+
+def default_profiles_path() -> Path:
+    """Return the installed runtime profile config path."""
+    from ament_index_python.packages import get_package_share_directory
+
+    share_dir = Path(get_package_share_directory("lunabot_bringup"))
+    return share_dir / "config" / "runtime_profiles.yaml"
+
+
+def _strings(raw_values: Any, *, field: str, profile_name: str) -> tuple[str, ...]:
+    if not isinstance(raw_values, list) or any(
+        not isinstance(value, str) for value in raw_values
+    ):
+        raise ValueError(f"profile {profile_name!r} field {field!r} must be strings")
+    return tuple(raw_values)
+
+
+def _telemetry_topics(
+    raw_values: Any, *, profile_name: str
+) -> tuple[TelemetryTopic, ...]:
+    if not isinstance(raw_values, list) or not raw_values:
+        raise ValueError(f"profile {profile_name!r} must list telemetry topics")
+
+    topics: list[TelemetryTopic] = []
+    for item in raw_values:
+        if not isinstance(item, dict):
+            raise ValueError(f"profile {profile_name!r} has invalid topic entry")
+
+        name = item.get("name")
+        max_hz = item.get("max_hz")
+        estimated_bytes = item.get("estimated_bytes")
+        if not isinstance(name, str) or not name.startswith("/"):
+            raise ValueError(f"profile {profile_name!r} has invalid topic name")
+        if not isinstance(max_hz, int | float) or max_hz <= 0:
+            raise ValueError(f"profile {profile_name!r} has invalid topic rate")
+        if not isinstance(estimated_bytes, int) or estimated_bytes <= 0:
+            raise ValueError(f"profile {profile_name!r} has invalid topic size")
+
+        topics.append(
+            TelemetryTopic(
+                name=name,
+                max_hz=float(max_hz),
+                estimated_bytes=estimated_bytes,
+            )
+        )
+    return tuple(topics)
+
+
+def load_profiles(path: Path) -> dict[str, RuntimeProfile]:
+    """Load runtime profiles from YAML."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("profiles"), dict):
+        raise ValueError(f"invalid runtime profile file: {path}")
+
+    profiles: dict[str, RuntimeProfile] = {}
+    for name, raw_profile in data["profiles"].items():
+        if not isinstance(name, str) or not isinstance(raw_profile, dict):
+            raise ValueError(f"invalid runtime profile entry in {path}")
+
+        launch_arguments = raw_profile.get("launch_arguments", {})
+        if not isinstance(launch_arguments, dict):
+            raise ValueError(f"profile {name!r} launch_arguments must be a mapping")
+
+        profiles[name] = RuntimeProfile(
+            name=name,
+            description=str(raw_profile.get("description", "")),
+            budget_kbps=float(raw_profile.get("budget_kbps", 0.0)),
+            target_kbps=float(raw_profile.get("target_kbps", 0.0)),
+            launch_arguments=launch_arguments,
+            required_processes=_strings(
+                raw_profile.get("required_processes", []),
+                field="required_processes",
+                profile_name=name,
+            ),
+            optional_tools=_strings(
+                raw_profile.get("optional_tools", []),
+                field="optional_tools",
+                profile_name=name,
+            ),
+            off_by_default=_strings(
+                raw_profile.get("off_by_default", []),
+                field="off_by_default",
+                profile_name=name,
+            ),
+            foxglove_allowlist=_strings(
+                raw_profile.get("foxglove_allowlist", []),
+                field="foxglove_allowlist",
+                profile_name=name,
+            ),
+            telemetry_topics=_telemetry_topics(
+                raw_profile.get("telemetry_topics"),
+                profile_name=name,
+            ),
+        )
+    return profiles
+
+
+def validate_profile(profile: RuntimeProfile) -> list[str]:
+    """Return validation errors for one runtime profile."""
+    errors: list[str] = []
+    if profile.estimated_kbps > profile.target_kbps:
+        errors.append(
+            f"{profile.name}: estimated telemetry {profile.estimated_kbps:.1f} "
+            f"Kbps exceeds target {profile.target_kbps:.1f} Kbps"
+        )
+    if profile.estimated_kbps > profile.budget_kbps:
+        errors.append(
+            f"{profile.name}: estimated telemetry {profile.estimated_kbps:.1f} "
+            f"Kbps exceeds budget {profile.budget_kbps:.1f} Kbps"
+        )
+
+    if profile.name in COMPETITION_PROFILES:
+        if profile.budget_kbps > COMPETITION_BUDGET_KBPS:
+            errors.append(
+                f"{profile.name}: budget {profile.budget_kbps:.0f} Kbps exceeds "
+                f"{COMPETITION_BUDGET_KBPS:.0f} Kbps"
+            )
+
+        exposed = " ".join(profile.foxglove_allowlist).lower()
+        forbidden = [marker for marker in RAW_STREAM_MARKERS if marker in exposed]
+        if forbidden:
+            errors.append(
+                f"{profile.name}: competition Foxglove allowlist exposes raw "
+                f"stream markers: {', '.join(forbidden)}"
+            )
+
+        off_by_default = " ".join(profile.off_by_default).lower()
+        for marker in ("raw image", "raw pointcloud", "heavy rosbag"):
+            if marker not in off_by_default:
+                errors.append(f"{profile.name}: {marker} must be off by default")
+    return errors
+
+
+def validate_profiles(profiles: dict[str, RuntimeProfile]) -> list[str]:
+    """Return validation errors for all loaded profiles."""
+    required = {
+        "sim_debug",
+        "sim_competition",
+        "hardware_bringup",
+        "hardware_competition",
+    }
+    errors = [
+        f"missing required runtime profile: {name}"
+        for name in sorted(required.difference(profiles))
+    ]
+    for profile in profiles.values():
+        errors.extend(validate_profile(profile))
+    return errors
+
+
+def profile_summary(profile: RuntimeProfile) -> dict[str, Any]:
+    """Return a JSON-serialisable profile summary."""
+    return {
+        "name": profile.name,
+        "description": profile.description,
+        "budget_kbps": profile.budget_kbps,
+        "target_kbps": profile.target_kbps,
+        "estimated_kbps": round(profile.estimated_kbps, 3),
+        "budget_margin_kbps": round(profile.budget_margin_kbps, 3),
+        "foxglove_allowlist": list(profile.foxglove_allowlist),
+        "off_by_default": list(profile.off_by_default),
+        "telemetry_topics": [
+            {
+                "name": topic.name,
+                "max_hz": topic.max_hz,
+                "estimated_bytes": topic.estimated_bytes,
+                "estimated_kbps": round(topic.estimated_kbps, 3),
+            }
+            for topic in profile.telemetry_topics
+        ],
+    }
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Inspect Jetson runtime and communications profiles.",
+    )
+    parser.add_argument("command", choices=("check", "show"))
+    parser.add_argument("--profiles-file", type=Path, default=None)
+    parser.add_argument("--profile", default="hardware_competition")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the runtime profile CLI."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    profiles = load_profiles(args.profiles_file or default_profiles_path())
+
+    if args.command == "check":
+        errors = validate_profiles(profiles)
+        if errors:
+            for error in errors:
+                print(error, file=sys.stderr)
+            return 1
+        print("runtime profiles: pass")
+        return 0
+
+    profile = profiles.get(args.profile)
+    if profile is None:
+        print(f"unknown runtime profile: {args.profile}", file=sys.stderr)
+        return 2
+
+    summary = profile_summary(profile)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"profile: {profile.name}")
+        print(f"estimated_kbps: {summary['estimated_kbps']}")
+        print(f"budget_margin_kbps: {summary['budget_margin_kbps']}")
+        print("foxglove_allowlist:")
+        for topic in profile.foxglove_allowlist:
+            print(f"- {topic}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lunabot_bringup/setup.py
+++ b/src/lunabot_bringup/setup.py
@@ -52,6 +52,7 @@ setup(
             "mission_dry_run = lunabot_bringup.mission_dry_run:main",
             "mission_manager = lunabot_bringup.mission_manager:main",
             "preflight_check = lunabot_bringup.preflight_check:main",
+            "runtime_profile = lunabot_bringup.runtime_profile:main",
         ],
     },
 )

--- a/src/lunabot_bringup/test/test_runtime_profile.py
+++ b/src/lunabot_bringup/test/test_runtime_profile.py
@@ -1,0 +1,71 @@
+"""Unit tests for Jetson runtime profile guardrails."""
+
+from pathlib import Path
+
+from lunabot_bringup.runtime_profile import (
+    COMPETITION_BUDGET_KBPS,
+    COMPETITION_PROFILES,
+    load_profiles,
+    profile_summary,
+    validate_profiles,
+)
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_PROFILES_PATH = PACKAGE_ROOT / "config" / "runtime_profiles.yaml"
+
+
+def test_required_runtime_profiles_are_present():
+    profiles = load_profiles(RUNTIME_PROFILES_PATH)
+
+    assert {
+        "sim_debug",
+        "sim_competition",
+        "hardware_bringup",
+        "hardware_competition",
+    }.issubset(profiles)
+
+
+def test_runtime_profiles_pass_guardrails():
+    profiles = load_profiles(RUNTIME_PROFILES_PATH)
+
+    assert validate_profiles(profiles) == []
+
+
+def test_competition_profiles_stay_below_rulebook_budget_with_margin():
+    profiles = load_profiles(RUNTIME_PROFILES_PATH)
+
+    for name in COMPETITION_PROFILES:
+        profile = profiles[name]
+        assert profile.budget_kbps <= COMPETITION_BUDGET_KBPS
+        assert profile.estimated_kbps <= profile.target_kbps
+        assert profile.budget_margin_kbps >= 3000.0
+
+
+def test_competition_foxglove_allowlists_exclude_raw_streams():
+    profiles = load_profiles(RUNTIME_PROFILES_PATH)
+
+    for name in COMPETITION_PROFILES:
+        exposed = " ".join(profiles[name].foxglove_allowlist).lower()
+        assert "image" not in exposed
+        assert "points" not in exposed
+        assert "camera" not in exposed
+
+
+def test_hardware_competition_keeps_debug_tools_off_by_default():
+    profiles = load_profiles(RUNTIME_PROFILES_PATH)
+
+    off_by_default = " ".join(profiles["hardware_competition"].off_by_default).lower()
+
+    assert "rviz2" in off_by_default
+    assert "gazebo" in off_by_default
+    assert "heavy rosbag" in off_by_default
+
+
+def test_profile_summary_reports_estimated_bandwidth():
+    profiles = load_profiles(RUNTIME_PROFILES_PATH)
+
+    summary = profile_summary(profiles["hardware_competition"])
+
+    assert summary["estimated_kbps"] > 0
+    assert summary["budget_margin_kbps"] > 0
+    assert summary["telemetry_topics"][0]["estimated_kbps"] > 0


### PR DESCRIPTION
## Summary
- add checked sim-debug, sim-competition, hardware-bringup, and hardware-competition runtime profiles
- add a runtime_profile CLI that validates competition bandwidth/raw-stream guardrails and reports estimated telemetry load
- document Jetson competition comms posture, Foxglove allowlist, and measurement commands

## Validation
- Local: ruff check for changed Python paths, ruff format check for changed Python paths, pyright, py_compile
- Local: PYTHONPATH=src/lunabot_bringup pytest -q src/lunabot_bringup/test/test_runtime_profile.py
- Jetson: clean temp clone, colcon build --packages-up-to lunabot_bringup
- Jetson: colcon test --packages-select lunabot_bringup --pytest-args test/test_runtime_profile.py
- Jetson: ros2 run lunabot_bringup runtime_profile check
- Jetson: ros2 run lunabot_bringup runtime_profile show --profile hardware_competition --json reports ~17.7 Kbps estimated telemetry and >3,900 Kbps margin

Linear: INX-45, INX-18, INX-7, INX-11