### PR TITLE
feat(bringup): add hardware fault injection

### DIFF
--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -82,6 +82,51 @@ For a direct shell exit code without the composed sim launch, run the harness en
 ros2 run lunabot_bringup mission_dry_run
 ```
 
+## Hardware Fault Injection
+
+Use the hardware fault injector when you want software-only checks for real
+hardware boundary failures. It publishes the same ROS interfaces as the
+hardware-facing nodes, so preflight and dry-run tooling see a controller-offline
+drivetrain, asserted E-stop, excavation driver fault, or lost localisation as a
+real contract failure rather than a private test stub.
+
+List the available scenarios:
+
+```bash
+ros2 run lunabot_bringup hardware_fault_injector --scenario nominal --list
+```
+
+Publish a healthy mock boundary for a short preflight smoke check:
+
+```bash
+ros2 run lunabot_bringup hardware_fault_injector \
+  --scenario nominal --duration-s 8
+```
+
+In another terminal, check that the hardware-boundary preflight accepts the
+healthy case:
+
+```bash
+ros2 run lunabot_bringup preflight_check \
+  --config src/lunabot_bringup/config/preflight_checks_fault_injection.yaml \
+  --use-sim-time false
+```
+
+Then publish a fault, for example:
+
+```bash
+ros2 run lunabot_bringup hardware_fault_injector \
+  --scenario drivetrain_controller_offline --duration-s 12
+```
+
+The same preflight command should fail with a field mismatch such as
+`fault_code expected=0 got=3`. That is the point: the failure is visible on the
+real project topic and the operator-facing check says what changed.
+
+Scenarios that publish `/safety/estop` or `/safety/motion_inhibit` require an
+explicit `--allow-live-topics` flag. Use that only with an isolated
+`ROS_DOMAIN_ID`; those topics are live safety inputs, not harmless log lines.
+
 ## Common failure modes
 
 - Launch starts successfully but one critical node crashes shortly after (dependency mismatch).

--- a/src/lunabot_bringup/config/hardware_fault_scenarios.yaml
+++ b/src/lunabot_bringup/config/hardware_fault_scenarios.yaml
@@ -1,0 +1,227 @@
+scenarios:
+  nominal:
+    description: Healthy hardware-boundary publishers for dry preflight checks.
+    topics:
+      - name: /drivetrain/status
+        type: lunabot_interfaces/msg/DrivetrainStatus
+        rate_hz: 5.0
+        fields:
+          state: 1
+          fault_code: 0
+          estop_active: false
+          motion_inhibited: false
+          controller_online: [true, true]
+      - name: /drivetrain/telemetry
+        type: lunabot_interfaces/msg/DrivetrainTelemetry
+        rate_hz: 5.0
+        fields:
+          wheel_velocity_rps: [0.0, 0.0, 0.0, 0.0]
+          encoder_ticks: [0, 0, 0, 0]
+          controller_online: [true, true]
+          estop_active: false
+          motion_inhibited: false
+          fault_code: 0
+      - name: /excavation/telemetry
+        type: lunabot_interfaces/msg/ExcavationTelemetry
+        rate_hz: 5.0
+        fields:
+          estop_active: false
+          driver_fault: false
+          home_switch: true
+          motor_enabled: false
+          motor_current_a: 0.0
+          fault_code: 0
+      - name: /localisation/start_zone_status
+        type: lunabot_interfaces/msg/LocalisationStartZoneStatus
+        rate_hz: 2.0
+        fields:
+          state: ready
+          ready: true
+          reason_code: locked
+          reason_detail: start-zone tag lock stable
+          stable_lock_age_s: 1.0
+          search_elapsed_s: 0.0
+
+  drivetrain_controller_offline:
+    description: Sabertooth controller missing at the drivetrain boundary.
+    topics:
+      - name: /drivetrain/status
+        type: lunabot_interfaces/msg/DrivetrainStatus
+        rate_hz: 5.0
+        fields:
+          state: 4
+          fault_code: 3
+          estop_active: false
+          motion_inhibited: false
+          controller_online: [false, false]
+      - name: /drivetrain/telemetry
+        type: lunabot_interfaces/msg/DrivetrainTelemetry
+        rate_hz: 5.0
+        fields:
+          wheel_velocity_rps: [0.0, 0.0, 0.0, 0.0]
+          encoder_ticks: [0, 0, 0, 0]
+          controller_online: [false, false]
+          estop_active: false
+          motion_inhibited: false
+          fault_code: 3
+      - name: /excavation/telemetry
+        type: lunabot_interfaces/msg/ExcavationTelemetry
+        rate_hz: 5.0
+        fields:
+          estop_active: false
+          driver_fault: false
+          home_switch: true
+          motor_enabled: false
+          motor_current_a: 0.0
+          fault_code: 0
+      - name: /localisation/start_zone_status
+        type: lunabot_interfaces/msg/LocalisationStartZoneStatus
+        rate_hz: 2.0
+        fields:
+          state: ready
+          ready: true
+          reason_code: locked
+          reason_detail: start-zone tag lock stable
+          stable_lock_age_s: 1.0
+          search_elapsed_s: 0.0
+
+  estop_asserted:
+    description: Operator or safety path has asserted the E-stop.
+    topics:
+      - name: /safety/estop
+        type: std_msgs/msg/Bool
+        rate_hz: 5.0
+        transient_local: true
+        fields:
+          data: true
+      - name: /safety/motion_inhibit
+        type: std_msgs/msg/Bool
+        rate_hz: 5.0
+        transient_local: true
+        fields:
+          data: true
+      - name: /drivetrain/status
+        type: lunabot_interfaces/msg/DrivetrainStatus
+        rate_hz: 5.0
+        fields:
+          state: 5
+          fault_code: 1
+          estop_active: true
+          motion_inhibited: true
+          controller_online: [true, true]
+      - name: /drivetrain/telemetry
+        type: lunabot_interfaces/msg/DrivetrainTelemetry
+        rate_hz: 5.0
+        fields:
+          wheel_velocity_rps: [0.0, 0.0, 0.0, 0.0]
+          encoder_ticks: [0, 0, 0, 0]
+          controller_online: [true, true]
+          estop_active: true
+          motion_inhibited: true
+          fault_code: 1
+      - name: /excavation/telemetry
+        type: lunabot_interfaces/msg/ExcavationTelemetry
+        rate_hz: 5.0
+        fields:
+          estop_active: true
+          driver_fault: false
+          home_switch: true
+          motor_enabled: false
+          motor_current_a: 0.0
+          fault_code: 1
+      - name: /localisation/start_zone_status
+        type: lunabot_interfaces/msg/LocalisationStartZoneStatus
+        rate_hz: 2.0
+        fields:
+          state: ready
+          ready: true
+          reason_code: locked
+          reason_detail: start-zone tag lock stable
+          stable_lock_age_s: 1.0
+          search_elapsed_s: 0.0
+
+  excavation_driver_fault:
+    description: Excavation motor driver reports a persistent fault.
+    topics:
+      - name: /drivetrain/status
+        type: lunabot_interfaces/msg/DrivetrainStatus
+        rate_hz: 5.0
+        fields:
+          state: 1
+          fault_code: 0
+          estop_active: false
+          motion_inhibited: false
+          controller_online: [true, true]
+      - name: /drivetrain/telemetry
+        type: lunabot_interfaces/msg/DrivetrainTelemetry
+        rate_hz: 5.0
+        fields:
+          wheel_velocity_rps: [0.0, 0.0, 0.0, 0.0]
+          encoder_ticks: [0, 0, 0, 0]
+          controller_online: [true, true]
+          estop_active: false
+          motion_inhibited: false
+          fault_code: 0
+      - name: /excavation/telemetry
+        type: lunabot_interfaces/msg/ExcavationTelemetry
+        rate_hz: 5.0
+        fields:
+          estop_active: false
+          driver_fault: true
+          home_switch: true
+          motor_enabled: false
+          motor_current_a: 0.0
+          fault_code: 2
+      - name: /localisation/start_zone_status
+        type: lunabot_interfaces/msg/LocalisationStartZoneStatus
+        rate_hz: 2.0
+        fields:
+          state: ready
+          ready: true
+          reason_code: locked
+          reason_detail: start-zone tag lock stable
+          stable_lock_age_s: 1.0
+          search_elapsed_s: 0.0
+
+  localisation_lost:
+    description: Start-zone localisation is stale or unavailable.
+    topics:
+      - name: /drivetrain/status
+        type: lunabot_interfaces/msg/DrivetrainStatus
+        rate_hz: 5.0
+        fields:
+          state: 1
+          fault_code: 0
+          estop_active: false
+          motion_inhibited: false
+          controller_online: [true, true]
+      - name: /drivetrain/telemetry
+        type: lunabot_interfaces/msg/DrivetrainTelemetry
+        rate_hz: 5.0
+        fields:
+          wheel_velocity_rps: [0.0, 0.0, 0.0, 0.0]
+          encoder_ticks: [0, 0, 0, 0]
+          controller_online: [true, true]
+          estop_active: false
+          motion_inhibited: false
+          fault_code: 0
+      - name: /excavation/telemetry
+        type: lunabot_interfaces/msg/ExcavationTelemetry
+        rate_hz: 5.0
+        fields:
+          estop_active: false
+          driver_fault: false
+          home_switch: true
+          motor_enabled: false
+          motor_current_a: 0.0
+          fault_code: 0
+      - name: /localisation/start_zone_status
+        type: lunabot_interfaces/msg/LocalisationStartZoneStatus
+        rate_hz: 2.0
+        fields:
+          state: lost
+          ready: false
+          reason_code: tag_lost
+          reason_detail: start-zone tag not visible
+          stable_lock_age_s: 0.0
+          search_elapsed_s: 6.0

--- a/src/lunabot_bringup/config/preflight_checks_fault_injection.yaml
+++ b/src/lunabot_bringup/config/preflight_checks_fault_injection.yaml
@@ -1,0 +1,54 @@
+preflight:
+  use_interface_contracts: false
+
+  sim_time:
+    enabled: false
+
+  topic_message_timeout_s: 2.0
+  topic_discovery_timeout_s: 2.0
+
+  required_topics:
+    - name: /drivetrain/status
+      type: lunabot_interfaces/msg/DrivetrainStatus
+      min_messages: 1
+      critical: true
+      reliability: reliable
+      expected_fields:
+        state: 1
+        fault_code: 0
+        estop_active: false
+        motion_inhibited: false
+        controller_online[0]: true
+        controller_online[1]: true
+    - name: /drivetrain/telemetry
+      type: lunabot_interfaces/msg/DrivetrainTelemetry
+      min_messages: 1
+      critical: true
+      reliability: reliable
+      expected_fields:
+        fault_code: 0
+        estop_active: false
+        motion_inhibited: false
+        controller_online[0]: true
+        controller_online[1]: true
+    - name: /excavation/telemetry
+      type: lunabot_interfaces/msg/ExcavationTelemetry
+      min_messages: 1
+      critical: true
+      reliability: reliable
+      expected_fields:
+        estop_active: false
+        driver_fault: false
+        fault_code: 0
+    - name: /localisation/start_zone_status
+      type: lunabot_interfaces/msg/LocalisationStartZoneStatus
+      min_messages: 1
+      critical: true
+      reliability: reliable
+      expected_fields:
+        ready: true
+        state: ready
+
+  required_tf_links: []
+  required_actions: []
+  required_nodes: []

--- a/src/lunabot_bringup/lunabot_bringup/hardware_fault_injection.py
+++ b/src/lunabot_bringup/lunabot_bringup/hardware_fault_injection.py
@@ -1,0 +1,287 @@
+"""Publish deterministic hardware-boundary fault scenarios."""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import rclpy
+import yaml
+from ament_index_python.packages import get_package_share_directory
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+from rosidl_runtime_py.utilities import get_message
+
+
+@dataclass(frozen=True)
+class TopicInjection:
+    """One topic and message payload published by a fault scenario."""
+
+    name: str
+    type_name: str
+    fields: dict[str, Any]
+    rate_hz: float
+    transient_local: bool = False
+
+
+@dataclass(frozen=True)
+class FaultScenario:
+    """A named group of topic injections."""
+
+    name: str
+    description: str
+    topics: tuple[TopicInjection, ...]
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load and validate a YAML mapping."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return data
+
+
+def _field_tokens(path: str) -> list[str | int]:
+    """Split a field path such as controller_online[0]."""
+    tokens: list[str | int] = []
+    for part in path.split("."):
+        if not part:
+            raise ValueError(f"Invalid empty field in path '{path}'")
+        name, bracket, rest = part.partition("[")
+        if name:
+            tokens.append(name)
+        while bracket:
+            index_text, close, rest = rest.partition("]")
+            if not close or not index_text.isdigit():
+                raise ValueError(f"Invalid list index in field path '{path}'")
+            tokens.append(int(index_text))
+            bracket, rest = rest[:1], rest[1:]
+    return tokens
+
+
+def _set_field(message: Any, path: str, value: Any) -> None:
+    """Set a simple or indexed message field."""
+    tokens = _field_tokens(path)
+    if not tokens:
+        raise ValueError("field path must not be empty")
+
+    target = message
+    for token in tokens[:-1]:
+        target = target[token] if isinstance(token, int) else getattr(target, token)
+
+    last = tokens[-1]
+    if isinstance(last, int):
+        target[last] = value
+    else:
+        setattr(target, last, value)
+
+
+def _message_from_config(type_name: str, fields: dict[str, Any]):
+    """Build a ROS message from a type name and field mapping."""
+    message_type = get_message(type_name)
+    message = message_type()
+    for path, value in fields.items():
+        _set_field(message, path, value)
+    return message
+
+
+def _topic_from_config(raw: Any) -> TopicInjection:
+    """Parse one topic entry from the scenario config."""
+    if not isinstance(raw, dict):
+        raise ValueError("topic entries must be mappings")
+
+    name = str(raw.get("name", "")).strip()
+    type_name = str(raw.get("type", "")).strip()
+    fields = raw.get("fields", {})
+    rate_hz = float(raw.get("rate_hz", 5.0))
+    transient_local = bool(raw.get("transient_local", False))
+
+    if not name.startswith("/"):
+        raise ValueError(f"topic name must be absolute: {name!r}")
+    if not type_name:
+        raise ValueError(f"{name} must define a message type")
+    if not isinstance(fields, dict):
+        raise ValueError(f"{name} fields must be a mapping")
+    if rate_hz <= 0.0:
+        raise ValueError(f"{name} rate_hz must be positive")
+
+    return TopicInjection(
+        name=name,
+        type_name=type_name,
+        fields=fields,
+        rate_hz=rate_hz,
+        transient_local=transient_local,
+    )
+
+
+def load_scenarios(path: Path) -> dict[str, FaultScenario]:
+    """Load all fault scenarios from a YAML config."""
+    data = _load_yaml(path)
+    raw_scenarios = data.get("scenarios")
+    if not isinstance(raw_scenarios, dict):
+        raise ValueError("config must contain a scenarios mapping")
+
+    scenarios: dict[str, FaultScenario] = {}
+    for name, raw_scenario in raw_scenarios.items():
+        if not isinstance(raw_scenario, dict):
+            raise ValueError(f"scenario {name!r} must be a mapping")
+        raw_topics = raw_scenario.get("topics", [])
+        if not isinstance(raw_topics, list) or not raw_topics:
+            raise ValueError(f"scenario {name!r} must define topic entries")
+        scenarios[str(name)] = FaultScenario(
+            name=str(name),
+            description=str(raw_scenario.get("description", "")),
+            topics=tuple(_topic_from_config(item) for item in raw_topics),
+        )
+    return scenarios
+
+
+def scenario_needs_live_topic_ack(scenario: FaultScenario) -> bool:
+    """Return whether a scenario publishes high-impact live stack topics."""
+    return any(topic.name.startswith("/safety/") for topic in scenario.topics)
+
+
+def validate_live_topic_ack(
+    scenario: FaultScenario,
+    *,
+    allow_live_topics: bool,
+) -> None:
+    """Reject live safety-topic publishing without an explicit operator ack."""
+    if scenario_needs_live_topic_ack(scenario) and not allow_live_topics:
+        raise ValueError(
+            f"scenario '{scenario.name}' publishes /safety topics; rerun with "
+            "--allow-live-topics only in an isolated test ROS_DOMAIN_ID"
+        )
+
+
+class HardwareFaultInjector(Node):
+    """Publish one hardware fault scenario on real project ROS interfaces."""
+
+    def __init__(self, scenario: FaultScenario) -> None:
+        """Create publishers and periodic timers for a scenario."""
+        super().__init__("hardware_fault_injector")
+        self._scenario = scenario
+        for topic in scenario.topics:
+            self._add_topic(topic)
+        self.get_logger().info(
+            f"Hardware fault scenario '{scenario.name}' publishing "
+            f"{len(scenario.topics)} topic(s)"
+        )
+
+    def _add_topic(self, topic: TopicInjection) -> None:
+        """Create one publisher/timer pair for a scenario topic."""
+        message_type = get_message(topic.type_name)
+        qos = QoSProfile(
+            history=HistoryPolicy.KEEP_LAST,
+            depth=1,
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=(
+                DurabilityPolicy.TRANSIENT_LOCAL
+                if topic.transient_local
+                else DurabilityPolicy.VOLATILE
+            ),
+        )
+        publisher = self.create_publisher(message_type, topic.name, qos)
+
+        def _publish() -> None:
+            message = _message_from_config(topic.type_name, topic.fields)
+            if hasattr(message, "header"):
+                message.header.stamp = self.get_clock().now().to_msg()
+            if hasattr(message, "stamp"):
+                message.stamp = self.get_clock().now().to_msg()
+            publisher.publish(message)
+
+        self.create_timer(1.0 / topic.rate_hz, _publish)
+        _publish()
+
+
+def _default_config_path() -> Path:
+    """Return the installed default hardware fault scenario config."""
+    share_dir = Path(get_package_share_directory("lunabot_bringup"))
+    return share_dir / "config" / "hardware_fault_scenarios.yaml"
+
+
+def _arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(
+        description="Publish hardware-boundary mock faults on ROS interfaces"
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Fault scenario YAML; defaults to the installed bringup config",
+    )
+    parser.add_argument(
+        "--scenario",
+        required=True,
+        help="Scenario name from the YAML config",
+    )
+    parser.add_argument(
+        "--duration-s",
+        type=float,
+        default=0.0,
+        help="Publish for this long, or run until interrupted when <= 0",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available scenarios and exit",
+    )
+    parser.add_argument(
+        "--allow-live-topics",
+        action="store_true",
+        help="Allow scenarios that publish live safety topics such as /safety/estop",
+    )
+    return parser
+
+
+def main(args=None) -> None:
+    """Run the hardware fault injector."""
+    parser = _arg_parser()
+    parsed = parser.parse_args(args)
+    config_path = parsed.config or _default_config_path()
+    scenarios = load_scenarios(config_path)
+
+    if parsed.list:
+        for scenario in scenarios.values():
+            print(f"{scenario.name}: {scenario.description}")
+        return
+
+    scenario = scenarios.get(parsed.scenario)
+    if scenario is None:
+        parser.error(
+            f"unknown scenario {parsed.scenario!r}; "
+            f"available: {', '.join(sorted(scenarios))}"
+        )
+    assert scenario is not None
+    try:
+        validate_live_topic_ack(
+            scenario,
+            allow_live_topics=bool(parsed.allow_live_topics),
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    rclpy.init(args=None)
+    node = HardwareFaultInjector(scenario)
+    try:
+        if parsed.duration_s > 0.0:
+            deadline = time.monotonic() + parsed.duration_s
+            while rclpy.ok() and time.monotonic() < deadline:
+                rclpy.spin_once(node, timeout_sec=0.1)
+        else:
+            rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/src/lunabot_bringup/lunabot_bringup/preflight_check.py
+++ b/src/lunabot_bringup/lunabot_bringup/preflight_check.py
@@ -57,6 +57,44 @@ DURABILITY_MAP = {
 }
 
 
+def _field_tokens(path: str) -> list[str | int]:
+    """Split a message field path into attribute and list-index tokens."""
+    tokens: list[str | int] = []
+    for part in path.split("."):
+        if not part:
+            raise ValueError(f"Invalid empty field in path '{path}'")
+        name, bracket, rest = part.partition("[")
+        if name:
+            tokens.append(name)
+        while bracket:
+            index_text, close, rest = rest.partition("]")
+            if not close or not index_text.isdigit():
+                raise ValueError(f"Invalid list index in field path '{path}'")
+            tokens.append(int(index_text))
+            bracket, rest = rest[:1], rest[1:]
+    return tokens
+
+
+def _read_field(message: Any, path: str) -> Any:
+    """Read a possibly nested message field such as controller_online[0]."""
+    value: Any = message
+    for token in _field_tokens(path):
+        value = value[token] if isinstance(token, int) else getattr(value, token)
+    return value
+
+
+def _fields_match(message: Any, expected_fields: dict[str, Any]) -> tuple[bool, str]:
+    """Return whether a message satisfies the configured field expectations."""
+    for path, expected in expected_fields.items():
+        try:
+            actual = _read_field(message, path)
+        except (AttributeError, IndexError, TypeError, ValueError) as exc:
+            return False, f"{path} unreadable: {exc}"
+        if actual != expected:
+            return False, f"{path} expected={expected!r} got={actual!r}"
+    return True, "field expectations met"
+
+
 @dataclass
 class CheckResult:
     """Result item for one preflight check."""
@@ -298,9 +336,14 @@ class PreflightChecker(Node):
         timeout_s: float,
         reliability: QoSReliabilityPolicy,
         durability: QoSDurabilityPolicy,
-    ) -> int:
+        expected_fields: dict[str, Any] | None,
+    ) -> tuple[int, int, str]:
         """Wait for the required message count on one topic."""
-        received = {"count": 0}
+        received = {
+            "count": 0,
+            "matching_count": 0,
+            "last_mismatch": "no messages received",
+        }
         qos = QoSProfile(
             history=QoSHistoryPolicy.KEEP_LAST,
             depth=max(10, min_messages),
@@ -308,23 +351,39 @@ class PreflightChecker(Node):
             durability=durability,
         )
 
+        def _handle_message(msg) -> None:
+            received["count"] += 1
+            if not expected_fields:
+                received["matching_count"] += 1
+                return
+            matched, detail = _fields_match(msg, expected_fields)
+            if matched:
+                received["matching_count"] += 1
+            else:
+                received["last_mismatch"] = detail
+
         subscription = self.create_subscription(
             message_type,
             topic_name,
-            lambda _msg, bucket=received: bucket.__setitem__(
-                "count", bucket["count"] + 1
-            ),
+            _handle_message,
             qos,
         )
 
         try:
             deadline = time.monotonic() + timeout_s
-            while time.monotonic() < deadline and received["count"] < min_messages:
+            while (
+                time.monotonic() < deadline
+                and received["matching_count"] < min_messages
+            ):
                 rclpy.spin_once(self, timeout_sec=0.1)
         finally:
             self.destroy_subscription(subscription)
 
-        return received["count"]
+        return (
+            int(received["count"]),
+            int(received["matching_count"]),
+            str(received["last_mismatch"]),
+        )
 
     def _check_required_topics(self) -> None:
         """Check required topics for type and message flow."""
@@ -387,27 +446,46 @@ class PreflightChecker(Node):
                 continue
 
             message_type = get_message(expected_type)
-            received_count = self._wait_for_required_messages(
-                topic_name,
-                message_type,
-                min_messages=min_messages,
-                timeout_s=msg_timeout_s,
-                reliability=reliability,
-                durability=durability,
+            expected_fields = topic_cfg.get("expected_fields")
+            if expected_fields is not None and not isinstance(expected_fields, dict):
+                self._record(
+                    f"topic:{topic_name}",
+                    critical,
+                    False,
+                    "expected_fields must be a mapping",
+                    started,
+                )
+                continue
+
+            received_count, matching_count, mismatch_detail = (
+                self._wait_for_required_messages(
+                    topic_name,
+                    message_type,
+                    min_messages=min_messages,
+                    timeout_s=msg_timeout_s,
+                    reliability=reliability,
+                    durability=durability,
+                    expected_fields=expected_fields,
+                )
             )
 
-            if received_count >= min_messages:
+            if matching_count >= min_messages:
+                detail = f"received {received_count} msg(s)"
+                if expected_fields:
+                    detail += f", {matching_count} matched expected fields"
                 self._record(
                     f"topic:{topic_name}",
                     critical,
                     True,
-                    f"received {received_count} msg(s)",
+                    detail,
                     started,
                 )
                 continue
 
             detail = f"received {received_count} msg(s), "
-            detail += f"expected >= {min_messages}"
+            detail += f"{matching_count} matched, expected >= {min_messages}"
+            if expected_fields:
+                detail += f"; last mismatch: {mismatch_detail}"
             self._record(
                 f"topic:{topic_name}",
                 critical,
@@ -632,9 +710,7 @@ def _parse_bool_text(value: str) -> bool:
         return True
     if normalised in FALSE_STRINGS:
         return False
-    raise argparse.ArgumentTypeError(
-        f"Expected a boolean value, got: {value}"
-    )
+    raise argparse.ArgumentTypeError(f"Expected a boolean value, got: {value}")
 
 
 def _strip_ros_cli_args(args: list[str] | None) -> list[str]:

--- a/src/lunabot_bringup/package.xml
+++ b/src/lunabot_bringup/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>action_msgs</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
   <exec_depend>python3-yaml</exec_depend>

--- a/src/lunabot_bringup/setup.py
+++ b/src/lunabot_bringup/setup.py
@@ -52,6 +52,7 @@ setup(
             "mission_dry_run = lunabot_bringup.mission_dry_run:main",
             "mission_manager = lunabot_bringup.mission_manager:main",
             "preflight_check = lunabot_bringup.preflight_check:main",
+            "hardware_fault_injector = lunabot_bringup.hardware_fault_injection:main",
         ],
     },
 )

--- a/src/lunabot_bringup/test/test_hardware_fault_injection.py
+++ b/src/lunabot_bringup/test/test_hardware_fault_injection.py
@@ -1,0 +1,107 @@
+"""Tests for hardware-boundary fault scenario loading."""
+
+from pathlib import Path
+
+import pytest
+from rosidl_runtime_py.utilities import get_message
+
+from lunabot_bringup.hardware_fault_injection import (
+    _message_from_config,
+    _set_field,
+    load_scenarios,
+    scenario_needs_live_topic_ack,
+    validate_live_topic_ack,
+)
+
+
+def _config_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[1] / "config" / "hardware_fault_scenarios.yaml"
+    )
+
+
+def test_load_scenarios_includes_required_fault_cases():
+    scenarios = load_scenarios(_config_path())
+
+    assert set(scenarios) >= {
+        "nominal",
+        "drivetrain_controller_offline",
+        "estop_asserted",
+        "excavation_driver_fault",
+        "localisation_lost",
+    }
+
+
+def test_scenarios_publish_only_absolute_topics():
+    scenarios = load_scenarios(_config_path())
+
+    for scenario in scenarios.values():
+        for topic in scenario.topics:
+            assert topic.name.startswith("/")
+
+
+def test_all_configured_payloads_instantiate_as_ros_messages():
+    scenarios = load_scenarios(_config_path())
+
+    for scenario in scenarios.values():
+        for topic in scenario.topics:
+            _message_from_config(topic.type_name, topic.fields)
+
+
+def test_safety_topic_scenarios_require_explicit_ack():
+    scenario = load_scenarios(_config_path())["estop_asserted"]
+
+    assert scenario_needs_live_topic_ack(scenario) is True
+    with pytest.raises(ValueError, match="--allow-live-topics"):
+        validate_live_topic_ack(scenario, allow_live_topics=False)
+
+
+def test_non_safety_scenarios_do_not_require_live_ack():
+    scenario = load_scenarios(_config_path())["drivetrain_controller_offline"]
+
+    assert scenario_needs_live_topic_ack(scenario) is False
+    validate_live_topic_ack(scenario, allow_live_topics=False)
+
+
+def test_message_from_config_sets_status_fault_fields():
+    message = _message_from_config(
+        "lunabot_interfaces/msg/DrivetrainStatus",
+        {
+            "state": 4,
+            "fault_code": 3,
+            "controller_online": [False, False],
+        },
+    )
+
+    assert message.state == 4
+    assert message.fault_code == 3
+    assert list(message.controller_online) == [False, False]
+
+
+def test_set_field_supports_indexed_arrays():
+    status_type = get_message("lunabot_interfaces/msg/DrivetrainStatus")
+    message = status_type()
+
+    _set_field(message, "controller_online[0]", True)
+    _set_field(message, "controller_online[1]", False)
+
+    assert list(message.controller_online) == [True, False]
+
+
+def test_invalid_topic_rate_is_rejected(tmp_path):
+    config = tmp_path / "faults.yaml"
+    config.write_text(
+        """
+scenarios:
+  bad:
+    topics:
+      - name: /drivetrain/status
+        type: lunabot_interfaces/msg/DrivetrainStatus
+        rate_hz: 0.0
+        fields: {}
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="rate_hz must be positive"):
+        load_scenarios(config)

--- a/src/lunabot_bringup/test/test_preflight_profiles.py
+++ b/src/lunabot_bringup/test/test_preflight_profiles.py
@@ -13,9 +13,11 @@ from lunabot_bringup.preflight_check import (
     ACTION_TYPE_MAP,
     DURABILITY_MAP,
     RELIABILITY_MAP,
+    _fields_match,
     _merge_contract_requirements,
     _parse_bool_text,
     _parse_qos_policy,
+    _read_field,
     _strip_ros_cli_args,
 )
 from lunabot_bringup.preflight_profiles import filter_preflight_config, validate_phase
@@ -103,16 +105,15 @@ def test_filter_preflight_config_keeps_runtime_actions_in_runtime_phase():
 
     filtered = filter_preflight_config(config, "runtime")
 
-    assert filtered["preflight"]["required_actions"] == config["preflight"][
-        "required_actions"
-    ]
+    assert (
+        filtered["preflight"]["required_actions"]
+        == config["preflight"]["required_actions"]
+    )
 
 
 def test_dry_run_preflight_config_keeps_mission_actions_in_runtime_phase():
     config_path = (
-        Path(__file__).resolve().parents[1]
-        / "config"
-        / "preflight_checks_dry_run.yaml"
+        Path(__file__).resolve().parents[1] / "config" / "preflight_checks_dry_run.yaml"
     )
     config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
@@ -228,6 +229,44 @@ def test_parse_qos_policy_accepts_known_value():
         )
         == DURABILITY_MAP["transient_local"]
     )
+
+
+def test_read_field_supports_indexed_message_fields():
+    message = SimpleNamespace(
+        controller_online=[True, False],
+        nested=SimpleNamespace(state="ready"),
+    )
+
+    assert _read_field(message, "controller_online[0]") is True
+    assert _read_field(message, "controller_online[1]") is False
+    assert _read_field(message, "nested.state") == "ready"
+
+
+def test_fields_match_reports_first_mismatch():
+    message = SimpleNamespace(fault_code=3, estop_active=False)
+
+    matched, detail = _fields_match(
+        message,
+        {"fault_code": 0, "estop_active": False},
+    )
+
+    assert matched is False
+    assert detail == "fault_code expected=0 got=3"
+
+
+def test_fault_injection_preflight_config_requires_healthy_fields():
+    config_path = (
+        Path(__file__).resolve().parents[1]
+        / "config"
+        / "preflight_checks_fault_injection.yaml"
+    )
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    drivetrain_check = config["preflight"]["required_topics"][0]
+
+    assert drivetrain_check["name"] == "/drivetrain/status"
+    assert drivetrain_check["expected_fields"]["fault_code"] == 0
+    assert drivetrain_check["expected_fields"]["controller_online[0]"] is True
 
 
 def test_parse_qos_policy_rejects_unknown_durability_value():


### PR DESCRIPTION
## Summary
- add a hardware fault injector that publishes deterministic boundary faults on real ROS interfaces
- add a dedicated fault-injection preflight profile with expected message-field checks
- document Jetson/operator usage and cover the scenario/preflight helpers with tests

## Validation
- Local: Ruff on touched Python files
- Local: Pyright on touched Python/test files
- Jetson: clean clone build with `colcon build --symlink-install --packages-up-to lunabot_bringup`
- Jetson: `colcon test --packages-select lunabot_bringup --pytest-args test/test_hardware_fault_injection.py test/test_preflight_profiles.py` (28 passed)
- Jetson live ROS smoke: nominal scenario passes fault preflight; drivetrain offline, E-stop, excavation driver fault, and localisation lost scenarios fail preflight with readable field mismatches

No Nexy review triggered.