### PR TITLE
Add golden mission evidence shuttle run

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ ros2 run lunabot_bringup runtime_profile show --profile hardware_competition
 The profile rules live in
 [`docs/jetson_runtime_profiles.md`](docs/jetson_runtime_profiles.md).
 
+## Mission evidence bags
+
+Use the evidence helper when a run is worth keeping:
+
+```bash
+ros2 run lunabot_bringup mission_evidence \
+  --profile minimal \
+  --label golden-shuttle \
+  --use-sim-time \
+  -- ros2 launch lunabot_bringup mission_shuttle_evidence.launch.py
+```
+
+The workflow is documented in
+[`docs/mission_evidence_workflow.md`](docs/mission_evidence_workflow.md).
+
 ## Visualisation options
 
 | Tool | Purpose | Command |

--- a/docs/mission_evidence_workflow.md
+++ b/docs/mission_evidence_workflow.md
@@ -1,0 +1,96 @@
+# Mission evidence workflow
+
+This is the way we record runs that are worth keeping.
+
+Most runs are not worth keeping. If the stack was half-launched, the rover was
+already in a strange pose, or someone was still tuning parameters mid-run, do
+not bless that bag as evidence. Keep it only if it explains a specific fault.
+
+## Golden shuttle bag
+
+The golden shuttle bag is a clean one-cycle sim run using the competition
+checkpoint route:
+
+1. start zone
+2. mid-obstacle checkpoint at `(3.0, -1.1, 0.0)`
+3. excavation target at `(6.0, -1.5, 0.0)`
+4. mid-obstacle checkpoint again
+5. deposition target at `(0.3, -2.8, 0.0)`
+
+Those coordinates come from `src/lunabot_bringup/config/arena_waypoints.yaml`.
+The midpoint is deliberate. It keeps the mission route honest about the
+obstacle zone instead of asking Nav2 to solve one big vague goal.
+
+The launch is simulation-only. It starts Nav2 directly and bypasses the
+AprilTag readiness gate because the moon yard sim does not always provide a
+stable start-zone tag lock. It also waits before starting the mission so Nav2
+has time to finish its lifecycle bringup on the Jetson. Do not copy those
+assumptions into hardware bringup.
+
+Record it on the Jetson:
+
+```bash
+ros2 run lunabot_bringup mission_evidence \
+  --profile minimal \
+  --label golden-shuttle \
+  --use-sim-time \
+  -- ros2 launch lunabot_bringup mission_shuttle_evidence.launch.py \
+    launch_rviz:=false \
+    max_shuttle_cycles:=1
+```
+
+The pack lands under `~/innex1_mission_evidence/`. It should contain:
+
+- `bag/`
+- `logs/mission_command.log`
+- `logs/rosbag_record.log`
+- `config/arena_waypoints.yaml`
+- `launch/mission_shuttle_evidence.launch.py`
+- `manifest.json`
+
+Check the bag before calling it golden:
+
+```bash
+ros2 bag info ~/innex1_mission_evidence/<pack>/bag
+```
+
+Then open `manifest.json`. The useful bit should look like this:
+
+```json
+{
+  "results": {
+    "mission_summary": {
+      "completed_cycles": 1,
+      "failure_reason": "",
+      "overall": "pass"
+    }
+  }
+}
+```
+
+If `overall` is not `pass`, the bag is not a golden bag. It may still be useful
+as a fault bag, but name it that way.
+
+## Replay
+
+Replay the bag with:
+
+```bash
+ros2 bag play ~/innex1_mission_evidence/<pack>/bag
+```
+
+Use replay for inspection first. Do not assume replay is a drop-in replacement
+for every sim run. It is best for checking topics, diagnostics, mission state,
+TF, command output, and timing around a known run.
+
+## Profiles
+
+Use `minimal` for normal mission evidence. It records operator state, safety
+state, diagnostics, status topics, TF, and command topics.
+
+Use `debug` when a run failed and you need navigation state. It adds odometry,
+scan, map, costmaps, and action status.
+
+Use `heavy` only for short perception investigations. It records raw image and
+point-cloud topics and can burn disk quickly. That is fine when you mean it.
+It is annoying when you do it by accident.

--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -180,6 +180,9 @@ ros2 run lunabot_bringup mission_evidence --plan-only --profile debug
 
 Record the one-cycle checkpoint shuttle route with:
 
+This launch is simulation-only. It disables the AprilTag readiness gate and uses
+sim-time defaults, so do not use it as a hardware bring-up path.
+
 ```bash
 ros2 run lunabot_bringup mission_evidence \
   --profile minimal \

--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -18,6 +18,8 @@ Use bring-up launches when validating end-to-end behaviour. Avoid debugging subs
 - `launch/`: stack launch entrypoints (navigation and related orchestration paths).
 - `launch/mission_manager.launch.py`: starts the standalone mission supervisor node.
 - `launch/mission_dry_run.launch.py`: one-command sim dry run for travel, excavate, and deposit.
+- `launch/mission_shuttle_evidence.launch.py`: one-cycle waypoint shuttle run for
+  golden rosbag evidence.
 - `launch/rover_diagnostics.launch.py`: publishes standard `/diagnostics`
   summaries for operator and bag review.
 
@@ -174,6 +176,18 @@ For a command preview without starting `ros2 bag record`, run:
 
 ```bash
 ros2 run lunabot_bringup mission_evidence --plan-only --profile debug
+```
+
+Record the one-cycle checkpoint shuttle route with:
+
+```bash
+ros2 run lunabot_bringup mission_evidence \
+  --profile minimal \
+  --label golden-shuttle \
+  --use-sim-time \
+  -- ros2 launch lunabot_bringup mission_shuttle_evidence.launch.py \
+    launch_rviz:=false \
+    max_shuttle_cycles:=1
 ```
 
 Replay a saved pack with the command written in `manifest.json`, normally:

--- a/src/lunabot_bringup/config/arena_waypoints.yaml
+++ b/src/lunabot_bringup/config/arena_waypoints.yaml
@@ -17,6 +17,7 @@ mission_manager:
     waypoint_mid_obstacle_x: 3.0
     waypoint_mid_obstacle_y: -1.1
     waypoint_mid_obstacle_yaw: 0.0
+    waypoint_mid_obstacle_enabled: true
 
     # Excavation zone target pose -- clear of rock_6 (6.15,-2.1).
     waypoint_excavation_x: 6.0

--- a/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
+++ b/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
@@ -10,6 +10,7 @@ profiles:
       - /mission/time_remaining_s
       - /mission/cycle_count
       - /mission/last_failure_reason
+      - /diagnostics
       - /safety/estop
       - /safety/motion_inhibit
       - /drivetrain/status
@@ -28,6 +29,7 @@ profiles:
       - /mission/time_remaining_s
       - /mission/cycle_count
       - /mission/last_failure_reason
+      - /diagnostics
       - /safety/estop
       - /safety/motion_inhibit
       - /drivetrain/status
@@ -54,6 +56,7 @@ profiles:
       - /mission/time_remaining_s
       - /mission/cycle_count
       - /mission/last_failure_reason
+      - /diagnostics
       - /safety/estop
       - /safety/motion_inhibit
       - /drivetrain/status

--- a/src/lunabot_bringup/launch/mission_shuttle_evidence.launch.py
+++ b/src/lunabot_bringup/launch/mission_shuttle_evidence.launch.py
@@ -108,6 +108,7 @@ def generate_launch_description():
         executable="rover_diagnostics",
         name="rover_diagnostics",
         output="screen",
+        parameters=[{"use_sim_time": ParameterValue(use_sim_time, value_type=bool)}],
     )
 
     mission_manager = Node(

--- a/src/lunabot_bringup/launch/mission_shuttle_evidence.launch.py
+++ b/src/lunabot_bringup/launch/mission_shuttle_evidence.launch.py
@@ -1,0 +1,165 @@
+"""Launch one waypoint-based mission cycle for evidence recording."""
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    EmitEvent,
+    IncludeLaunchDescription,
+    LogInfo,
+    RegisterEventHandler,
+    TimerAction,
+)
+from launch.event_handlers import OnProcessExit
+from launch.events import Shutdown
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def _launch_file(package_name: str, *parts: str) -> str:
+    """Return one launch file path from a package share directory."""
+    return str(Path(get_package_share_directory(package_name)).joinpath(*parts))
+
+
+def _handle_mission_exit(event, _context):
+    """Shut the evidence stack down when the mission manager exits."""
+    if event.returncode == 0:
+        return [
+            LogInfo(msg="Mission shuttle evidence run complete; shutting down."),
+            EmitEvent(event=Shutdown(reason="mission shuttle evidence complete")),
+        ]
+
+    return [
+        LogInfo(
+            msg=(
+                "Mission shuttle evidence run exited with a non-zero code; "
+                "shutting down."
+            )
+        ),
+        EmitEvent(event=Shutdown(reason="mission shuttle evidence failed")),
+    ]
+
+
+def generate_launch_description():
+    """Compose sim, navigation, mechanism mocks and one mission-manager cycle."""
+    use_sim_time = LaunchConfiguration("use_sim_time")
+    launch_rviz = LaunchConfiguration("launch_rviz")
+    world = LaunchConfiguration("world")
+    waypoints_file = LaunchConfiguration("waypoints_file")
+    max_shuttle_cycles = LaunchConfiguration("max_shuttle_cycles")
+    disable_nav_gate = LaunchConfiguration("disable_nav_gate")
+    enforce_preflight = LaunchConfiguration("enforce_preflight")
+    force_overcurrent = LaunchConfiguration("force_overcurrent")
+    force_driver_fault = LaunchConfiguration("force_driver_fault")
+    hold_home_switch_false = LaunchConfiguration("hold_home_switch_false")
+
+    moon_yard = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            _launch_file("lunabot_simulation", "launch", "moon_yard.launch.py")
+        ),
+        launch_arguments={"world": world}.items(),
+    )
+
+    navigation = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            _launch_file("lunabot_bringup", "launch", "navigation.launch.py")
+        ),
+        launch_arguments={
+            "use_sim_time": use_sim_time,
+            "launch_rviz": launch_rviz,
+            "enforce_preflight": enforce_preflight,
+            "disable_nav_gate": disable_nav_gate,
+        }.items(),
+    )
+
+    excavation_sim = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            _launch_file("lunabot_excavation", "launch", "excavation_sim.launch.py")
+        ),
+        launch_arguments={
+            "force_overcurrent": force_overcurrent,
+            "force_driver_fault": force_driver_fault,
+            "hold_home_switch_false": hold_home_switch_false,
+        }.items(),
+    )
+
+    estop_node = Node(
+        package="lunabot_safety",
+        executable="estop_node",
+        name="estop_node",
+        output="screen",
+        parameters=[{"use_sim_time": ParameterValue(use_sim_time, value_type=bool)}],
+    )
+
+    deposit_action_server = Node(
+        package="lunabot_control",
+        executable="material_action_server",
+        name="material_action_server",
+        output="screen",
+        parameters=[{"use_sim_time": ParameterValue(use_sim_time, value_type=bool)}],
+    )
+
+    rover_diagnostics = Node(
+        package="lunabot_bringup",
+        executable="rover_diagnostics",
+        name="rover_diagnostics",
+        output="screen",
+    )
+
+    mission_manager = Node(
+        package="lunabot_bringup",
+        executable="mission_manager",
+        name="mission_manager",
+        output="screen",
+        parameters=[
+            waypoints_file,
+            {
+                "use_sim_time": ParameterValue(use_sim_time, value_type=bool),
+                "max_shuttle_cycles": ParameterValue(
+                    max_shuttle_cycles,
+                    value_type=int,
+                ),
+            },
+        ],
+    )
+
+    mission_exit_handler = RegisterEventHandler(
+        OnProcessExit(
+            target_action=mission_manager,
+            on_exit=_handle_mission_exit,
+        )
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument("use_sim_time", default_value="true"),
+            DeclareLaunchArgument("launch_rviz", default_value="false"),
+            DeclareLaunchArgument("world", default_value="moon_yard_craters"),
+            DeclareLaunchArgument(
+                "waypoints_file",
+                default_value=_launch_file(
+                    "lunabot_bringup",
+                    "config",
+                    "arena_waypoints.yaml",
+                ),
+            ),
+            DeclareLaunchArgument("max_shuttle_cycles", default_value="1"),
+            DeclareLaunchArgument("disable_nav_gate", default_value="true"),
+            DeclareLaunchArgument("enforce_preflight", default_value="false"),
+            DeclareLaunchArgument("force_overcurrent", default_value="false"),
+            DeclareLaunchArgument("force_driver_fault", default_value="false"),
+            DeclareLaunchArgument("hold_home_switch_false", default_value="false"),
+            moon_yard,
+            navigation,
+            excavation_sim,
+            estop_node,
+            deposit_action_server,
+            rover_diagnostics,
+            TimerAction(period=45.0, actions=[mission_manager]),
+            mission_exit_handler,
+        ]
+    )

--- a/src/lunabot_bringup/lunabot_bringup/mission_evidence.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_evidence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -27,8 +28,10 @@ DEFAULT_SNAPSHOT_RELATIVE_PATHS = (
     "config/arena_waypoints.yaml",
     "config/preflight_checks_dry_run.yaml",
     "config/rosbag_evidence_profiles.yaml",
+    "launch/mission_shuttle_evidence.launch.py",
 )
 SUMMARY_STEPS = ("travel", "excavate", "deposit", "overall")
+MISSION_HALTED_RE = re.compile(r"Mission halted after (?P<cycles>\d+) cycles?\.")
 
 
 @dataclass(frozen=True)
@@ -260,18 +263,39 @@ def write_manifest(
 
 
 def parse_mission_summary(log_path: Path) -> dict[str, Any]:
-    """Extract flat dry-run result lines from a mission command log."""
+    """Extract readable mission result details from a command log."""
     if not log_path.exists():
         return {}
 
     step_results: dict[str, str] = {}
+    completed_cycles: int | None = None
+    safe_fail = False
+    failure_reason = ""
     for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
-        if ": " not in line:
-            continue
+        halted_match = MISSION_HALTED_RE.search(line)
+        if halted_match is not None:
+            completed_cycles = int(halted_match.group("cycles"))
 
-        name, value = line.split(": ", 1)
-        if name in SUMMARY_STEPS and value in {"pass", "fail"}:
-            step_results[name] = value
+        if "Safe-fail triggered" in line:
+            safe_fail = True
+            failure_reason = "safe-fail triggered"
+
+        if "Safety stop during mission" in line:
+            safe_fail = True
+            failure_reason = "safety stop during mission"
+
+        if ": " in line:
+            name, value = line.split(": ", 1)
+            if name in SUMMARY_STEPS and value in {"pass", "fail"}:
+                step_results[name] = value
+
+    if completed_cycles is not None:
+        overall = "fail" if safe_fail or completed_cycles == 0 else "pass"
+        return {
+            "completed_cycles": completed_cycles,
+            "overall": overall,
+            "failure_reason": failure_reason,
+        }
 
     if not step_results:
         return {}
@@ -281,7 +305,6 @@ def parse_mission_summary(log_path: Path) -> dict[str, Any]:
         for step in SUMMARY_STEPS
         if step != "overall" and step_results.get(step) == "fail"
     ]
-    failure_reason = ""
     if step_results.get("overall") == "fail":
         if failed_steps:
             failure_reason = f"{failed_steps[0]} failed"

--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -608,6 +608,8 @@ class MissionManager(Node):
         """Send configured navigation goals in order."""
         completed: list[str] = []
         for goal_label, goal in goals:
+            if not self._is_safe():
+                return False, f"{label}: safety stop active before {goal_label}"
             success, detail = self._send_nav_goal(goal, goal_label)
             if not success:
                 return False, detail

--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -81,6 +81,7 @@ class MissionManager(Node):
         self.declare_parameter("waypoint_mid_obstacle_x", 3.0)
         self.declare_parameter("waypoint_mid_obstacle_y", -1.1)
         self.declare_parameter("waypoint_mid_obstacle_yaw", 0.0)
+        self.declare_parameter("waypoint_mid_obstacle_enabled", True)
         self.declare_parameter("waypoint_excavation_x", 6.0)
         self.declare_parameter("waypoint_excavation_y", -1.5)
         self.declare_parameter("waypoint_excavation_yaw", 0.0)
@@ -561,6 +562,22 @@ class MissionManager(Node):
         goal.pose.pose.orientation.w = math.cos(yaw / 2.0)
         return goal
 
+    def _mid_obstacle_enabled(self) -> bool:
+        """Return whether mission travel should route through the midpoint."""
+        value = self.get_parameter("waypoint_mid_obstacle_enabled").value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    def _waypoint_goal(self, prefix: str) -> NavigateToPose.Goal | None:
+        """Build one configured waypoint goal, returning None on bad params."""
+        x = self._safe_float_parameter(f"waypoint_{prefix}_x")
+        y = self._safe_float_parameter(f"waypoint_{prefix}_y")
+        yaw = self._safe_float_parameter(f"waypoint_{prefix}_yaw")
+        if x is None or y is None or yaw is None:
+            return None
+        return self._build_nav_goal(x, y, yaw)
+
     def _send_nav_goal(self, goal, label: str) -> tuple[bool, str]:
         """Send a NavigateToPose goal and wait for the result."""
         available, detail = self._wait_for_server(
@@ -583,27 +600,52 @@ class MissionManager(Node):
         )
         return self._check_goal_result(goal_handle, label, timeout)
 
+    def _send_nav_sequence(
+        self,
+        goals: list[tuple[str, NavigateToPose.Goal]],
+        label: str,
+    ) -> tuple[bool, str]:
+        """Send configured navigation goals in order."""
+        completed: list[str] = []
+        for goal_label, goal in goals:
+            success, detail = self._send_nav_goal(goal, goal_label)
+            if not success:
+                return False, detail
+            completed.append(goal_label)
+
+        return True, f"{label} succeeded via {', '.join(completed)}"
+
     def _send_navigate_to_excavation(self) -> tuple[bool, str]:
         """Send a NavigateToPose goal toward the excavation zone."""
-        x = self._safe_float_parameter("waypoint_excavation_x")
-        y = self._safe_float_parameter("waypoint_excavation_y")
-        yaw = self._safe_float_parameter("waypoint_excavation_yaw")
-        if x is None or y is None or yaw is None:
+        excavation_goal = self._waypoint_goal("excavation")
+        if excavation_goal is None:
             return False, "excavation waypoint parameters invalid"
 
-        goal = self._build_nav_goal(x, y, yaw)
-        return self._send_nav_goal(goal, "navigate_to_excavation")
+        goals = []
+        if self._mid_obstacle_enabled():
+            midpoint_goal = self._waypoint_goal("mid_obstacle")
+            if midpoint_goal is None:
+                return False, "mid-obstacle waypoint parameters invalid"
+            goals.append(("navigate_to_mid_obstacle", midpoint_goal))
+        goals.append(("navigate_to_excavation", excavation_goal))
+
+        return self._send_nav_sequence(goals, "navigate_to_excavation")
 
     def _send_navigate_to_deposition(self) -> tuple[bool, str]:
         """Send a NavigateToPose goal toward the deposition zone."""
-        x = self._safe_float_parameter("waypoint_deposition_x")
-        y = self._safe_float_parameter("waypoint_deposition_y")
-        yaw = self._safe_float_parameter("waypoint_deposition_yaw")
-        if x is None or y is None or yaw is None:
+        deposition_goal = self._waypoint_goal("deposition")
+        if deposition_goal is None:
             return False, "deposition waypoint parameters invalid"
 
-        goal = self._build_nav_goal(x, y, yaw)
-        return self._send_nav_goal(goal, "navigate_to_deposition")
+        goals = []
+        if self._mid_obstacle_enabled():
+            midpoint_goal = self._waypoint_goal("mid_obstacle")
+            if midpoint_goal is None:
+                return False, "mid-obstacle waypoint parameters invalid"
+            goals.append(("navigate_to_mid_obstacle", midpoint_goal))
+        goals.append(("navigate_to_deposition", deposition_goal))
+
+        return self._send_nav_sequence(goals, "navigate_to_deposition")
 
     def _send_excavate(self) -> tuple[bool, str]:
         """Send an Excavate action goal."""

--- a/src/lunabot_bringup/package.xml
+++ b/src/lunabot_bringup/package.xml
@@ -38,6 +38,7 @@
   <exec_depend>lunabot_perception</exec_depend>
   <exec_depend>lunabot_control</exec_depend>
   <exec_depend>lunabot_excavation</exec_depend>
+  <exec_depend>lunabot_safety</exec_depend>
   <exec_depend>lunabot_simulation</exec_depend>
   <exec_depend>twist_mux</exec_depend>
   <export>

--- a/src/lunabot_bringup/test/test_mission_evidence.py
+++ b/src/lunabot_bringup/test/test_mission_evidence.py
@@ -40,6 +40,7 @@ def test_load_profiles_reads_minimal_topic_allowlist():
     minimal = profiles["minimal"]
 
     assert "/mission/state" in minimal.topics
+    assert "/diagnostics" in minimal.topics
     assert "/ouster/points" not in minimal.topics
     assert profiles["heavy"].topics[-1] == "/ouster/points"
 
@@ -170,4 +171,38 @@ def test_parse_mission_summary_extracts_flat_dry_run_results(tmp_path):
         },
         "overall": "fail",
         "failure_reason": "excavate failed",
+    }
+
+
+def test_parse_mission_summary_extracts_shuttle_cycle_count(tmp_path):
+    log_path = tmp_path / "mission_command.log"
+    log_path.write_text(
+        "[mission_manager]: Completed cycle 1/1\n"
+        "[mission_manager]: Mission halted after 1 cycles.\n",
+        encoding="utf-8",
+    )
+
+    summary = parse_mission_summary(log_path)
+
+    assert summary == {
+        "completed_cycles": 1,
+        "overall": "pass",
+        "failure_reason": "",
+    }
+
+
+def test_parse_mission_summary_marks_safe_fail_as_failure(tmp_path):
+    log_path = tmp_path / "mission_command.log"
+    log_path.write_text(
+        "[mission_manager]: Safe-fail triggered; halting mission.\n"
+        "[mission_manager]: Mission halted after 0 cycles.\n",
+        encoding="utf-8",
+    )
+
+    summary = parse_mission_summary(log_path)
+
+    assert summary == {
+        "completed_cycles": 0,
+        "overall": "fail",
+        "failure_reason": "safe-fail triggered",
     }

--- a/src/lunabot_bringup/test/test_mission_manager.py
+++ b/src/lunabot_bringup/test/test_mission_manager.py
@@ -270,6 +270,90 @@ def test_nav_to_deposition_success_transitions_to_deposit(monkeypatch):
     assert next_state == MissionState.DEPOSIT
 
 
+def _nav_test_goal(name):
+    """Return a small stand-in for a NavigateToPose goal."""
+    return SimpleNamespace(name=name)
+
+
+def _patch_waypoint_goals(monkeypatch, manager):
+    """Patch configured waypoint lookups with small test goals."""
+    goals = {
+        "mid_obstacle": _nav_test_goal("mid_obstacle"),
+        "excavation": _nav_test_goal("excavation"),
+        "deposition": _nav_test_goal("deposition"),
+    }
+    monkeypatch.setattr(manager, "_waypoint_goal", lambda prefix: goals[prefix])
+    return goals
+
+
+def test_navigate_to_excavation_routes_through_midpoint(monkeypatch):
+    """Excavation travel should use the obstacle-zone midpoint."""
+    manager = _make_manager(monkeypatch)
+    goals = _patch_waypoint_goals(monkeypatch, manager)
+    sent = []
+    monkeypatch.setattr(manager, "_mid_obstacle_enabled", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_send_nav_goal",
+        lambda goal, label: sent.append((label, goal)) or (True, "ok"),
+    )
+
+    success, detail = manager._send_navigate_to_excavation()
+
+    assert success
+    assert detail == (
+        "navigate_to_excavation succeeded via "
+        "navigate_to_mid_obstacle, navigate_to_excavation"
+    )
+    assert sent == [
+        ("navigate_to_mid_obstacle", goals["mid_obstacle"]),
+        ("navigate_to_excavation", goals["excavation"]),
+    ]
+
+
+def test_navigate_to_deposition_routes_through_midpoint(monkeypatch):
+    """Deposition travel should use the obstacle-zone midpoint."""
+    manager = _make_manager(monkeypatch)
+    goals = _patch_waypoint_goals(monkeypatch, manager)
+    sent = []
+    monkeypatch.setattr(manager, "_mid_obstacle_enabled", lambda: True)
+    monkeypatch.setattr(
+        manager,
+        "_send_nav_goal",
+        lambda goal, label: sent.append((label, goal)) or (True, "ok"),
+    )
+
+    success, detail = manager._send_navigate_to_deposition()
+
+    assert success
+    assert detail == (
+        "navigate_to_deposition succeeded via "
+        "navigate_to_mid_obstacle, navigate_to_deposition"
+    )
+    assert sent == [
+        ("navigate_to_mid_obstacle", goals["mid_obstacle"]),
+        ("navigate_to_deposition", goals["deposition"]),
+    ]
+
+
+def test_midpoint_can_be_disabled_for_direct_nav(monkeypatch):
+    """The midpoint remains configurable for local debugging."""
+    manager = _make_manager(monkeypatch)
+    goals = _patch_waypoint_goals(monkeypatch, manager)
+    sent = []
+    monkeypatch.setattr(manager, "_mid_obstacle_enabled", lambda: False)
+    monkeypatch.setattr(
+        manager,
+        "_send_nav_goal",
+        lambda goal, label: sent.append((label, goal)) or (True, "ok"),
+    )
+
+    success, _detail = manager._send_navigate_to_excavation()
+
+    assert success
+    assert sent == [("navigate_to_excavation", goals["excavation"])]
+
+
 def test_deposit_success_transitions_to_check_next_cycle_time(monkeypatch):
     """DEPOSIT must advance to CHECK_NEXT_CYCLE_TIME on success."""
     manager = _make_manager(monkeypatch)

--- a/src/lunabot_bringup/test/test_mission_manager.py
+++ b/src/lunabot_bringup/test/test_mission_manager.py
@@ -354,6 +354,35 @@ def test_midpoint_can_be_disabled_for_direct_nav(monkeypatch):
     assert sent == [("navigate_to_excavation", goals["excavation"])]
 
 
+def test_nav_sequence_stops_when_safety_trips_between_legs(monkeypatch):
+    """Navigation should not start the next leg after an E-stop or inhibit."""
+    manager = _make_manager(monkeypatch)
+    first_goal = _nav_test_goal("mid_obstacle")
+    second_goal = _nav_test_goal("excavation")
+    safe_states = iter([True, False])
+    sent = []
+    monkeypatch.setattr(manager, "_is_safe", lambda: next(safe_states))
+    monkeypatch.setattr(
+        manager,
+        "_send_nav_goal",
+        lambda goal, label: sent.append((label, goal)) or (True, "ok"),
+    )
+
+    success, detail = manager._send_nav_sequence(
+        [
+            ("navigate_to_mid_obstacle", first_goal),
+            ("navigate_to_excavation", second_goal),
+        ],
+        "navigate_to_excavation",
+    )
+
+    assert not success
+    assert detail == (
+        "navigate_to_excavation: safety stop active before navigate_to_excavation"
+    )
+    assert sent == [("navigate_to_mid_obstacle", first_goal)]
+
+
 def test_deposit_success_transitions_to_check_next_cycle_time(monkeypatch):
     """DEPOSIT must advance to CHECK_NEXT_CYCLE_TIME on success."""
     manager = _make_manager(monkeypatch)

--- a/src/lunabot_bringup/test/test_mission_shuttle_evidence_launch.py
+++ b/src/lunabot_bringup/test/test_mission_shuttle_evidence_launch.py
@@ -1,0 +1,66 @@
+import importlib.util
+from pathlib import Path
+
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, TimerAction
+from launch_ros.actions import Node
+
+
+def _load_launch_module():
+    launch_path = (
+        Path(__file__).resolve().parents[1]
+        / "launch"
+        / "mission_shuttle_evidence.launch.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "mission_shuttle_evidence_launch",
+        launch_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mission_shuttle_evidence_launch_composes_one_cycle_stack():
+    module = _load_launch_module()
+    description = module.generate_launch_description()
+
+    declared_arguments = [
+        entity.name
+        for entity in description.entities
+        if isinstance(entity, DeclareLaunchArgument)
+    ]
+    includes = [
+        entity
+        for entity in description.entities
+        if isinstance(entity, IncludeLaunchDescription)
+    ]
+    nodes = [entity for entity in description.entities if isinstance(entity, Node)]
+    timers = [
+        entity for entity in description.entities if isinstance(entity, TimerAction)
+    ]
+
+    assert declared_arguments == [
+        "use_sim_time",
+        "launch_rviz",
+        "world",
+        "waypoints_file",
+        "max_shuttle_cycles",
+        "disable_nav_gate",
+        "enforce_preflight",
+        "force_overcurrent",
+        "force_driver_fault",
+        "hold_home_switch_false",
+    ]
+    assert len(includes) == 3
+    assert [node.node_executable for node in nodes] == [
+        "estop_node",
+        "material_action_server",
+        "rover_diagnostics",
+    ]
+    assert len(timers) == 1
+    assert timers[0].period == 45.0
+    assert [node.node_executable for node in timers[0].actions] == [
+        "mission_manager",
+    ]

--- a/src/lunabot_description/package.xml
+++ b/src/lunabot_description/package.xml
@@ -11,6 +11,8 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <exec_depend>leo_description</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/lunabot_simulation/package.xml
+++ b/src/lunabot_simulation/package.xml
@@ -11,8 +11,11 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <exec_depend>lunabot_description</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros_gz_sim</exec_depend>
   <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
 
   <export>


### PR DESCRIPTION
## Summary

Adds a repeatable one-cycle golden shuttle evidence path for the checkpoint route:

- routes mission navigation through the mid-obstacle checkpoint before excavation and deposition
- adds a simulation-only evidence launch that waits for Nav2, records a lean rosbag profile, and shuts down after one mission cycle
- extends evidence manifests so mission-manager logs report completed shuttle cycles
- documents how to record and replay the golden bag
- declares the launch-time package dependencies that the Jetson run exposed

Linear: INX-47

## Jetson validation

Run on `innex1-desktop` from `/home/innex-1/innex1-rover`.

- `colcon build --symlink-install --packages-up-to lunabot_bringup` passed
- `python3 -m pytest src/lunabot_bringup/test/test_mission_manager.py src/lunabot_bringup/test/test_mission_evidence.py src/lunabot_bringup/test/test_mission_shuttle_evidence_launch.py` passed: 41 tests
- Golden evidence command passed:
  `ros2 run lunabot_bringup mission_evidence --output-root /home/innex-1/innex1_mission_evidence --profile minimal --label golden-shuttle --use-sim-time -- ros2 launch lunabot_bringup mission_shuttle_evidence.launch.py launch_rviz:=false max_shuttle_cycles:=1`

Golden bag:
`/home/innex-1/innex1_mission_evidence/20260509T105047Z_golden-shuttle`

Manifest result:
`overall: pass`, `completed_cycles: 1`, `mission_return_code: 0`, `recording_return_code: 0`.

`ros2 bag info`: 102.922s, 6.4 MiB, 74,364 messages. Topics include `/mission/state`, `/mission/cycle_count`, `/diagnostics`, `/tf`, `/tf_static`, `/localisation/start_zone_status`, `/excavation/status`, `/safety/motion_inhibit`, and `/cmd_vel_safe`.

## Local validation

- `python3 -m py_compile ...` passed for changed Python and launch/test files
- `.venv-quality/bin/python -m ruff check ...` passed
- `.venv-quality/bin/python -m pyright` passed
- `git diff --check` passed

## Notes

The evidence launch is deliberately simulation-only: it disables the AprilTag nav gate and launch preflight because this moon yard sim does not reliably produce a stable start-zone tag lock. Hardware bringup keeps the stricter defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Mission Evidence Recording for Golden-Shuttle Route

This PR adds support for recording a repeatable, one-cycle "golden shuttle" evidence dataset for the mission checkpoint route. The shuttle path routes the rover through a mid-obstacle checkpoint before excavation and deposition.

### Key Additions

**New Evidence Launch & Workflow:**
- Added `mission_shuttle_evidence.launch.py` to enable simulation-only mission evidence recording with automatic shutdown after one mission cycle
- New workflow documentation (`docs/mission_evidence_workflow.md`) explaining how to record and validate golden evidence bags
- Updated package README with instructions for generating golden-shuttle evidence

**Navigation Routing:**
- Introduced configurable mid-obstacle waypoint routing in mission manager via `waypoint_mid_obstacle_enabled` parameter
- Enabled mid-obstacle waypoint in arena configuration

**Evidence Manifest Improvements:**
- Extended mission evidence parsing to extract and report completed shuttle cycle counts from mission logs
- Added detection of safe-fail and safety stop failure modes in mission summary
- Added `/diagnostics` topic to all rosbag recording profiles (minimal, debug, heavy)

### Dependencies
- Added `lunabot_safety` runtime dependency to `lunabot_bringup`
- Added `leo_description`, `xacro`, and `robot_state_publisher` dependencies to simulation and description packages

### Testing
- Added unit tests for mission-summary parsing of shuttle cycle counts and failure modes
- Added navigation routing tests for mid-obstacle waypoint behavior
- Added launch validation test for the mission shuttle evidence launch file

### Validation
The PR was validated on Jetson hardware with a successful golden evidence run producing a 6.4 MiB rosbag (102.9s duration, 74,364 messages) with manifest confirming pass status and 1 completed cycle.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/291)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->