### PR TITLE
Make runbook prose direct

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The profile rules live in
 
 ## Mission evidence bags
 
-Use the evidence helper when a run is worth keeping:
+Use the evidence helper when a run should be reviewed later:
 
 ```bash
 ros2 run lunabot_bringup mission_evidence \

--- a/docs/hardware_week_runbook.md
+++ b/docs/hardware_week_runbook.md
@@ -1,9 +1,8 @@
 # Hardware Week Runbook
 
-This is the short version for the first week back with the rover. It is not a
-replacement for thinking. It is here so the team does not have to remember
-which terminal had the magic incantation while a judge, a router, and a pile of
-sand are all staring back.
+Use this during the first week back with the rover. It gives the team one
+place for the commands, checks, callouts, and evidence capture steps needed for
+hardware bring-up and scored-run rehearsal.
 
 The rulebook constraints that shape this are simple:
 
@@ -17,7 +16,7 @@ The rulebook constraints that shape this are simple:
 
 ## Before You Leave The Pit
 
-Do the boring checks before the rover is in the arena. They are cheaper there.
+Run these checks before the rover is in the arena.
 
 On the Jetson:
 
@@ -60,8 +59,8 @@ sleep 2
 ps -eo pid,cmd | egrep "ros2|rviz2|ign gazebo|gz sim|mission_manager|nav2" | grep -v egrep || true
 ```
 
-That last command should print nothing useful. If something is still alive,
-kill it before blaming Nav2 for yesterday's leftovers.
+That last command should not show any active rover processes. If something is
+still running, stop it before launching a fresh stack.
 
 ## Start Lean
 
@@ -72,11 +71,11 @@ ros2 run lunabot_bringup runtime_profile check
 ros2 run lunabot_bringup runtime_profile show --profile hardware_competition
 ```
 
-For Mission Control, keep Foxglove boring. Show mission state, safety,
-drivetrain status, excavation status, localisation status, diagnostics, and the
-minimum camera view you need. Do not stream raw point clouds or every debug
-costmap during a scored run unless someone can explain why that is worth the
-bandwidth.
+For Mission Control, keep Foxglove limited to the topics needed to operate the
+rover. Show mission state, safety, drivetrain status, excavation status,
+localisation status, diagnostics, and the minimum camera view needed for the
+run. Do not stream raw point clouds or every debug costmap during a scored run
+unless the team has a specific reason to spend the bandwidth.
 
 The useful telemetry set is:
 
@@ -102,7 +101,7 @@ sar -n DEV 1 10
 ```
 
 If `sar` is not installed, use the router dashboard, `ifstat`, or `nload`. The
-rule is about the robot comms link, not whether one ROS topic looks polite.
+limit applies to the robot comms link, not to an individual ROS topic.
 
 ## First Motion
 
@@ -114,7 +113,7 @@ For drivetrain bench work, use the Sabertooth bring-up guide:
 ros2 launch lunabot_drivetrain drivetrain_bench.launch.py max_throttle:=0.2
 ```
 
-Then send a tiny command from another terminal:
+Then send a low-speed command from another terminal:
 
 ```bash
 ros2 topic pub --once /cmd_vel_safe geometry_msgs/msg/Twist "{linear: {x: 0.05}, angular: {z: 0.0}}"
@@ -129,8 +128,8 @@ ros2 topic echo /drivetrain/telemetry
 ros2 topic echo /safety/motion_inhibit
 ```
 
-If the rover is on the ground and someone says "just a small one", treat that as
-a request for a proper stop plan, not as permission to improvise.
+If the rover is on the ground, agree the stop command and operator before any
+motion test starts.
 
 ## Before Autonomy
 
@@ -153,7 +152,7 @@ In RViz or Foxglove, check:
 - `/cmd_vel_safe` changes when Nav2 or teleop commands motion;
 - `/cmd_vel_gated` only opens when drivetrain and safety state allow it.
 
-For autonomy scoring, say the quiet part out loud before touching anything:
+For autonomy scoring, use explicit callouts:
 
 1. Tell the Mission Control Judge what autonomy attempt is about to begin.
 2. Start the attempt.
@@ -162,12 +161,13 @@ For autonomy scoring, say the quiet part out loud before touching anything:
 4. Announce whether the attempt completed or failed before taking manual
    control back.
 
-This is not theatre. It is how the points are recognised.
+Do this every time. The judge needs to know when autonomy starts, when it ends,
+and whether manual control has resumed.
 
 ## Evidence Bags
 
-Record bags for runs that teach us something. Do not keep every messy half-run
-as "golden"; that word should mean the run was clean enough to trust later.
+Record bags for runs that need later review. Do not keep every messy half-run
+as "golden"; use that label only for runs clean enough to trust later.
 
 For a lean evidence pack around a command:
 
@@ -196,7 +196,8 @@ summary. If the summary says failed, keep it as a fault bag and name it that way
 
 ## When Something Fails
 
-Use this order. It avoids debugging vibes, which are famously not a sensor.
+Use this order. It checks the high-level state before moving into subsystem
+debugging.
 
 First, check the summary topics:
 
@@ -236,11 +237,11 @@ If comms degrade:
 - stop raw streams;
 - close RViz if Foxglove has enough telemetry;
 - check router counters;
-- keep the rover responsive before trying to preserve a pretty view.
+- keep the rover responsive before preserving high-bandwidth visualisation.
 
 ## End Of Run
 
-When the run ends, stop the rover before celebrating or sulking:
+When the run ends, stop the rover first:
 
 ```bash
 ros2 topic pub --once /cmd_vel_safe geometry_msgs/msg/Twist "{linear: {x: 0.0}, angular: {z: 0.0}}"
@@ -249,7 +250,7 @@ ros2 topic pub --once /cmd_vel_safe geometry_msgs/msg/Twist "{linear: {x: 0.0}, 
 Do not disconnect the robot or pack Mission Control until the judge says so.
 The rulebook allows the robot to need relocation or unloading after the timer.
 
-Then save the evidence path, the branch, and the short human note:
+Then save the evidence path, branch, and short note:
 
 ```text
 Bag:
@@ -258,4 +259,4 @@ What happened:
 What to try next:
 ```
 
-Keep the note short. Future-you wants the truth, not a novella.
+Keep the note short. Record what happened and what the next test should check.

--- a/docs/jetson_sabertooth_bringup.md
+++ b/docs/jetson_sabertooth_bringup.md
@@ -66,7 +66,7 @@ uses `serial_protocol:=legacy_simplified` by default. Use
 `serial_protocol:=packetized` only if the Sabertooth DIP switches are set for
 Packet Serial instead.
 
-## Send a tiny motion command
+## Send a low-speed motion command
 
 In a second terminal:
 

--- a/docs/mission_evidence_workflow.md
+++ b/docs/mission_evidence_workflow.md
@@ -1,10 +1,10 @@
 # Mission evidence workflow
 
-This is the way we record runs that are worth keeping.
+Use this workflow to record runs that should be reviewed later.
 
-Most runs are not worth keeping. If the stack was half-launched, the rover was
-already in a strange pose, or someone was still tuning parameters mid-run, do
-not bless that bag as evidence. Keep it only if it explains a specific fault.
+Do not keep every run as evidence. If the stack was half-launched, the rover was
+already in an unusual pose, or parameters were changing mid-run, keep the bag
+only when it explains a specific fault.
 
 ## Golden shuttle bag
 
@@ -18,8 +18,8 @@ checkpoint route:
 5. deposition target at `(0.3, -2.8, 0.0)`
 
 Those coordinates come from `src/lunabot_bringup/config/arena_waypoints.yaml`.
-The midpoint is deliberate. It keeps the mission route honest about the
-obstacle zone instead of asking Nav2 to solve one big vague goal.
+The midpoint is deliberate. It makes the route pass through the obstacle-zone
+checkpoint instead of sending Nav2 one long start-to-zone goal.
 
 The launch is simulation-only. It starts Nav2 directly and bypasses the
 AprilTag readiness gate because the moon yard sim does not always provide a
@@ -92,5 +92,4 @@ Use `debug` when a run failed and you need navigation state. It adds odometry,
 scan, map, costmaps, and action status.
 
 Use `heavy` only for short perception investigations. It records raw image and
-point-cloud topics and can burn disk quickly. That is fine when you mean it.
-It is annoying when you do it by accident.
+point-cloud topics and can use disk space quickly.

--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -200,9 +200,9 @@ ros2 bag play ~/innex1_mission_evidence/<pack>/bag
 ```
 
 The helper passes `--max-bag-duration` and `--max-bag-size` to rosbag2 so long
-runs split cleanly instead of producing one awkward file. On the Jetson Humble
-image the available storage backend is `sqlite3`; keep that as the default
-unless `ros2 bag record --help` shows MCAP has been installed.
+runs split into manageable files. On the Jetson Humble image the available
+storage backend is `sqlite3`; keep that as the default unless
+`ros2 bag record --help` shows MCAP has been installed.
 
 ## Runtime Diagnostics
 

--- a/src/lunabot_navigation/README.md
+++ b/src/lunabot_navigation/README.md
@@ -28,8 +28,8 @@ At runtime, navigation expects:
 
 The June baseline still uses the stock Nav2 `navigate_to_pose` tree from
 `nav2_bt_navigator`. The custom mission BT in this package is only a scaffold
-for future work under issue `#107`, so it should not shape the current runtime
-story.
+for future work under issue `#107`, so it is not part of the current runtime
+path.
 
 ## Common failure modes
 


### PR DESCRIPTION
## Summary
- remove jokey and purple prose from the hardware week runbook
- tighten the mission evidence docs and README wording
- keep the docs procedural and direct

## Testing
- 
- grep pass for known inflated/jokey phrasing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR streamlines and clarifies documentation across multiple runbook and README files by removing informal language, tightening prose, and standardizing instruction phrasing to keep documentation procedural and direct.

## Changes by document

### Hardware week runbook (`docs/hardware_week_runbook.md`)
Revised multiple sections for clarity and directness:
- Replaced opening guidance with clearer "first week back" directive
- Tightened pre-arena checklist phrasing (removed "boring checks" language)
- Clarified the "Kill The Old Run" expectation
- Emphasized limited needed topics and bandwidth discipline in Mission Control/Foxglove guidance
- Specified that the 4,000 Kbps limit applies to the robot comms link, not individual ROS topics
- Updated "First Motion" guidance from "tiny" to "low-speed" command, with explicit instruction to agree on stop command/operator before testing
- Refined autonomy-scoring instructions to require explicit start/end/manual-resume callouts to the judge
- Reworded Evidence Bags guidance to emphasize keeping notes short and reserving "golden" runs for trusted clean bags
- Clarified "End of Run" section to prioritize stopping the rover first and shortened evidence note guidance

### Mission evidence workflow (`docs/mission_evidence_workflow.md`)
- Clarified that the "midpoint" in the golden shuttle bag route is intentional to force passage through the obstacle-zone checkpoint
- Shortened description of point-cloud data storage consumption, removing inflated phrasing

### Motion command documentation (`docs/jetson_sabertooth_bringup.md`)
- Renamed "Send a tiny motion command" to "Send a low-speed motion command" for consistency with runbook updates

### README files
- **README.md**: Updated "Mission evidence bags" section to specify using the evidence helper when a run should be "reviewed later" (changed from "worth keeping")
- **src/lunabot_bringup/README.md**: Clarified rosbag2 output splitting terminology; reiterates default storage backend is `sqlite3` unless MCAP is available
- **src/lunabot_navigation/README.md**: Clarified that the custom mission behavior tree is a scaffold for future work under issue #107 and is not part of the current runtime path

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/293)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->