### PR TITLE
Add reset-safe E-stop latch

### DIFF
--- a/.github/contracts/interface_contracts.json
+++ b/.github/contracts/interface_contracts.json
@@ -46,6 +46,28 @@
       "kind": "publisher",
       "source": "src/lunabot_bringup/lunabot_bringup/mission_manager.py",
       "phases": ["runtime"]
+    },
+    {
+      "name": "/safety/estop",
+      "type": "std_msgs/msg/Bool",
+      "kind": "subscription",
+      "source": "src/lunabot_safety/lunabot_safety/estop_node.py",
+      "phases": ["runtime", "hardware"]
+    },
+    {
+      "name": "/safety/motion_inhibit",
+      "type": "std_msgs/msg/Bool",
+      "kind": "publisher",
+      "source": "src/lunabot_safety/lunabot_safety/estop_node.py",
+      "phases": ["runtime", "hardware"],
+      "qos": "reliable, transient-local"
+    },
+    {
+      "name": "/safety/reset_motion_inhibit",
+      "type": "std_msgs/msg/Bool",
+      "kind": "subscription",
+      "source": "src/lunabot_safety/lunabot_safety/estop_node.py",
+      "phases": ["runtime", "hardware"]
     }
   ],
   "tf_links": [

--- a/docs/hardware_week_runbook.md
+++ b/docs/hardware_week_runbook.md
@@ -131,6 +131,17 @@ ros2 topic echo /safety/motion_inhibit
 If the rover is on the ground, agree the stop command and operator before any
 motion test starts.
 
+After an E-stop event, releasing the physical E-stop does not re-enable motion
+by itself. Confirm `/safety/estop` is false, then clear the software inhibit:
+
+```bash
+ros2 topic echo /safety/estop --once
+ros2 topic pub --once /safety/reset_motion_inhibit std_msgs/msg/Bool "{data: true}"
+ros2 topic echo /safety/motion_inhibit --once
+```
+
+Only continue when `/safety/motion_inhibit` reports `data: false`.
+
 ## Before Autonomy
 
 The minimum useful checks are:
@@ -211,6 +222,8 @@ ros2 topic echo /diagnostics --once
 If the rover does not move:
 
 - check `/safety/estop` and `/safety/motion_inhibit`;
+- if E-stop was used, reset `/safety/motion_inhibit` after `/safety/estop`
+  is false;
 - check `/drivetrain/status`;
 - check whether `/cmd_vel_safe` is being produced;
 - check whether `/cmd_vel_gated` is blocked;

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -14,7 +14,7 @@
 | `lunabot_simulation` | ament_cmake | Gazebo worlds (`moon_yard.sdf`), sim launch |
 | `lunabot_teleop` | ament_python | Joystick control |
 | `lunabot_perception` | ament_python | `crater_detection` — publishes `/crater_grid` for Nav2 costmaps |
-| `lunabot_safety` | ament_python | `estop_node` — subscribes `/safety/estop`, publishes `/safety/motion_inhibit` |
+| `lunabot_safety` | ament_python | `estop_node` — subscribes `/safety/estop` and `/safety/reset_motion_inhibit`, publishes `/safety/motion_inhibit` |
 
 ## External (vendored)
 - `src/external/leo_common-ros2` — Leo Rover base packages

--- a/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
+++ b/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
@@ -13,6 +13,7 @@ profiles:
       - /diagnostics
       - /safety/estop
       - /safety/motion_inhibit
+      - /safety/reset_motion_inhibit
       - /drivetrain/status
       - /localisation/start_zone_status
       - /excavation/status
@@ -32,6 +33,7 @@ profiles:
       - /diagnostics
       - /safety/estop
       - /safety/motion_inhibit
+      - /safety/reset_motion_inhibit
       - /drivetrain/status
       - /drivetrain/telemetry
       - /localisation/start_zone_status
@@ -59,6 +61,7 @@ profiles:
       - /diagnostics
       - /safety/estop
       - /safety/motion_inhibit
+      - /safety/reset_motion_inhibit
       - /drivetrain/status
       - /drivetrain/telemetry
       - /localisation/start_zone_status

--- a/src/lunabot_bringup/config/runtime_profiles.yaml
+++ b/src/lunabot_bringup/config/runtime_profiles.yaml
@@ -31,6 +31,7 @@ profiles:
       - /mission/last_failure_reason
       - /safety/estop
       - /safety/motion_inhibit
+      - /safety/reset_motion_inhibit
       - /drivetrain/status
       - /excavation/status
       - /localisation/start_zone_status
@@ -105,6 +106,7 @@ profiles:
       - /mission/last_failure_reason
       - /safety/estop
       - /safety/motion_inhibit
+      - /safety/reset_motion_inhibit
       - /drivetrain/status
       - /excavation/status
       - /localisation/start_zone_status
@@ -130,6 +132,9 @@ profiles:
         estimated_bytes: 24
       - name: /safety/motion_inhibit
         max_hz: 2.0
+        estimated_bytes: 24
+      - name: /safety/reset_motion_inhibit
+        max_hz: 1.0
         estimated_bytes: 24
       - name: /drivetrain/status
         max_hz: 5.0
@@ -182,6 +187,7 @@ profiles:
       - /mission/last_failure_reason
       - /safety/estop
       - /safety/motion_inhibit
+      - /safety/reset_motion_inhibit
       - /drivetrain/status
       - /drivetrain/telemetry
       - /excavation/status
@@ -250,6 +256,7 @@ profiles:
       - /mission/last_failure_reason
       - /safety/estop
       - /safety/motion_inhibit
+      - /safety/reset_motion_inhibit
       - /drivetrain/status
       - /excavation/status
       - /localisation/start_zone_status
@@ -275,6 +282,9 @@ profiles:
         estimated_bytes: 24
       - name: /safety/motion_inhibit
         max_hz: 2.0
+        estimated_bytes: 24
+      - name: /safety/reset_motion_inhibit
+        max_hz: 1.0
         estimated_bytes: 24
       - name: /drivetrain/status
         max_hz: 2.0

--- a/src/lunabot_safety/README.md
+++ b/src/lunabot_safety/README.md
@@ -19,16 +19,29 @@ is currently distributed across other packages:
 
 ### `estop_node`
 
-Bridges the hardware E-stop signal to a latched motion-inhibit topic.
+Latches the hardware E-stop signal into a motion-inhibit topic. When
+`/safety/estop` becomes true, `/safety/motion_inhibit` is set true and stays
+true after the E-stop input clears. Motion is only allowed again after an
+operator publishes a true message on `/safety/reset_motion_inhibit`.
 
 | Direction | Topic | Type | QoS |
 |-----------|-------|------|-----|
 | Subscribe | `/safety/estop` | `std_msgs/Bool` | default (reliable, volatile) |
+| Subscribe | `/safety/reset_motion_inhibit` | `std_msgs/Bool` | default (reliable, volatile) |
 | Publish | `/safety/motion_inhibit` | `std_msgs/Bool` | reliable, transient-local |
 
 Transient-local durability ensures that nodes joining after an E-stop event
 (e.g. a motor controller that restarts) immediately receive the current
 inhibit state rather than waiting for the next event.
+
+The reset topic is deliberately separate from `/safety/estop`. Releasing a
+physical E-stop should not make the rover move again by itself.
+
+```bash
+ros2 topic pub --once /safety/reset_motion_inhibit std_msgs/msg/Bool "{data: true}"
+```
+
+The node ignores reset requests while `/safety/estop` is still true.
 
 ## Safety topic convention
 

--- a/src/lunabot_safety/lunabot_safety/estop_node.py
+++ b/src/lunabot_safety/lunabot_safety/estop_node.py
@@ -1,4 +1,4 @@
-"""E-stop node: bridges /safety/estop hardware signal to /safety/motion_inhibit."""
+"""E-stop node: latches /safety/estop into /safety/motion_inhibit."""
 
 import rclpy
 from rclpy.node import Node
@@ -22,7 +22,9 @@ class EstopNode(Node):
         """Initialise publishers, subscribers, and internal state."""
         super().__init__("estop_node")
 
+        self._estop_active = False
         self._inhibited = False
+        self._reset_required = False
 
         self._motion_inhibit_pub = self.create_publisher(
             Bool,
@@ -37,10 +39,17 @@ class EstopNode(Node):
             10,
         )
 
+        self._reset_sub = self.create_subscription(
+            Bool,
+            "/safety/reset_motion_inhibit",
+            self._reset_callback,
+            10,
+        )
+
         # Publish initial state so subscribers joining before any e-stop event
         # receive a well-defined value.
         self._publish_inhibit()
-        self.get_logger().info("estop_node started — waiting for /safety/estop")
+        self.get_logger().info("estop_node started; waiting for /safety/estop")
 
     def _publish_inhibit(self) -> None:
         """Publish the current motion-inhibit state."""
@@ -49,16 +58,48 @@ class EstopNode(Node):
         self._motion_inhibit_pub.publish(out)
 
     def _estop_callback(self, msg: Bool) -> None:
-        """Handle incoming e-stop signal and propagate motion-inhibit state."""
-        new_state = msg.data
+        """Handle incoming e-stop signal and latch motion inhibit until reset."""
+        new_state = bool(msg.data)
 
-        if new_state != self._inhibited:
-            if new_state:
-                self.get_logger().info("E-stop ACTIVE — motion inhibited")
+        if new_state == self._estop_active:
+            self._publish_inhibit()
+            return
+
+        self._estop_active = new_state
+        if self._estop_active:
+            self._reset_required = True
+            self._inhibited = True
+            self.get_logger().warn(
+                "E-stop active; motion inhibited until reset"
+            )
+        else:
+            if self._reset_required:
+                self.get_logger().info(
+                    "E-stop cleared; publish /safety/reset_motion_inhibit "
+                    "before motion is allowed"
+                )
             else:
-                self.get_logger().info("E-stop cleared — motion allowed")
-            self._inhibited = new_state
+                self._inhibited = False
 
+        self._publish_inhibit()
+
+    def _reset_callback(self, msg: Bool) -> None:
+        """Clear a latched motion inhibit once the E-stop input is clear."""
+        if not msg.data:
+            return
+
+        if self._estop_active:
+            self.get_logger().warn(
+                "Motion-inhibit reset ignored while E-stop is active"
+            )
+            self._publish_inhibit()
+            return
+
+        if self._reset_required or self._inhibited:
+            self.get_logger().info("Motion inhibit reset; motion allowed")
+
+        self._reset_required = False
+        self._inhibited = False
         self._publish_inhibit()
 
     def destroy_node(self):

--- a/src/lunabot_safety/test/test_estop_node.py
+++ b/src/lunabot_safety/test/test_estop_node.py
@@ -1,0 +1,97 @@
+from std_msgs.msg import Bool
+
+from lunabot_safety.estop_node import EstopNode
+
+
+class FakePublisher:
+    def __init__(self):
+        self.messages = []
+
+    def publish(self, msg):
+        self.messages.append(msg.data)
+
+
+class FakeLogger:
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+
+    def info(self, message):
+        self.infos.append(message)
+
+    def warn(self, message):
+        self.warnings.append(message)
+
+
+def _bool(value):
+    msg = Bool()
+    msg.data = value
+    return msg
+
+
+def _node():
+    node = object.__new__(EstopNode)
+    node._estop_active = False
+    node._inhibited = False
+    node._reset_required = False
+    node._motion_inhibit_pub = FakePublisher()
+    logger = FakeLogger()
+    node.get_logger = lambda: logger
+    node._test_logger = logger
+    return node
+
+
+def test_estop_assertion_latches_motion_inhibit():
+    node = _node()
+
+    node._estop_callback(_bool(True))
+
+    assert node._estop_active is True
+    assert node._reset_required is True
+    assert node._inhibited is True
+    assert node._motion_inhibit_pub.messages == [True]
+
+
+def test_estop_clear_keeps_motion_inhibit_until_reset():
+    node = _node()
+
+    node._estop_callback(_bool(True))
+    node._estop_callback(_bool(False))
+
+    assert node._estop_active is False
+    assert node._reset_required is True
+    assert node._inhibited is True
+    assert node._motion_inhibit_pub.messages == [True, True]
+
+
+def test_reset_while_estop_active_is_ignored():
+    node = _node()
+
+    node._estop_callback(_bool(True))
+    node._reset_callback(_bool(True))
+
+    assert node._estop_active is True
+    assert node._reset_required is True
+    assert node._inhibited is True
+    assert node._motion_inhibit_pub.messages == [True, True]
+
+
+def test_reset_after_estop_clear_allows_motion():
+    node = _node()
+
+    node._estop_callback(_bool(True))
+    node._estop_callback(_bool(False))
+    node._reset_callback(_bool(True))
+
+    assert node._estop_active is False
+    assert node._reset_required is False
+    assert node._inhibited is False
+    assert node._motion_inhibit_pub.messages == [True, True, False]
+
+
+def test_false_reset_message_is_ignored():
+    node = _node()
+
+    node._reset_callback(_bool(False))
+
+    assert node._motion_inhibit_pub.messages == []


### PR DESCRIPTION
## Summary

- latch /safety/motion_inhibit after /safety/estop until an explicit /safety/reset_motion_inhibit command
- document the operator reset flow and add the safety topics to the local interface contract, runtime profiles, and evidence bags
- add unit tests for E-stop assertion, release, ignored active reset, and reset after release

Closes #274.

## Validation

- .venv-quality/bin/python -m ruff check src/lunabot_safety/lunabot_safety/estop_node.py src/lunabot_safety/test/test_estop_node.py
- .venv-quality/bin/python -m compileall -q src/lunabot_safety/lunabot_safety/estop_node.py src/lunabot_safety/test/test_estop_node.py
- .venv-quality/bin/python JSON/YAML parse check for interface contracts, runtime profiles, and rosbag evidence profiles
- git diff --check

Local macOS pytest cannot import ROS std_msgs; ROS-environment pytest will run in CI and on the Jetson.
