### PR TITLE
Add power telemetry contract

### DIFF
--- a/.github/contracts/interface_contracts.json
+++ b/.github/contracts/interface_contracts.json
@@ -68,6 +68,13 @@
       "kind": "subscription",
       "source": "src/lunabot_safety/lunabot_safety/estop_node.py",
       "phases": ["runtime", "hardware"]
+    },
+    {
+      "name": "/power/telemetry",
+      "type": "lunabot_interfaces/msg/PowerTelemetry",
+      "kind": "publisher",
+      "source": "src/lunabot_bringup/lunabot_bringup/power_telemetry.py",
+      "phases": ["runtime", "hardware"]
     }
   ],
   "tf_links": [

--- a/docs/hardware_week_runbook.md
+++ b/docs/hardware_week_runbook.md
@@ -91,6 +91,7 @@ The useful telemetry set is:
 /excavation/status
 /localisation/start_zone_status
 /diagnostics
+/power/telemetry
 ```
 
 Check bandwidth at the network edge as well as in ROS:
@@ -125,6 +126,7 @@ Watch these while doing it:
 ```bash
 ros2 topic echo /drivetrain/status
 ros2 topic echo /drivetrain/telemetry
+ros2 topic echo /power/telemetry
 ros2 topic echo /safety/motion_inhibit
 ```
 
@@ -141,6 +143,22 @@ ros2 topic echo /safety/motion_inhibit --once
 ```
 
 Only continue when `/safety/motion_inhibit` reports `data: false`.
+
+For early runs without a wired battery sensor, publish the value from the
+visible power meter manually:
+
+```bash
+ros2 run lunabot_bringup manual_power_telemetry \
+  --ros-args \
+  -p profile:=lipo_6s \
+  -p bus_voltage_v:=22.2 \
+  -p bus_current_a:=0.0 \
+  -p energy_wh:=0.0
+```
+
+Use `lipo_4s` if the rover is on a 4S pack. The default voltage is unavailable,
+so diagnostics will say power telemetry is missing until someone enters a real
+value.
 
 ## Before Autonomy
 
@@ -217,6 +235,7 @@ ros2 topic echo /mission/state --once
 ros2 topic echo /mission/autonomy_mode --once
 ros2 topic echo /mission/last_failure_reason --once
 ros2 topic echo /diagnostics --once
+ros2 topic echo /power/telemetry --once
 ```
 
 If the rover does not move:

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -5,7 +5,7 @@
 | Package | Build | Owns |
 |---|---|---|
 | `lunabot_interfaces` | ament_cmake (ROSIDL) | All shared ROS contracts — actions, msgs, srvs. Edit here for new interfaces. |
-| `lunabot_bringup` | ament_python | Top-level launch, mission execution, preflight system, dry-run harness |
+| `lunabot_bringup` | ament_python | Top-level launch, mission execution, preflight system, dry-run harness, manual power telemetry |
 | `lunabot_control` | ament_python | `material_action_server`, `material_action_client` — material movement |
 | `lunabot_excavation` | ament_python | `excavation_action_server`, `excavation_controller`, sim proxy, telemetry mock |
 | `lunabot_localisation` | ament_python | `start_zone_localiser`, `stereo_camera_info_publisher`, `tag_pose_publisher` |

--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -218,9 +218,17 @@ It publishes `diagnostic_msgs/DiagnosticArray` on `/diagnostics` for:
 - drivetrain status
 - start-zone localisation readiness
 - excavation status
+- power telemetry
 
 Each item uses standard `OK`, `WARN`, `ERROR`, and `STALE` levels so Foxglove,
 bags, and future preflight tooling can show health without scraping logs.
+
+Until the real power bridge exists, publish manual power telemetry from the
+visible meter:
+
+```bash
+ros2 run lunabot_bringup manual_power_telemetry --ros-args -p profile:=lipo_6s -p bus_voltage_v:=22.2
+```
 
 ## Common failure modes
 

--- a/src/lunabot_bringup/config/power_profiles.yaml
+++ b/src/lunabot_bringup/config/power_profiles.yaml
@@ -1,0 +1,9 @@
+profiles:
+  lipo_4s:
+    cells: 4
+    warning_voltage_v: 14.0
+    critical_voltage_v: 13.2
+  lipo_6s:
+    cells: 6
+    warning_voltage_v: 21.0
+    critical_voltage_v: 19.8

--- a/src/lunabot_bringup/config/preflight_checks.yaml
+++ b/src/lunabot_bringup/config/preflight_checks.yaml
@@ -54,6 +54,10 @@ preflight:
       type: lunabot_interfaces/msg/LocalisationStartZoneStatus
       min_messages: 1
       critical: false
+    - name: /power/telemetry
+      type: lunabot_interfaces/msg/PowerTelemetry
+      min_messages: 1
+      critical: false
 
   required_tf_links:
     - parent: map

--- a/src/lunabot_bringup/config/preflight_checks_dry_run.yaml
+++ b/src/lunabot_bringup/config/preflight_checks_dry_run.yaml
@@ -65,6 +65,11 @@ preflight:
       min_messages: 1
       critical: true
       phases: [runtime]
+    - name: /power/telemetry
+      type: lunabot_interfaces/msg/PowerTelemetry
+      min_messages: 1
+      critical: false
+      phases: [runtime]
 
   required_tf_links:
     - parent: map

--- a/src/lunabot_bringup/config/preflight_checks_fault_injection.yaml
+++ b/src/lunabot_bringup/config/preflight_checks_fault_injection.yaml
@@ -48,6 +48,11 @@ preflight:
       expected_fields:
         ready: true
         state: ready
+    - name: /power/telemetry
+      type: lunabot_interfaces/msg/PowerTelemetry
+      min_messages: 1
+      critical: false
+      reliability: reliable
 
   required_tf_links: []
   required_actions: []

--- a/src/lunabot_bringup/config/preflight_checks_lidar_debug.yaml
+++ b/src/lunabot_bringup/config/preflight_checks_lidar_debug.yaml
@@ -50,6 +50,10 @@ preflight:
       type: nav_msgs/msg/Odometry
       min_messages: 1
       critical: true
+    - name: /power/telemetry
+      type: lunabot_interfaces/msg/PowerTelemetry
+      min_messages: 1
+      critical: false
 
   required_tf_links:
     - parent: map

--- a/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
+++ b/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
@@ -11,6 +11,7 @@ profiles:
       - /mission/cycle_count
       - /mission/last_failure_reason
       - /diagnostics
+      - /power/telemetry
       - /safety/estop
       - /safety/motion_inhibit
       - /safety/reset_motion_inhibit
@@ -31,6 +32,7 @@ profiles:
       - /mission/cycle_count
       - /mission/last_failure_reason
       - /diagnostics
+      - /power/telemetry
       - /safety/estop
       - /safety/motion_inhibit
       - /safety/reset_motion_inhibit
@@ -59,6 +61,7 @@ profiles:
       - /mission/cycle_count
       - /mission/last_failure_reason
       - /diagnostics
+      - /power/telemetry
       - /safety/estop
       - /safety/motion_inhibit
       - /safety/reset_motion_inhibit

--- a/src/lunabot_bringup/config/runtime_profiles.yaml
+++ b/src/lunabot_bringup/config/runtime_profiles.yaml
@@ -35,6 +35,7 @@ profiles:
       - /drivetrain/status
       - /excavation/status
       - /localisation/start_zone_status
+      - /power/telemetry
       - /map
       - /local_costmap/costmap
       - /global_costmap/costmap
@@ -111,6 +112,7 @@ profiles:
       - /excavation/status
       - /localisation/start_zone_status
       - /diagnostics
+      - /power/telemetry
     telemetry_topics:
       - name: /mission/state
         max_hz: 1.0
@@ -148,6 +150,9 @@ profiles:
       - name: /diagnostics
         max_hz: 1.0
         estimated_bytes: 1024
+      - name: /power/telemetry
+        max_hz: 1.0
+        estimated_bytes: 128
 
   hardware_bringup:
     description: Bench profile for hardware checkout before competition mode.
@@ -194,6 +199,7 @@ profiles:
       - /excavation/telemetry
       - /localisation/start_zone_status
       - /diagnostics
+      - /power/telemetry
     telemetry_topics:
       - name: /drivetrain/status
         max_hz: 5.0
@@ -213,6 +219,9 @@ profiles:
       - name: /diagnostics
         max_hz: 1.0
         estimated_bytes: 1024
+      - name: /power/telemetry
+        max_hz: 1.0
+        estimated_bytes: 128
 
   hardware_competition:
     description: Lean default for the competition run.
@@ -261,6 +270,7 @@ profiles:
       - /excavation/status
       - /localisation/start_zone_status
       - /diagnostics
+      - /power/telemetry
     telemetry_topics:
       - name: /mission/state
         max_hz: 1.0
@@ -298,3 +308,6 @@ profiles:
       - name: /diagnostics
         max_hz: 1.0
         estimated_bytes: 1024
+      - name: /power/telemetry
+        max_hz: 1.0
+        estimated_bytes: 128

--- a/src/lunabot_bringup/lunabot_bringup/power_telemetry.py
+++ b/src/lunabot_bringup/lunabot_bringup/power_telemetry.py
@@ -1,0 +1,171 @@
+# pyright: reportAttributeAccessIssue=false
+"""Publish and classify rover power telemetry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import rclpy
+import yaml
+from ament_index_python.packages import get_package_share_directory
+from rclpy.node import Node
+
+from lunabot_interfaces.msg import PowerTelemetry
+
+
+@dataclass(frozen=True)
+class PowerProfile:
+    """Voltage thresholds for one battery profile."""
+
+    name: str
+    cells: int
+    warning_voltage_v: float
+    critical_voltage_v: float
+
+
+def load_power_profiles(path: Path) -> dict[str, PowerProfile]:
+    """Load named power profiles from a YAML file."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    raw_profiles = data.get("profiles") if isinstance(data, dict) else None
+    if not isinstance(raw_profiles, dict):
+        raise ValueError(f"{path} must contain a profiles mapping")
+
+    profiles: dict[str, PowerProfile] = {}
+    for name, raw_profile in raw_profiles.items():
+        if not isinstance(raw_profile, dict):
+            raise ValueError(f"profile {name!r} must be a mapping")
+        profile = PowerProfile(
+            name=str(name),
+            cells=int(raw_profile["cells"]),
+            warning_voltage_v=float(raw_profile["warning_voltage_v"]),
+            critical_voltage_v=float(raw_profile["critical_voltage_v"]),
+        )
+        if profile.cells <= 0:
+            raise ValueError(f"profile {name!r} cells must be positive")
+        if profile.critical_voltage_v >= profile.warning_voltage_v:
+            raise ValueError(
+                f"profile {name!r} critical voltage must be below warning voltage"
+            )
+        profiles[profile.name] = profile
+    return profiles
+
+
+def classify_power_state(
+    voltage_v: float | None,
+    profile: PowerProfile,
+) -> int:
+    """Return the power state for one voltage sample."""
+    if voltage_v is None or voltage_v <= 0.0:
+        return PowerTelemetry.STATE_UNAVAILABLE
+    if voltage_v <= profile.critical_voltage_v:
+        return PowerTelemetry.STATE_LOW_CRITICAL
+    if voltage_v <= profile.warning_voltage_v:
+        return PowerTelemetry.STATE_LOW_WARNING
+    return PowerTelemetry.STATE_OK
+
+
+def build_power_telemetry(
+    *,
+    voltage_v: float | None,
+    current_a: float,
+    energy_wh: float,
+    profile: PowerProfile,
+    source: str,
+) -> PowerTelemetry:
+    """Build one power telemetry message from the current source values."""
+    state = classify_power_state(voltage_v, profile)
+    msg = PowerTelemetry()
+    msg.profile = profile.name
+    msg.source = source
+    msg.state = state
+    msg.bus_voltage_v = float(voltage_v) if voltage_v is not None else 0.0
+    msg.bus_current_a = float(current_a)
+    msg.energy_wh = float(energy_wh)
+    msg.warning_voltage_v = profile.warning_voltage_v
+    msg.critical_voltage_v = profile.critical_voltage_v
+    msg.low_voltage_warning = state in {
+        PowerTelemetry.STATE_LOW_WARNING,
+        PowerTelemetry.STATE_LOW_CRITICAL,
+    }
+    msg.low_voltage_critical = state == PowerTelemetry.STATE_LOW_CRITICAL
+    return msg
+
+
+def _package_config_path(filename: str) -> Path:
+    share = get_package_share_directory("lunabot_bringup")
+    return Path(share) / "config" / filename
+
+
+class ManualPowerTelemetryNode(Node):
+    """Publish operator-entered power telemetry until a hardware source exists."""
+
+    def __init__(self) -> None:
+        super().__init__("manual_power_telemetry")
+        self.declare_parameter(
+            "profiles_path",
+            str(_package_config_path("power_profiles.yaml")),
+        )
+        self.declare_parameter("profile", "lipo_6s")
+        self.declare_parameter("source", "manual")
+        self.declare_parameter("bus_voltage_v", -1.0)
+        self.declare_parameter("bus_current_a", 0.0)
+        self.declare_parameter("energy_wh", 0.0)
+        self.declare_parameter("publish_hz", 1.0)
+
+        profiles_path = Path(str(self.get_parameter("profiles_path").value))
+        self._profiles = load_power_profiles(profiles_path)
+        self._profile_name = str(self.get_parameter("profile").value)
+        if self._profile_name not in self._profiles:
+            supported = ", ".join(sorted(self._profiles))
+            raise ValueError(
+                f"Unknown power profile {self._profile_name!r}; "
+                f"expected one of: {supported}"
+            )
+
+        publish_hz = float(self.get_parameter("publish_hz").value)
+        if publish_hz <= 0.0:
+            raise ValueError("publish_hz must be positive")
+
+        self._publisher = self.create_publisher(
+            PowerTelemetry, "/power/telemetry", 10
+        )
+        self.create_timer(1.0 / publish_hz, self._publish)
+        self.get_logger().info(
+            "Manual power telemetry publishing on /power/telemetry"
+        )
+
+    def _float_parameter(self, name: str) -> float:
+        return float(self.get_parameter(name).value)
+
+    def _string_parameter(self, name: str) -> str:
+        return str(self.get_parameter(name).value)
+
+    def _current_message(self) -> PowerTelemetry:
+        voltage = self._float_parameter("bus_voltage_v")
+        msg = build_power_telemetry(
+            voltage_v=voltage if voltage > 0.0 else None,
+            current_a=self._float_parameter("bus_current_a"),
+            energy_wh=self._float_parameter("energy_wh"),
+            profile=self._profiles[self._profile_name],
+            source=self._string_parameter("source"),
+        )
+        msg.header.stamp = self.get_clock().now().to_msg()
+        return msg
+
+    def _publish(self) -> None:
+        self._publisher.publish(self._current_message())
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = ManualPowerTelemetryNode()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lunabot_bringup/lunabot_bringup/rover_diagnostics.py
+++ b/src/lunabot_bringup/lunabot_bringup/rover_diagnostics.py
@@ -29,6 +29,7 @@ ExcavationStatus: Any = lunabot_msgs.__dict__["ExcavationStatus"]
 LocalisationStartZoneStatus: Any = lunabot_msgs.__dict__[
     "LocalisationStartZoneStatus"
 ]
+PowerTelemetry: Any = lunabot_msgs.__dict__["PowerTelemetry"]
 
 
 @dataclass
@@ -314,6 +315,71 @@ def excavation_diagnostic(
     )
 
 
+def power_diagnostic(
+    sample: TopicSample,
+    *,
+    now_s: float,
+    timeout_s: float,
+) -> DiagnosticStatus:
+    """Build power health from the latest power telemetry sample."""
+    age_s = _sample_age_s(sample, now_s)
+    if _is_stale(sample, now_s, timeout_s):
+        return _status(
+            "power/telemetry",
+            LEVEL_STALE,
+            "No fresh power telemetry",
+            values={"age_s": age_s if age_s is not None else "never"},
+        )
+
+    msg = sample.msg
+    if msg is None:
+        return _status(
+            "power/telemetry",
+            LEVEL_STALE,
+            "No fresh power telemetry",
+            values={"age_s": age_s if age_s is not None else "never"},
+        )
+
+    values = {
+        "profile": msg.profile,
+        "source": msg.source,
+        "state": msg.state,
+        "bus_voltage_v": f"{msg.bus_voltage_v:.2f}",
+        "bus_current_a": f"{msg.bus_current_a:.2f}",
+        "energy_wh": f"{msg.energy_wh:.2f}",
+        "warning_voltage_v": f"{msg.warning_voltage_v:.2f}",
+        "critical_voltage_v": f"{msg.critical_voltage_v:.2f}",
+        "age_s": f"{age_s:.2f}",
+    }
+    if msg.state == PowerTelemetry.STATE_UNAVAILABLE:
+        return _status(
+            "power/telemetry",
+            LEVEL_STALE,
+            "Power telemetry unavailable",
+            values=values,
+        )
+    if msg.low_voltage_critical:
+        return _status(
+            "power/telemetry",
+            LEVEL_ERROR,
+            "Power voltage critical",
+            values=values,
+        )
+    if msg.low_voltage_warning:
+        return _status(
+            "power/telemetry",
+            LEVEL_WARN,
+            "Power voltage low",
+            values=values,
+        )
+    return _status(
+        "power/telemetry",
+        LEVEL_OK,
+        "Power telemetry OK",
+        values=values,
+    )
+
+
 class RoverDiagnostics(Node):
     """Aggregate rover health into `/diagnostics`."""
 
@@ -336,6 +402,7 @@ class RoverDiagnostics(Node):
         self._motion_inhibit = TopicSample()
         self._localisation = TopicSample()
         self._excavation = TopicSample()
+        self._power = TopicSample()
 
         self.create_subscription(
             DrivetrainStatus,
@@ -365,6 +432,12 @@ class RoverDiagnostics(Node):
             ExcavationStatus,
             "/excavation/status",
             lambda msg: self._store(self._excavation, msg),
+            10,
+        )
+        self.create_subscription(
+            PowerTelemetry,
+            "/power/telemetry",
+            lambda msg: self._store(self._power, msg),
             10,
         )
         self._publisher = self.create_publisher(
@@ -400,6 +473,11 @@ class RoverDiagnostics(Node):
             ),
             excavation_diagnostic(
                 self._excavation,
+                now_s=now_s,
+                timeout_s=self._stale_timeout_s,
+            ),
+            power_diagnostic(
+                self._power,
                 now_s=now_s,
                 timeout_s=self._stale_timeout_s,
             ),

--- a/src/lunabot_bringup/setup.py
+++ b/src/lunabot_bringup/setup.py
@@ -56,6 +56,7 @@ setup(
             "hardware_fault_injector = lunabot_bringup.hardware_fault_injection:main",
             "runtime_profile = lunabot_bringup.runtime_profile:main",
             "rover_diagnostics = lunabot_bringup.rover_diagnostics:main",
+            "manual_power_telemetry = lunabot_bringup.power_telemetry:main",
         ],
     },
 )

--- a/src/lunabot_bringup/test/test_mission_evidence.py
+++ b/src/lunabot_bringup/test/test_mission_evidence.py
@@ -41,6 +41,7 @@ def test_load_profiles_reads_minimal_topic_allowlist():
 
     assert "/mission/state" in minimal.topics
     assert "/diagnostics" in minimal.topics
+    assert "/power/telemetry" in minimal.topics
     assert "/ouster/points" not in minimal.topics
     assert profiles["heavy"].topics[-1] == "/ouster/points"
 

--- a/src/lunabot_bringup/test/test_power_telemetry.py
+++ b/src/lunabot_bringup/test/test_power_telemetry.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from lunabot_bringup.power_telemetry import (
+    PowerProfile,
+    build_power_telemetry,
+    classify_power_state,
+    load_power_profiles,
+)
+from lunabot_interfaces.msg import PowerTelemetry
+
+
+def _profile():
+    return PowerProfile(
+        name="lipo_6s",
+        cells=6,
+        warning_voltage_v=21.0,
+        critical_voltage_v=19.8,
+    )
+
+
+def test_classify_power_state_reports_nominal_voltage_ok():
+    assert classify_power_state(22.2, _profile()) == PowerTelemetry.STATE_OK
+
+
+def test_classify_power_state_reports_warning_threshold():
+    assert (
+        classify_power_state(21.0, _profile())
+        == PowerTelemetry.STATE_LOW_WARNING
+    )
+
+
+def test_classify_power_state_reports_critical_threshold():
+    assert (
+        classify_power_state(19.8, _profile())
+        == PowerTelemetry.STATE_LOW_CRITICAL
+    )
+
+
+def test_classify_power_state_reports_unavailable_without_voltage():
+    assert (
+        classify_power_state(None, _profile())
+        == PowerTelemetry.STATE_UNAVAILABLE
+    )
+
+
+def test_build_power_telemetry_sets_threshold_flags():
+    msg = build_power_telemetry(
+        voltage_v=19.7,
+        current_a=4.0,
+        energy_wh=12.5,
+        profile=_profile(),
+        source="manual",
+    )
+
+    assert msg.state == PowerTelemetry.STATE_LOW_CRITICAL
+    assert msg.low_voltage_warning is True
+    assert msg.low_voltage_critical is True
+    assert msg.warning_voltage_v == 21.0
+    assert msg.critical_voltage_v == 19.8
+
+
+def test_load_power_profiles_reads_config():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "config"
+        / "power_profiles.yaml"
+    )
+
+    profiles = load_power_profiles(path)
+
+    assert profiles["lipo_4s"].warning_voltage_v == 14.0
+    assert profiles["lipo_6s"].critical_voltage_v == 19.8

--- a/src/lunabot_bringup/test/test_rover_diagnostics.py
+++ b/src/lunabot_bringup/test/test_rover_diagnostics.py
@@ -11,12 +11,14 @@ from lunabot_bringup.rover_diagnostics import (
     drivetrain_diagnostic,
     excavation_diagnostic,
     localisation_diagnostic,
+    power_diagnostic,
     safety_diagnostic,
 )
 from lunabot_interfaces.msg import (
     DrivetrainStatus,
     ExcavationStatus,
     LocalisationStartZoneStatus,
+    PowerTelemetry,
 )
 
 
@@ -126,3 +128,58 @@ def test_excavation_diagnostic_reports_fault_as_error():
     )
 
     assert status.level == LEVEL_ERROR
+
+
+def test_power_diagnostic_reports_stale_without_telemetry():
+    status = power_diagnostic(TopicSample(), now_s=20.0, timeout_s=2.5)
+
+    assert status.level == LEVEL_STALE
+    assert status.message == "No fresh power telemetry"
+
+
+def test_power_diagnostic_reports_nominal_voltage_ok():
+    msg = PowerTelemetry()
+    msg.state = PowerTelemetry.STATE_OK
+    msg.profile = "lipo_6s"
+    msg.source = "manual"
+    msg.bus_voltage_v = 22.2
+    msg.warning_voltage_v = 21.0
+    msg.critical_voltage_v = 19.8
+
+    status = power_diagnostic(_sample(msg), now_s=10.1, timeout_s=2.5)
+
+    assert status.level == LEVEL_OK
+    assert status.message == "Power telemetry OK"
+
+
+def test_power_diagnostic_reports_low_voltage_warning():
+    msg = PowerTelemetry()
+    msg.state = PowerTelemetry.STATE_LOW_WARNING
+    msg.profile = "lipo_6s"
+    msg.source = "manual"
+    msg.bus_voltage_v = 20.7
+    msg.warning_voltage_v = 21.0
+    msg.critical_voltage_v = 19.8
+    msg.low_voltage_warning = True
+
+    status = power_diagnostic(_sample(msg), now_s=10.1, timeout_s=2.5)
+
+    assert status.level == LEVEL_WARN
+    assert status.message == "Power voltage low"
+
+
+def test_power_diagnostic_reports_low_voltage_critical():
+    msg = PowerTelemetry()
+    msg.state = PowerTelemetry.STATE_LOW_CRITICAL
+    msg.profile = "lipo_6s"
+    msg.source = "manual"
+    msg.bus_voltage_v = 19.5
+    msg.warning_voltage_v = 21.0
+    msg.critical_voltage_v = 19.8
+    msg.low_voltage_warning = True
+    msg.low_voltage_critical = True
+
+    status = power_diagnostic(_sample(msg), now_s=10.1, timeout_s=2.5)
+
+    assert status.level == LEVEL_ERROR
+    assert status.message == "Power voltage critical"

--- a/src/lunabot_interfaces/CMakeLists.txt
+++ b/src/lunabot_interfaces/CMakeLists.txt
@@ -16,6 +16,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ExcavationStatus.msg"
   "msg/ExcavationTelemetry.msg"
   "msg/LocalisationStartZoneStatus.msg"
+  "msg/PowerTelemetry.msg"
   "srv/ExcavationJog.srv"
   DEPENDENCIES builtin_interfaces std_msgs
 )

--- a/src/lunabot_interfaces/README.md
+++ b/src/lunabot_interfaces/README.md
@@ -204,6 +204,49 @@ Published at the control loop rate. Per-wheel encoder feedback ordered
 - `controller_online[2]` — true if UART heartbeat received per Sabertooth.
 - `estop_active`, `motion_inhibited`, `fault_code` — mirrored safety state.
 
+## Power Telemetry Contract
+
+Added under issue [#277](https://github.com/KJdotIO/innex1-rover/issues/277).
+
+### Operator-Facing Topic
+
+- `/power/telemetry` uses `lunabot_interfaces/msg/PowerTelemetry`
+
+This topic is the rover software view of the main battery bus. During early
+hardware runs it may come from `manual_power_telemetry`, with values entered by
+the operator from the visible power meter. Once the electrical path is settled,
+replace that source with the chosen sensor or logger bridge without changing
+the topic contract.
+
+### PowerTelemetry
+
+Fields:
+
+- `profile` — battery profile used for thresholds, currently `lipo_4s` or
+  `lipo_6s`.
+- `source` — `manual`, `meter_bridge`, `sensor_bridge`, or another short source
+  name.
+- `bus_voltage_v`, `bus_current_a`, `energy_wh` — measured or manually entered
+  bus values.
+- `warning_voltage_v`, `critical_voltage_v` — thresholds used to classify the
+  sample.
+- `low_voltage_warning`, `low_voltage_critical` — explicit operator and safety
+  flags.
+
+State table:
+
+- `STATE_UNAVAILABLE=0`
+- `STATE_OK=1`
+- `STATE_LOW_WARNING=2`
+- `STATE_LOW_CRITICAL=3`
+
+Policy:
+
+- warning means the operator should plan to stop the run;
+- critical means motion should be inhibited before starting another attempt;
+- if the topic is missing or reports unavailable, preflight must show that
+  clearly rather than hiding it.
+
 ## Minimum Hardware Signals for Bridge Nodes
 
 - `estop_active` (latched)

--- a/src/lunabot_interfaces/msg/PowerTelemetry.msg
+++ b/src/lunabot_interfaces/msg/PowerTelemetry.msg
@@ -1,0 +1,20 @@
+# Rover power telemetry. Early hardware runs may publish this from a manual
+# bridge; later runs should replace that source with the chosen meter/sensor.
+
+std_msgs/Header header
+
+uint8 STATE_UNAVAILABLE=0
+uint8 STATE_OK=1
+uint8 STATE_LOW_WARNING=2
+uint8 STATE_LOW_CRITICAL=3
+
+string profile
+string source
+uint8 state
+float32 bus_voltage_v
+float32 bus_current_a
+float32 energy_wh
+float32 warning_voltage_v
+float32 critical_voltage_v
+bool low_voltage_warning
+bool low_voltage_critical


### PR DESCRIPTION
## Summary

- add `lunabot_interfaces/msg/PowerTelemetry` and a `manual_power_telemetry` publisher for early hardware runs
- add 4S/6S voltage profiles, low-voltage classification, and diagnostics for unavailable/warning/critical power state
- include `/power/telemetry` in runtime profiles, preflight configs, evidence bags, and operator docs

Closes #277.

## Validation

- `.venv-quality/bin/python -m ruff check src/lunabot_bringup/lunabot_bringup/power_telemetry.py src/lunabot_bringup/lunabot_bringup/rover_diagnostics.py src/lunabot_bringup/test/test_power_telemetry.py src/lunabot_bringup/test/test_rover_diagnostics.py`
- `python3 .github/scripts/check_interface_contracts.py`
- YAML parse check for power, runtime, rosbag, and preflight configs
- `.venv-quality/bin/python -m compileall -q src/lunabot_bringup/lunabot_bringup/power_telemetry.py src/lunabot_bringup/lunabot_bringup/rover_diagnostics.py src/lunabot_bringup/test/test_power_telemetry.py src/lunabot_bringup/test/test_rover_diagnostics.py`
- `git diff --check`

Jetson ROS build and pytest are next.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a project-facing power telemetry contract and supporting integration to provide a unified view of the rover’s main battery bus and to satisfy issue #277.

What changed / fixes
- New ROS message lunabot_interfaces/msg/PowerTelemetry exposing: timestamp, state (UNAVAILABLE/OK/LOW_WARNING/LOW_CRITICAL), profile, source, bus voltage/current/energy, configured warning/critical voltages, and boolean low-voltage flags.
- Adds two battery profiles (lipo_4s, lipo_6s) with configured warning and critical voltage thresholds.
- Introduces a manual_power_telemetry publisher (console entrypoint) so operators can publish power telemetry manually for early hardware runs when no wired battery bridge is present.
- Integrates /power/telemetry into preflight checks (reports availability/non-availability), runtime profiles, Foxglove allowlists, and rosbag evidence capture profiles.
- Adds diagnostics integration: a power_diagnostic that reports stale/unavailable/warning/critical conditions into the /diagnostics DiagnosticArray.
- Tests: unit tests for profile loading, voltage-to-state classification (nominal/warning/critical/unavailable), telemetry message construction, and diagnostic behavior.
- Documentation: interface README, runbook, package map, and bringup README updated to document the contract and manual publish workflow.

Acceptance criteria addressed
- Defines project-facing topics/messages for battery bus measurements and low-voltage status.
- Provides an operator/manual data source for early runs (manual publisher) and a clear profile-based low-voltage policy for 4S and 6S.
- Ensures preflight reports telemetry availability and includes power telemetry in mission evidence capture.
- Includes tests for nominal, warning, critical, stale telemetry, and profile selection.

Closes: #277

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/298)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->