### PR TITLE
Add Foxglove mission control layout

### DIFF
--- a/docs/foxglove/README.md
+++ b/docs/foxglove/README.md
@@ -1,0 +1,36 @@
+# Foxglove Ground Control
+
+Use `mission_control.layout.json` as the shared Mission Control layout. It is
+deliberately lean: mission state, safety, diagnostics, drivetrain,
+excavation, localisation, power telemetry, and one low-bandwidth camera view.
+
+Import it in Foxglove from the layouts menu. Connect to the rover through
+`foxglove_bridge`, usually:
+
+```bash
+ros2 run foxglove_bridge foxglove_bridge
+```
+
+Then open:
+
+```text
+ws://<jetson-ip>:8765
+```
+
+## Foxglove or RViz
+
+Use Foxglove for operating the rover. It should answer the basic questions:
+
+- What state is the mission in?
+- Is motion inhibited or E-stop active?
+- Are diagnostics OK, warning, stale, or error?
+- Are drivetrain, excavation, localisation, and power telemetry sane?
+- Is the front camera enough for situational awareness?
+
+Use RViz for debugging navigation and perception. If you need TF, robot model,
+costmap layers, point clouds, local planner behaviour, or camera geometry, use
+RViz. Keep it closed during a scored run unless you need it; it is easy to turn
+a quiet telemetry setup into a bandwidth problem.
+
+The layout includes `/power/telemetry`. If the power telemetry PR has not
+merged yet, that panel will simply be empty.

--- a/docs/foxglove/mission_control.layout.json
+++ b/docs/foxglove/mission_control.layout.json
@@ -1,0 +1,117 @@
+{
+  "name": "INNEX-1 Mission Control",
+  "description": "Lean Foxglove layout for hardware week and competition-style operation.",
+  "topics": [
+    "/mission/state",
+    "/mission/autonomy_mode",
+    "/mission/time_remaining_s",
+    "/mission/cycle_count",
+    "/mission/last_failure_reason",
+    "/safety/estop",
+    "/safety/motion_inhibit",
+    "/diagnostics",
+    "/drivetrain/status",
+    "/drivetrain/telemetry",
+    "/excavation/status",
+    "/excavation/telemetry",
+    "/localisation/start_zone_status",
+    "/power/telemetry",
+    "/camera_front/image"
+  ],
+  "content": {
+    "type": "split",
+    "direction": "row",
+    "items": [
+      {
+        "proportion": 2,
+        "content": {
+          "type": "split",
+          "direction": "column",
+          "items": [
+            {
+              "proportion": 2,
+              "content": {
+                "type": "panel",
+                "panelType": "Image",
+                "title": "Front Camera",
+                "config": {
+                  "cameraTopic": "/camera_front/image",
+                  "annotations": []
+                }
+              }
+            },
+            {
+              "proportion": 1,
+              "content": {
+                "type": "panel",
+                "panelType": "DiagnosticsSummary",
+                "title": "Diagnostics",
+                "config": {
+                  "topic": "/diagnostics"
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "proportion": 1,
+        "content": {
+          "type": "split",
+          "direction": "column",
+          "items": [
+            {
+              "proportion": 1,
+              "content": {
+                "type": "panel",
+                "panelType": "RawMessages",
+                "title": "Mission",
+                "config": {
+                  "topics": [
+                    "/mission/state",
+                    "/mission/autonomy_mode",
+                    "/mission/time_remaining_s",
+                    "/mission/cycle_count",
+                    "/mission/last_failure_reason"
+                  ]
+                }
+              }
+            },
+            {
+              "proportion": 1,
+              "content": {
+                "type": "panel",
+                "panelType": "RawMessages",
+                "title": "Safety and Power",
+                "config": {
+                  "topics": [
+                    "/safety/estop",
+                    "/safety/motion_inhibit",
+                    "/power/telemetry"
+                  ]
+                }
+              }
+            },
+            {
+              "proportion": 1,
+              "content": {
+                "type": "panel",
+                "panelType": "RawMessages",
+                "title": "Subsystems",
+                "config": {
+                  "topics": [
+                    "/drivetrain/status",
+                    "/drivetrain/telemetry",
+                    "/excavation/status",
+                    "/excavation/telemetry",
+                    "/localisation/start_zone_status"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/docs/hardware_week_runbook.md
+++ b/docs/hardware_week_runbook.md
@@ -77,6 +77,10 @@ localisation status, diagnostics, and the minimum camera view needed for the
 run. Do not stream raw point clouds or every debug costmap during a scored run
 unless the team has a specific reason to spend the bandwidth.
 
+Use the shared layout in `docs/foxglove/mission_control.layout.json` for normal
+operation. RViz is still the better tool for TF, robot model, costmap, and
+planner debugging.
+
 The useful telemetry set is:
 
 ```text

--- a/src/lunabot_bringup/test/test_foxglove_layout.py
+++ b/src/lunabot_bringup/test/test_foxglove_layout.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+
+LAYOUT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "foxglove"
+    / "mission_control.layout.json"
+)
+
+
+def _walk_panels(node):
+    if isinstance(node, dict):
+        if node.get("type") == "panel":
+            yield node
+        for value in node.values():
+            yield from _walk_panels(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk_panels(item)
+
+
+def test_mission_control_layout_is_valid_json():
+    layout = json.loads(LAYOUT_PATH.read_text(encoding="utf-8"))
+
+    assert layout["name"] == "INNEX-1 Mission Control"
+    assert layout["content"]["type"] == "split"
+
+
+def test_mission_control_layout_covers_operator_topics():
+    layout = json.loads(LAYOUT_PATH.read_text(encoding="utf-8"))
+
+    topics = set(layout["topics"])
+
+    assert "/mission/state" in topics
+    assert "/safety/motion_inhibit" in topics
+    assert "/diagnostics" in topics
+    assert "/drivetrain/status" in topics
+    assert "/excavation/status" in topics
+    assert "/localisation/start_zone_status" in topics
+    assert "/power/telemetry" in topics
+    assert "/camera_front/image" in topics
+
+
+def test_mission_control_layout_keeps_debug_streams_out():
+    layout = json.loads(LAYOUT_PATH.read_text(encoding="utf-8"))
+    topics = set(layout["topics"])
+
+    assert "/ouster/points" not in topics
+    assert "/global_costmap/costmap" not in topics
+    assert "/local_costmap/costmap" not in topics
+
+
+def test_mission_control_layout_has_expected_panel_groups():
+    layout = json.loads(LAYOUT_PATH.read_text(encoding="utf-8"))
+    panels = {panel["title"]: panel for panel in _walk_panels(layout["content"])}
+
+    assert {
+        "Front Camera",
+        "Diagnostics",
+        "Mission",
+        "Safety and Power",
+        "Subsystems",
+    }.issubset(panels)


### PR DESCRIPTION
## Summary

- add a checked-in Foxglove Mission Control layout with mission, safety, diagnostics, subsystem, power, and front-camera panels
- document when to use Foxglove versus RViz during hardware week
- add a lightweight test that validates the layout JSON and keeps debug-heavy topics out

Closes #294.

## Validation

- `.venv-quality/bin/python -m ruff check src/lunabot_bringup/test/test_foxglove_layout.py`
- `.venv-quality/bin/python -m ruff format --check src/lunabot_bringup/test/test_foxglove_layout.py`
- `/Library/Frameworks/Python.framework/Versions/3.12/bin/pytest src/lunabot_bringup/test/test_foxglove_layout.py -q`
- `python3 -m json.tool docs/foxglove/mission_control.layout.json`
- `git diff --check`
