### PR TITLE
Add compressed Foxglove ground control profile

### DIFF
--- a/docs/foxglove/README.md
+++ b/docs/foxglove/README.md
@@ -1,20 +1,44 @@
 # Foxglove Ground Control
 
-Use `mission_control.layout.json` as the shared Mission Control layout. It is
-deliberately lean: mission state, safety, diagnostics, drivetrain,
-excavation, localisation, power telemetry, and one low-bandwidth camera view.
+Use `mission_control.layout.json` as the shared Mission Control layout. It shows
+mission state, safety, diagnostics, drivetrain, excavation, localisation, power
+telemetry, and one compressed front camera view.
 
 Import it in Foxglove from the layouts menu. Connect to the rover through
-`foxglove_bridge`, usually:
+`foxglove_bridge` through the ground-control launch file:
 
 ```bash
-ros2 run foxglove_bridge foxglove_bridge
+ros2 launch lunabot_bringup foxglove_ground_control.launch.py \
+  profile:=sim_competition \
+  use_sim_time:=true
 ```
 
 Then open:
 
 ```text
 ws://<jetson-ip>:8765
+```
+
+For hardware competition mode, use:
+
+```bash
+ros2 launch lunabot_bringup foxglove_ground_control.launch.py \
+  profile:=hardware_competition \
+  use_sim_time:=false
+```
+
+The launch file republishes `/camera_front/image` to
+`/camera_front/image/compressed` using JPEG compression. Foxglove must subscribe
+to the compressed topic. Do not point the operator layout at raw
+`/camera_front/image`.
+
+Rear camera streaming is available when needed, but is off by default:
+
+```bash
+ros2 launch lunabot_bringup foxglove_ground_control.launch.py \
+  profile:=hardware_bringup \
+  use_sim_time:=false \
+  enable_rear_camera:=true
 ```
 
 ## Foxglove or RViz
@@ -27,10 +51,20 @@ Use Foxglove for operating the rover. It should answer the basic questions:
 - Are drivetrain, excavation, localisation, and power telemetry sane?
 - Is the front camera enough for situational awareness?
 
-Use RViz for debugging navigation and perception. If you need TF, robot model,
-costmap layers, point clouds, local planner behaviour, or camera geometry, use
-RViz. Keep it closed during a scored run unless you need it; it is easy to turn
-a quiet telemetry setup into a bandwidth problem.
+Use RViz, or a separate Foxglove debug profile, for navigation and perception
+debugging. If you need TF, robot model, costmap layers, point clouds, local
+planner behaviour, or camera geometry, keep that out of the scored-run operator
+layout.
 
 The layout includes `/power/telemetry`. If the power telemetry PR has not
 merged yet, that panel will simply be empty.
+
+## Bandwidth
+
+The rulebook limit is **4,000 Kbps average**. Raw image and point cloud topics
+must not be streamed to Mission Control. A single `640x480` raw RGB image stream
+at `15 Hz` can exceed `100,000 Kbps`, before WebSocket overhead.
+
+The competition profile budgets for one compressed camera stream at roughly
+`1,500 Kbps`, plus low-rate operator telemetry. That leaves more than `1,000
+Kbps` of margin under the rulebook limit.

--- a/docs/foxglove/mission_control.layout.json
+++ b/docs/foxglove/mission_control.layout.json
@@ -1,117 +1,149 @@
 {
-  "name": "INNEX-1 Mission Control",
-  "description": "Lean Foxglove layout for hardware week and competition-style operation.",
-  "topics": [
-    "/mission/state",
-    "/mission/autonomy_mode",
-    "/mission/time_remaining_s",
-    "/mission/cycle_count",
-    "/mission/last_failure_reason",
-    "/safety/estop",
-    "/safety/motion_inhibit",
-    "/diagnostics",
-    "/drivetrain/status",
-    "/drivetrain/telemetry",
-    "/excavation/status",
-    "/excavation/telemetry",
-    "/localisation/start_zone_status",
-    "/power/telemetry",
-    "/camera_front/image"
-  ],
-  "content": {
-    "type": "split",
-    "direction": "row",
-    "items": [
-      {
-        "proportion": 2,
-        "content": {
-          "type": "split",
-          "direction": "column",
-          "items": [
-            {
-              "proportion": 2,
-              "content": {
-                "type": "panel",
-                "panelType": "Image",
-                "title": "Front Camera",
-                "config": {
-                  "cameraTopic": "/camera_front/image",
-                  "annotations": []
-                }
-              }
-            },
-            {
-              "proportion": 1,
-              "content": {
-                "type": "panel",
-                "panelType": "DiagnosticsSummary",
-                "title": "Diagnostics",
-                "config": {
-                  "topic": "/diagnostics"
-                }
-              }
-            }
-          ]
-        }
+  "configById": {
+    "Image!front_camera": {
+      "cameraTopic": "/camera_front/image/compressed",
+      "enabledMarkerTopics": [],
+      "mode": "fit",
+      "pan": {
+        "x": 0,
+        "y": 0
       },
-      {
-        "proportion": 1,
-        "content": {
-          "type": "split",
+      "rotation": 0,
+      "synchronize": true,
+      "zoom": 1
+    },
+    "RawMessages!mission_state": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/mission/state"
+    },
+    "RawMessages!autonomy_mode": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/mission/autonomy_mode"
+    },
+    "RawMessages!time_remaining": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/mission/time_remaining_s"
+    },
+    "RawMessages!cycle_count": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/mission/cycle_count"
+    },
+    "RawMessages!failure_reason": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/mission/last_failure_reason"
+    },
+    "RawMessages!motion_inhibit": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/safety/motion_inhibit"
+    },
+    "RawMessages!estop": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/safety/estop"
+    },
+    "RawMessages!power": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/power/telemetry"
+    },
+    "RawMessages!drivetrain": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/drivetrain/status"
+    },
+    "RawMessages!diagnostics": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/diagnostics"
+    },
+    "RawMessages!excavation": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/excavation/status"
+    },
+    "RawMessages!localisation": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/localisation/start_zone_status"
+    }
+  },
+  "globalVariables": {},
+  "layout": {
+    "direction": "row",
+    "first": {
+      "direction": "column",
+      "first": "Image!front_camera",
+      "second": "RawMessages!diagnostics",
+      "splitPercentage": 68
+    },
+    "second": {
+      "direction": "column",
+      "first": {
+        "direction": "column",
+        "first": {
+          "direction": "row",
+          "first": "RawMessages!mission_state",
+          "second": "RawMessages!autonomy_mode",
+          "splitPercentage": 50
+        },
+        "second": {
+          "direction": "row",
+          "first": "RawMessages!time_remaining",
+          "second": "RawMessages!cycle_count",
+          "splitPercentage": 50
+        },
+        "splitPercentage": 50
+      },
+      "second": {
+        "direction": "column",
+        "first": {
+          "direction": "row",
+          "first": "RawMessages!motion_inhibit",
+          "second": "RawMessages!estop",
+          "splitPercentage": 50
+        },
+        "second": {
           "direction": "column",
-          "items": [
-            {
-              "proportion": 1,
-              "content": {
-                "type": "panel",
-                "panelType": "RawMessages",
-                "title": "Mission",
-                "config": {
-                  "topics": [
-                    "/mission/state",
-                    "/mission/autonomy_mode",
-                    "/mission/time_remaining_s",
-                    "/mission/cycle_count",
-                    "/mission/last_failure_reason"
-                  ]
-                }
-              }
-            },
-            {
-              "proportion": 1,
-              "content": {
-                "type": "panel",
-                "panelType": "RawMessages",
-                "title": "Safety and Power",
-                "config": {
-                  "topics": [
-                    "/safety/estop",
-                    "/safety/motion_inhibit",
-                    "/power/telemetry"
-                  ]
-                }
-              }
-            },
-            {
-              "proportion": 1,
-              "content": {
-                "type": "panel",
-                "panelType": "RawMessages",
-                "title": "Subsystems",
-                "config": {
-                  "topics": [
-                    "/drivetrain/status",
-                    "/drivetrain/telemetry",
-                    "/excavation/status",
-                    "/excavation/telemetry",
-                    "/localisation/start_zone_status"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      }
-    ]
-  }
+          "first": {
+            "direction": "row",
+            "first": "RawMessages!power",
+            "second": "RawMessages!drivetrain",
+            "splitPercentage": 50
+          },
+          "second": {
+            "direction": "row",
+            "first": "RawMessages!excavation",
+            "second": "RawMessages!localisation",
+            "splitPercentage": 50
+          },
+          "splitPercentage": 50
+        },
+        "splitPercentage": 34
+      },
+      "splitPercentage": 50
+    },
+    "splitPercentage": 62
+  },
+  "playbackConfig": {
+    "speed": 1
+  },
+  "userNodes": {}
 }

--- a/docs/jetson_runtime_profiles.md
+++ b/docs/jetson_runtime_profiles.md
@@ -2,13 +2,14 @@
 
 The competition communications rule that matters most for software is simple:
 average data utilisation must stay at or below **4,000 Kbps**. There is no peak
-limit, but treating that as permission to stream raw sensors would be a small
-masterclass in missing the point.
+limit. We still keep the average low because the operator link needs to stay
+stable.
 
 The default competition posture is:
 
 - run autonomy and safety locally on the Jetson;
 - expose only operator telemetry and health topics to Foxglove;
+- stream camera video only through compressed image topics;
 - keep raw images, point clouds, RViz, Gazebo and heavy rosbag captures off by
   default;
 - record evidence locally with the minimal rosbag profile unless debugging
@@ -45,10 +46,35 @@ For `hardware_competition`, expose only:
 - `/excavation/status`
 - `/localisation/start_zone_status`
 - `/diagnostics`
+- `/power/telemetry`
+- `/camera_front/image/compressed`
+- `/camera_front/camera_info`
 
-Do not expose raw camera images, point clouds, debug costmap panels or the heavy
-rosbag profile during a scored run. If a raw stream is needed for diagnosis, use
-`hardware_bringup` or `sim_debug`, say why, and turn it back off before the run.
+Do not expose raw camera images, depth images, point clouds, debug costmap
+panels or the heavy rosbag profile during a scored run. If a raw stream is
+needed for diagnosis, use `hardware_bringup` or `sim_debug`, say why, and turn
+it back off before the run.
+
+Start Foxglove through the project launch file so the allowlist and camera
+compression stay consistent:
+
+```bash
+ros2 launch lunabot_bringup foxglove_ground_control.launch.py \
+  profile:=hardware_competition \
+  use_sim_time:=false
+```
+
+For simulation:
+
+```bash
+ros2 launch lunabot_bringup foxglove_ground_control.launch.py \
+  profile:=sim_competition \
+  use_sim_time:=true
+```
+
+The front camera is republished as `/camera_front/image/compressed` with JPEG
+quality `50` by default. The rear camera republisher is available with
+`enable_rear_camera:=true`, but keep it off unless you need it.
 
 ## Measurement Commands
 
@@ -60,6 +86,7 @@ ros2 run lunabot_bringup runtime_profile show --profile hardware_competition --j
 ros2 topic bw /mission/state
 ros2 topic bw /drivetrain/status
 ros2 topic bw /excavation/status
+ros2 topic bw /camera_front/image/compressed
 ros2 topic hz /diagnostics
 top -b -n 1 | head -n 20
 free -h
@@ -101,3 +128,11 @@ ros2 run lunabot_bringup mission_evidence \
 
 Use `debug` or `heavy` evidence profiles only for short investigations. They are
 not the default scored-run posture.
+
+## Navigation Debug
+
+When the rover gets close to craters or boulders, use a debug profile instead of
+adding costmaps and point clouds to the operator layout. The useful debug topics
+are `/global_costmap/costmap`, `/local_costmap/costmap`, `/map`, paths, TF and
+collision monitor polygons. Do not stream those at the same time as camera video
+unless you are doing a short, supervised investigation.

--- a/src/lunabot_bringup/config/runtime_profiles.yaml
+++ b/src/lunabot_bringup/config/runtime_profiles.yaml
@@ -76,7 +76,7 @@ profiles:
   sim_competition:
     description: Simulation dress rehearsal using competition telemetry rules.
     budget_kbps: 4000
-    target_kbps: 1000
+    target_kbps: 2500
     launch_arguments:
       navigation:
         use_sim_time: true
@@ -113,6 +113,8 @@ profiles:
       - /localisation/start_zone_status
       - /diagnostics
       - /power/telemetry
+      - /camera_front/image/compressed
+      - /camera_front/camera_info
     telemetry_topics:
       - name: /mission/state
         max_hz: 1.0
@@ -153,11 +155,17 @@ profiles:
       - name: /power/telemetry
         max_hz: 1.0
         estimated_bytes: 128
+      - name: /camera_front/image/compressed
+        max_hz: 5.0
+        estimated_bytes: 37500
+      - name: /camera_front/camera_info
+        max_hz: 1.0
+        estimated_bytes: 512
 
   hardware_bringup:
     description: Bench profile for hardware checkout before competition mode.
     budget_kbps: 4000
-    target_kbps: 1500
+    target_kbps: 2000
     launch_arguments:
       navigation:
         use_sim_time: false
@@ -200,6 +208,10 @@ profiles:
       - /localisation/start_zone_status
       - /diagnostics
       - /power/telemetry
+      - /camera_front/image/compressed
+      - /camera_rear/image/compressed
+      - /camera_front/camera_info
+      - /camera_rear/camera_info
     telemetry_topics:
       - name: /drivetrain/status
         max_hz: 5.0
@@ -222,11 +234,14 @@ profiles:
       - name: /power/telemetry
         max_hz: 1.0
         estimated_bytes: 128
+      - name: /camera_front/image/compressed
+        max_hz: 5.0
+        estimated_bytes: 37500
 
   hardware_competition:
     description: Lean default for the competition run.
     budget_kbps: 4000
-    target_kbps: 800
+    target_kbps: 2500
     launch_arguments:
       navigation:
         use_sim_time: false
@@ -271,6 +286,8 @@ profiles:
       - /localisation/start_zone_status
       - /diagnostics
       - /power/telemetry
+      - /camera_front/image/compressed
+      - /camera_front/camera_info
     telemetry_topics:
       - name: /mission/state
         max_hz: 1.0
@@ -311,3 +328,9 @@ profiles:
       - name: /power/telemetry
         max_hz: 1.0
         estimated_bytes: 128
+      - name: /camera_front/image/compressed
+        max_hz: 5.0
+        estimated_bytes: 37500
+      - name: /camera_front/camera_info
+        max_hz: 1.0
+        estimated_bytes: 512

--- a/src/lunabot_bringup/launch/foxglove_ground_control.launch.py
+++ b/src/lunabot_bringup/launch/foxglove_ground_control.launch.py
@@ -1,0 +1,146 @@
+"""Launch Foxglove ground control with compressed camera topics only."""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+from lunabot_bringup.runtime_profile import default_profiles_path, load_profiles
+
+
+def _profile_allowlist(context) -> list[str]:
+    profile_name = LaunchConfiguration("profile").perform(context)
+    profiles = load_profiles(default_profiles_path())
+    if profile_name not in profiles:
+        available = ", ".join(sorted(profiles))
+        raise ValueError(
+            f"Unknown Foxglove runtime profile '{profile_name}'. "
+            f"Available profiles: {available}."
+        )
+    return list(profiles[profile_name].foxglove_allowlist)
+
+
+def _launch_nodes(context):
+    allowlist = _profile_allowlist(context)
+    use_sim_time = LaunchConfiguration("use_sim_time")
+    jpeg_quality = LaunchConfiguration("jpeg_quality")
+    port = LaunchConfiguration("port")
+    send_buffer_limit = LaunchConfiguration("send_buffer_limit")
+
+    front_camera_republisher = Node(
+        package="image_transport",
+        executable="republish",
+        name="camera_front_compressed_republisher",
+        output="screen",
+        arguments=[
+            "raw",
+            "compressed",
+            "--ros-args",
+            "--remap",
+            "in:=/camera_front/image",
+            "--remap",
+            "out:=/camera_front/image",
+        ],
+        parameters=[
+            {
+                "use_sim_time": ParameterValue(use_sim_time, value_type=bool),
+                "out.format": "jpeg",
+                "out.jpeg_quality": ParameterValue(jpeg_quality, value_type=int),
+            }
+        ],
+        condition=IfCondition(LaunchConfiguration("enable_front_camera")),
+    )
+
+    rear_camera_republisher = Node(
+        package="image_transport",
+        executable="republish",
+        name="camera_rear_compressed_republisher",
+        output="screen",
+        arguments=[
+            "raw",
+            "compressed",
+            "--ros-args",
+            "--remap",
+            "in:=/camera_rear/image",
+            "--remap",
+            "out:=/camera_rear/image",
+        ],
+        parameters=[
+            {
+                "use_sim_time": ParameterValue(use_sim_time, value_type=bool),
+                "out.format": "jpeg",
+                "out.jpeg_quality": ParameterValue(jpeg_quality, value_type=int),
+            }
+        ],
+        condition=IfCondition(LaunchConfiguration("enable_rear_camera")),
+    )
+
+    foxglove_bridge = Node(
+        package="foxglove_bridge",
+        executable="foxglove_bridge",
+        name="foxglove_bridge",
+        output="screen",
+        parameters=[
+            {
+                "use_sim_time": ParameterValue(use_sim_time, value_type=bool),
+                "port": ParameterValue(port, value_type=int),
+                "send_buffer_limit": ParameterValue(
+                    send_buffer_limit,
+                    value_type=int,
+                ),
+                "topic_whitelist": allowlist,
+                "capabilities": ["clientPublish"],
+            }
+        ],
+    )
+
+    return [front_camera_republisher, rear_camera_republisher, foxglove_bridge]
+
+
+def generate_launch_description():
+    """Generate a Foxglove bridge launch description for operator telemetry."""
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "profile",
+                default_value="sim_competition",
+                description="Runtime profile whose Foxglove allowlist should be exposed.",
+            ),
+            DeclareLaunchArgument(
+                "use_sim_time",
+                default_value="true",
+                description="Use /clock for the camera republishers and bridge.",
+            ),
+            DeclareLaunchArgument(
+                "port",
+                default_value="8765",
+                description="Foxglove WebSocket port.",
+            ),
+            DeclareLaunchArgument(
+                "send_buffer_limit",
+                default_value="10000000",
+                description=(
+                    "Maximum Foxglove per-client send buffer in bytes. "
+                    "Keep payloads lean instead of relying on this."
+                ),
+            ),
+            DeclareLaunchArgument(
+                "jpeg_quality",
+                default_value="50",
+                description="JPEG quality for compressed camera republishing.",
+            ),
+            DeclareLaunchArgument(
+                "enable_front_camera",
+                default_value="true",
+                description="Republish /camera_front/image as compressed JPEG.",
+            ),
+            DeclareLaunchArgument(
+                "enable_rear_camera",
+                default_value="false",
+                description="Republish /camera_rear/image as compressed JPEG.",
+            ),
+            OpaqueFunction(function=_launch_nodes),
+        ]
+    )

--- a/src/lunabot_bringup/launch/foxglove_ground_control.launch.py
+++ b/src/lunabot_bringup/launch/foxglove_ground_control.launch.py
@@ -41,7 +41,7 @@ def _launch_nodes(context):
             "--remap",
             "in:=/camera_front/image",
             "--remap",
-            "out:=/camera_front/image",
+            "out/compressed:=/camera_front/image/compressed",
         ],
         parameters=[
             {
@@ -65,7 +65,7 @@ def _launch_nodes(context):
             "--remap",
             "in:=/camera_rear/image",
             "--remap",
-            "out:=/camera_rear/image",
+            "out/compressed:=/camera_rear/image/compressed",
         ],
         parameters=[
             {

--- a/src/lunabot_bringup/lunabot_bringup/runtime_profile.py
+++ b/src/lunabot_bringup/lunabot_bringup/runtime_profile.py
@@ -12,8 +12,9 @@ from typing import Any
 import yaml
 
 COMPETITION_BUDGET_KBPS = 4000.0
-RAW_STREAM_MARKERS = ("image", "points", "pointcloud", "camera")
 COMPETITION_PROFILES = ("sim_competition", "hardware_competition")
+RAW_TOPIC_SUFFIXES = ("/image", "/depth_image", "/points")
+RAW_TOPIC_MARKERS = ("pointcloud",)
 
 
 @dataclass(frozen=True)
@@ -173,12 +174,15 @@ def validate_profile(profile: RuntimeProfile) -> list[str]:
                 f"{COMPETITION_BUDGET_KBPS:.0f} Kbps"
             )
 
-        exposed = " ".join(profile.foxglove_allowlist).lower()
-        forbidden = [marker for marker in RAW_STREAM_MARKERS if marker in exposed]
+        forbidden = [
+            topic
+            for topic in profile.foxglove_allowlist
+            if _is_raw_stream_topic(topic)
+        ]
         if forbidden:
             errors.append(
-                f"{profile.name}: competition Foxglove allowlist exposes raw "
-                f"stream markers: {', '.join(forbidden)}"
+                f"{profile.name}: competition Foxglove allowlist exposes raw streams: "
+                f"{', '.join(forbidden)}"
             )
 
         off_by_default = " ".join(profile.off_by_default).lower()
@@ -186,6 +190,16 @@ def validate_profile(profile: RuntimeProfile) -> list[str]:
             if marker not in off_by_default:
                 errors.append(f"{profile.name}: {marker} must be off by default")
     return errors
+
+
+def _is_raw_stream_topic(topic: str) -> bool:
+    """Return True when a topic is too heavy for competition Foxglove use."""
+    normalised = topic.strip().lower()
+    if normalised.endswith("/compressed") or normalised.endswith("/camera_info"):
+        return False
+    return normalised.endswith(RAW_TOPIC_SUFFIXES) or any(
+        marker in normalised for marker in RAW_TOPIC_MARKERS
+    )
 
 
 def validate_profiles(profiles: dict[str, RuntimeProfile]) -> list[str]:

--- a/src/lunabot_bringup/package.xml
+++ b/src/lunabot_bringup/package.xml
@@ -9,6 +9,9 @@
 
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>compressed_image_transport</exec_depend>
+  <exec_depend>foxglove_bridge</exec_depend>
+  <exec_depend>image_transport</exec_depend>
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/src/lunabot_bringup/test/test_foxglove_ground_control_launch.py
+++ b/src/lunabot_bringup/test/test_foxglove_ground_control_launch.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+LAUNCH_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "launch"
+    / "foxglove_ground_control.launch.py"
+)
+
+
+def test_foxglove_ground_control_launch_uses_compressed_camera_republishers():
+    launch_text = LAUNCH_PATH.read_text(encoding="utf-8")
+
+    assert 'package="image_transport"' in launch_text
+    assert '"compressed"' in launch_text
+    assert "out.jpeg_quality" in launch_text
+    assert "/camera_front/image" in launch_text
+    assert "/camera_rear/image" in launch_text
+
+
+def test_foxglove_ground_control_launch_uses_runtime_profile_allowlist():
+    launch_text = LAUNCH_PATH.read_text(encoding="utf-8")
+
+    assert "topic_whitelist" in launch_text
+    assert "load_profiles(default_profiles_path())" in launch_text
+    assert "send_buffer_limit" in launch_text

--- a/src/lunabot_bringup/test/test_foxglove_layout.py
+++ b/src/lunabot_bringup/test/test_foxglove_layout.py
@@ -9,28 +9,37 @@ LAYOUT_PATH = (
 )
 
 
-def _walk_panels(node):
+def _walk_layout_ids(node):
     if isinstance(node, dict):
-        if node.get("type") == "panel":
-            yield node
         for value in node.values():
-            yield from _walk_panels(value)
+            yield from _walk_layout_ids(value)
     elif isinstance(node, list):
         for item in node:
-            yield from _walk_panels(item)
+            yield from _walk_layout_ids(item)
+    elif isinstance(node, str):
+        yield node
+
+
+def _configured_topics(layout):
+    topics = set()
+    for config in layout["configById"].values():
+        topic = config.get("topicPath") or config.get("cameraTopic")
+        if topic:
+            topics.add(topic)
+    return topics
 
 
 def test_mission_control_layout_is_valid_json():
     layout = json.loads(LAYOUT_PATH.read_text(encoding="utf-8"))
 
-    assert layout["name"] == "INNEX-1 Mission Control"
-    assert layout["content"]["type"] == "split"
+    assert isinstance(layout["configById"], dict)
+    assert isinstance(layout["layout"], dict)
 
 
 def test_mission_control_layout_covers_operator_topics():
     layout = json.loads(LAYOUT_PATH.read_text(encoding="utf-8"))
 
-    topics = set(layout["topics"])
+    topics = _configured_topics(layout)
 
     assert "/mission/state" in topics
     assert "/safety/motion_inhibit" in topics
@@ -39,13 +48,14 @@ def test_mission_control_layout_covers_operator_topics():
     assert "/excavation/status" in topics
     assert "/localisation/start_zone_status" in topics
     assert "/power/telemetry" in topics
-    assert "/camera_front/image" in topics
+    assert "/camera_front/image/compressed" in topics
 
 
 def test_mission_control_layout_keeps_debug_streams_out():
     layout = json.loads(LAYOUT_PATH.read_text(encoding="utf-8"))
-    topics = set(layout["topics"])
+    topics = _configured_topics(layout)
 
+    assert "/camera_front/image" not in topics
     assert "/ouster/points" not in topics
     assert "/global_costmap/costmap" not in topics
     assert "/local_costmap/costmap" not in topics
@@ -53,12 +63,14 @@ def test_mission_control_layout_keeps_debug_streams_out():
 
 def test_mission_control_layout_has_expected_panel_groups():
     layout = json.loads(LAYOUT_PATH.read_text(encoding="utf-8"))
-    panels = {panel["title"]: panel for panel in _walk_panels(layout["content"])}
+    panels = set(_walk_layout_ids(layout["layout"]))
 
     assert {
-        "Front Camera",
-        "Diagnostics",
-        "Mission",
-        "Safety and Power",
-        "Subsystems",
+        "Image!front_camera",
+        "RawMessages!diagnostics",
+        "RawMessages!mission_state",
+        "RawMessages!motion_inhibit",
+        "RawMessages!power",
+        "RawMessages!drivetrain",
+        "RawMessages!excavation",
     }.issubset(panels)

--- a/src/lunabot_bringup/test/test_runtime_profile.py
+++ b/src/lunabot_bringup/test/test_runtime_profile.py
@@ -38,17 +38,19 @@ def test_competition_profiles_stay_below_rulebook_budget_with_margin():
         profile = profiles[name]
         assert profile.budget_kbps <= COMPETITION_BUDGET_KBPS
         assert profile.estimated_kbps <= profile.target_kbps
-        assert profile.budget_margin_kbps >= 3000.0
+        assert profile.budget_margin_kbps >= 1000.0
 
 
-def test_competition_foxglove_allowlists_exclude_raw_streams():
+def test_competition_foxglove_allowlists_exclude_raw_streams_but_allow_compressed_video():
     profiles = load_profiles(RUNTIME_PROFILES_PATH)
 
     for name in COMPETITION_PROFILES:
-        exposed = " ".join(profiles[name].foxglove_allowlist).lower()
-        assert "image" not in exposed
-        assert "points" not in exposed
-        assert "camera" not in exposed
+        exposed = set(profiles[name].foxglove_allowlist)
+        assert "/camera_front/image" not in exposed
+        assert "/camera_front/depth_image" not in exposed
+        assert "/camera_front/points" not in exposed
+        assert "/ouster/points" not in exposed
+        assert "/camera_front/image/compressed" in exposed
 
 
 def test_hardware_competition_keeps_debug_tools_off_by_default():


### PR DESCRIPTION
## Summary
- add a Foxglove ground-control launch file that republishes camera images as JPEG-compressed image transport topics
- update competition runtime profiles to expose compressed camera video, keep raw images/point clouds out, and budget about 1.53 Mbps for sim competition telemetry
- update the shared Foxglove layout and docs to use /camera_front/image/compressed

## Testing
- Local: PYTHONPATH=src/lunabot_bringup pytest -q src/lunabot_bringup/test/test_runtime_profile.py src/lunabot_bringup/test/test_foxglove_layout.py src/lunabot_bringup/test/test_foxglove_ground_control_launch.py
- Local: python3 -m py_compile src/lunabot_bringup/launch/foxglove_ground_control.launch.py src/lunabot_bringup/lunabot_bringup/runtime_profile.py
- Jetson: colcon build --packages-select lunabot_bringup --symlink-install
- Jetson: colcon test --packages-select lunabot_bringup --event-handlers console_direct+  # 133 passed, 1 skipped
- Jetson: ros2 run lunabot_bringup runtime_profile check
- Jetson smoke: launched foxglove_ground_control.launch.py, confirmed /camera_front_compressed_republisher out.jpeg_quality=50 and foxglove topic_whitelist includes /camera_front/image/compressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds JPEG-compressed camera streaming and related controls to Foxglove ground control to reduce telemetry bandwidth for competition runs while retaining operator visibility. Introduces a dedicated Foxglove launch, updates runtime profiles and layouts to expose only compressed camera topics, tightens raw-stream validation, and updates docs and tests.

## Key changes
- New Foxglove launch: adds foxglove_ground_control.launch.py which republishes camera images as JPEG-compressed image_transport topics (front and optional rear), exposes only allowlisted topics to foxglove_bridge, and provides launch args for profile, JPEG quality (default 50), sim time, port/buffering, and per-camera enablement.
- Runtime profiles: updated sim_competition, hardware_bringup, and hardware_competition profiles to include compressed camera image and camera_info topics in Foxglove allowlists and telemetry budgets; competition telemetry budget adjusted (~1.53 Mbps for simulation competition) and guidance to keep average ≤ 4,000 Kbps.
- Raw-stream validation: improved detection in runtime_profile.py to classify and forbid raw streams (image, depth, point cloud) via configurable suffixes/markers while allowing compressed topics.
- Foxglove layout & docs: migrated mission_control.layout.json to configById/layout schema and updated camera widgets to use /camera_front/image/compressed; docs/foxglove/README.md and jetson_runtime_profiles.md updated with concrete launch commands, bandwidth guidance, and navigation/debug profile guidance.
- Package dependencies: added runtime exec dependencies for compressed_image_transport, foxglove_bridge, and image_transport.
- Tests: added/updated tests to assert compressed republishers, runtime-profile allowlist behavior, updated layout tests to the new schema, and adjusted budget-margin tests.

## Testing
Unit tests and lint/syntax checks run locally; Jetson build and tests passed (colcon build, colcon test: 133 passed, 1 skipped). Performed runtime/profile checks and a smoke test launching foxglove_ground_control, confirming republisher quality setting and that foxglove whitelist includes /camera_front/image/compressed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/300)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->