### PR TITLE
Make hardware failures explicit

### DIFF
--- a/src/lunabot_control/lunabot_control/deposition_bridge.py
+++ b/src/lunabot_control/lunabot_control/deposition_bridge.py
@@ -74,6 +74,7 @@ class DepositionBridge(Node):
         self.declare_parameter("bed_lower_duration_s", 5.0)
         self.declare_parameter("dump_hold_duration_s", 3.0)
         self.declare_parameter("feedback_hz", 5.0)
+        self.declare_parameter("dry_run", False)
 
     def _validate_parameters(self) -> None:
         """Read and validate parameters."""
@@ -119,6 +120,7 @@ class DepositionBridge(Node):
         self._fb_period = 1.0 / self.get_parameter(
             "feedback_hz"
         ).value
+        self._dry_run = bool(self.get_parameter("dry_run").value)
 
         if not 0.0 < self._duty <= 100.0:
             raise ValueError(
@@ -131,6 +133,7 @@ class DepositionBridge(Node):
         self._estop_active = False
         self._motion_inhibited = False
         self._gpio_available = False
+        self._hardware_fault_reason = ""
         self._door_pwm: Any = None
         self._bed_l_pwm_obj: Any = None
         self._bed_r_pwm_obj: Any = None
@@ -140,11 +143,19 @@ class DepositionBridge(Node):
         try:
             import Jetson.GPIO as GPIO
         except (ImportError, RuntimeError) as exc:
-            self.get_logger().warn(
-                f"GPIO unavailable: {exc}. "
-                f"Running in dry-run mode."
-            )
             self._gpio_available = False
+            self._hardware_fault_reason = f"GPIO unavailable: {exc}"
+            if self._dry_run:
+                self.get_logger().warn(
+                    f"{self._hardware_fault_reason}. "
+                    "Explicit dry-run enabled, so actuator output is disabled "
+                    "but ROS interfaces stay active."
+                )
+            else:
+                self.get_logger().error(
+                    f"{self._hardware_fault_reason}. "
+                    "dry_run is false, so deposit goals will be rejected."
+                )
             return
 
         GPIO.setmode(GPIO.BOARD)
@@ -177,6 +188,7 @@ class DepositionBridge(Node):
         self._bed_r_pwm_obj.start(0)
 
         self._gpio_available = True
+        self._hardware_fault_reason = ""
         self.get_logger().info("GPIO initialised for Cytron control")
 
     def _init_ros(self) -> None:
@@ -216,6 +228,11 @@ class DepositionBridge(Node):
         if self._estop_active or self._motion_inhibited:
             self.get_logger().warn(
                 "Deposit goal rejected: safety active"
+            )
+            return GoalResponse.REJECT
+        if not self._gpio_available and not self._dry_run:
+            self.get_logger().error(
+                "Deposit goal rejected: actuator hardware unavailable"
             )
             return GoalResponse.REJECT
         return GoalResponse.ACCEPT
@@ -258,6 +275,8 @@ class DepositionBridge(Node):
             return "E-stop active during deposition"
         if self._motion_inhibited:
             return "Motion inhibited during deposition"
+        if not self._gpio_available and not self._dry_run:
+            return self._hardware_fault_reason or "Actuator hardware unavailable"
         return None
 
     def _wait_phase(
@@ -332,6 +351,14 @@ class DepositionBridge(Node):
         """Run the full dump sequence: open → raise → hold → lower → close."""
         start = time.monotonic()
         self.get_logger().info("Deposit sequence starting")
+        if not self._gpio_available and not self._dry_run:
+            goal_handle.abort()
+            return self._result(
+                False,
+                Deposit.Result.REASON_DRIVER_FAULT,
+                self._hardware_fault_reason or "Actuator hardware unavailable",
+                time.monotonic() - start,
+            )
 
         # Phase 1: Open door
         self._set_actuator(

--- a/src/lunabot_control/test/test_deposition_bridge.py
+++ b/src/lunabot_control/test/test_deposition_bridge.py
@@ -14,6 +14,10 @@
 
 """Unit tests for the deposition bridge logic."""
 
+from unittest.mock import MagicMock
+
+from rclpy.action import GoalResponse
+
 from lunabot_interfaces.action import Deposit
 
 
@@ -61,3 +65,45 @@ class TestDepositPhases:
         ]
         for i in range(len(phases) - 1):
             assert phases[i] < phases[i + 1]
+
+
+class TestDepositHardwareAvailability:
+    """Verify deposit goals fail closed when actuator hardware is unavailable."""
+
+    def _make_bridge(self, *, dry_run=False):
+        from lunabot_control.deposition_bridge import DepositionBridge
+
+        bridge = object.__new__(DepositionBridge)
+        bridge._estop_active = False
+        bridge._motion_inhibited = False
+        bridge._gpio_available = False
+        bridge._dry_run = dry_run
+        bridge._hardware_fault_reason = "GPIO unavailable"
+        bridge.get_logger = MagicMock()
+        return bridge
+
+    def test_goal_rejected_when_gpio_missing_and_not_dry_run(self):
+        bridge = self._make_bridge(dry_run=False)
+
+        response = bridge._goal_cb(object())
+
+        assert response == GoalResponse.REJECT
+        bridge.get_logger().error.assert_called_once()
+
+    def test_goal_accepted_when_gpio_missing_but_dry_run_explicit(self):
+        bridge = self._make_bridge(dry_run=True)
+
+        response = bridge._goal_cb(object())
+
+        assert response == GoalResponse.ACCEPT
+
+    def test_execute_aborts_when_hardware_unavailable(self):
+        bridge = self._make_bridge(dry_run=False)
+        goal_handle = MagicMock()
+
+        result = bridge._execute_deposit(goal_handle)
+
+        goal_handle.abort.assert_called_once()
+        assert result.success is False
+        assert result.reason_code == Deposit.Result.REASON_DRIVER_FAULT
+        assert result.failure_reason == "GPIO unavailable"

--- a/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
@@ -33,6 +33,7 @@ from rclpy.qos import (
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Bool
 
+from lunabot_drivetrain import sabertooth_serial
 from lunabot_interfaces.msg import (
     DrivetrainStatus,
     DrivetrainTelemetry,
@@ -133,6 +134,11 @@ class DrivetrainBridge(Node):
             raise ValueError(
                 f"Expected 2 Sabertooth addresses, got {len(self._addresses)}"
             )
+        for address in self._addresses:
+            if not 0 <= int(address) <= 255:
+                raise ValueError(
+                    f"Sabertooth address out of range: {address}"
+                )
         if self._serial_protocol not in _SUPPORTED_PROTOCOLS:
             raise ValueError(
                 "serial_protocol must be one of "
@@ -210,6 +216,13 @@ class DrivetrainBridge(Node):
         """Open the UART serial port, failing closed unless dry-run is explicit."""
         try:
             import serial as pyserial
+        except ImportError as exc:
+            self._serial = None
+            self._controller_online = [False, False]
+            self._handle_serial_unavailable(exc)
+            return
+
+        try:
             self._serial = pyserial.Serial(
                 self._serial_port,
                 self._baud_rate,
@@ -218,7 +231,7 @@ class DrivetrainBridge(Node):
             self._controller_online = [True, True]
             self._state = DrivetrainStatus.STATE_READY
             self.get_logger().info(f"Serial port {self._serial_port} opened")
-        except Exception as exc:
+        except (OSError, pyserial.SerialException) as exc:
             self._serial = None
             self._controller_online = [False, False]
             self._handle_serial_unavailable(exc)
@@ -241,6 +254,13 @@ class DrivetrainBridge(Node):
         )
         self._fault_code = DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
         self._state = DrivetrainStatus.STATE_FAULT
+
+    def _mark_controller_offline(self, reason: str) -> None:
+        """Record a controller IO failure and fail closed."""
+        self.get_logger().error(reason)
+        self._controller_online = [False, False]
+        self._fault_code = DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
+        self._transition_to(DrivetrainStatus.STATE_FAULT)
 
     def _init_ros(self) -> None:
         """Set up publishers, subscribers, and timers."""
@@ -406,36 +426,32 @@ class DrivetrainBridge(Node):
         if self._serial is None:
             return
         try:
-            from lunabot_drivetrain.sabertooth_serial import (
-                send_simplified_throttle,
-                send_throttle,
-            )
             if self._serial_protocol in _LEGACY_SIMPLIFIED_PROTOCOLS:
-                send_simplified_throttle(self._serial, left, right)
+                sabertooth_serial.send_simplified_throttle(
+                    self._serial, left, right
+                )
                 return
-            send_throttle(self._serial, self._addresses[0], left, right)
-            send_throttle(self._serial, self._addresses[1], left, right)
-        except Exception as exc:
-            self.get_logger().error(f"Serial write failed: {exc}")
-            self._fault_code = DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
-            self._transition_to(DrivetrainStatus.STATE_FAULT)
+            sabertooth_serial.send_throttle(
+                self._serial, self._addresses[0], left, right
+            )
+            sabertooth_serial.send_throttle(
+                self._serial, self._addresses[1], left, right
+            )
+        except OSError as exc:
+            self._mark_controller_offline(f"Serial write failed: {exc}")
 
     def _send_stop(self) -> None:
         """Command zero throttle to all motors."""
         if self._serial is None:
             return
         try:
-            from lunabot_drivetrain.sabertooth_serial import (
-                send_simplified_stop,
-                send_stop,
-            )
             if self._serial_protocol in _LEGACY_SIMPLIFIED_PROTOCOLS:
-                send_simplified_stop(self._serial)
+                sabertooth_serial.send_simplified_stop(self._serial)
                 return
             for addr in self._addresses:
-                send_stop(self._serial, addr)
-        except Exception as exc:
-            self.get_logger().error(f"Serial stop failed: {exc}")
+                sabertooth_serial.send_stop(self._serial, addr)
+        except OSError as exc:
+            self._mark_controller_offline(f"Serial stop failed: {exc}")
 
     def _transition_to(self, new_state: int) -> None:
         """Update the state machine, only logging on actual transitions."""
@@ -489,8 +505,8 @@ class DrivetrainBridge(Node):
         if self._serial is not None:
             try:
                 self._serial.close()
-            except Exception:
-                pass
+            except OSError as exc:
+                self.get_logger().warn(f"Serial close failed: {exc}")
         super().destroy_node()
 
 

--- a/src/lunabot_drivetrain/test/test_sabertooth_serial.py
+++ b/src/lunabot_drivetrain/test/test_sabertooth_serial.py
@@ -180,12 +180,18 @@ class TestDrivetrainBridgeSerialDispatch:
     """Verify the bridge chooses the configured Sabertooth protocol."""
 
     def _make_bridge(self, protocol):
+        from unittest.mock import MagicMock
+
         from lunabot_drivetrain.drivetrain_bridge import DrivetrainBridge
 
         bridge = object.__new__(DrivetrainBridge)
         bridge._serial = object()
         bridge._serial_protocol = protocol
         bridge._addresses = [128, 129]
+        bridge._controller_online = [True, True]
+        bridge._fault_code = DrivetrainStatus.FAULT_NONE
+        bridge._state = DrivetrainStatus.STATE_READY
+        bridge.get_logger = MagicMock()
         return bridge
 
     def test_legacy_simplified_throttle_path(self, monkeypatch):
@@ -268,3 +274,39 @@ class TestDrivetrainBridgeSerialDispatch:
         bridge._send_stop()
 
         assert calls == [(bridge._serial, 128), (bridge._serial, 129)]
+
+    def test_throttle_write_failure_faults_controller(self, monkeypatch):
+        def raise_io_error(*_args):
+            raise OSError("serial disconnected")
+
+        monkeypatch.setattr(
+            sabertooth_serial,
+            "send_simplified_throttle",
+            raise_io_error,
+        )
+
+        bridge = self._make_bridge("legacy_simplified")
+        bridge._send_wheel_throttles(0.2, -0.1)
+
+        assert bridge._state == DrivetrainStatus.STATE_FAULT
+        assert bridge._fault_code == DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
+        assert bridge._controller_online == [False, False]
+        bridge.get_logger().error.assert_called_once()
+
+    def test_stop_write_failure_faults_controller(self, monkeypatch):
+        def raise_io_error(*_args):
+            raise OSError("serial disconnected")
+
+        monkeypatch.setattr(
+            sabertooth_serial,
+            "send_simplified_stop",
+            raise_io_error,
+        )
+
+        bridge = self._make_bridge("legacy_simplified")
+        bridge._send_stop()
+
+        assert bridge._state == DrivetrainStatus.STATE_FAULT
+        assert bridge._fault_code == DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
+        assert bridge._controller_online == [False, False]
+        bridge.get_logger().error.assert_called_once()


### PR DESCRIPTION
## Summary

- make `deposition_bridge` dry-run explicit instead of silently treating missing GPIO as success-capable
- reject/abort deposit goals with `REASON_DRIVER_FAULT` when actuator hardware is unavailable and `dry_run` is false
- narrow drivetrain serial startup handling and move serial helper imports out of runtime `try` blocks
- make throttle/stop serial write failures mark controllers offline and enter `STATE_FAULT`
- log serial close failures during shutdown instead of silently swallowing them

Linear: https://linear.app/kjdotio/issue/INX-50/safety-cleanup-make-hardware-failures-explicit-and-fail-closed

## Research basis

This follows the error-handling subagent report:

- implicit deposition dry-run could make the mission action look successful while actuators cannot move
- drivetrain broad catches could hide programming/config/import errors as generic controller-offline faults
- actuator stop failures should enter a defined safe failure path

Firecrawl-backed sources used in that report included Python exception guidance and ROS 2 Humble service/TF guidance.

## Validation

Local:

- `python3 -m compileall src/lunabot_control/lunabot_control/deposition_bridge.py src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py src/lunabot_control/test/test_deposition_bridge.py src/lunabot_drivetrain/test/test_sabertooth_serial.py`
- `uv run ruff check src/lunabot_control/lunabot_control/deposition_bridge.py src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py src/lunabot_control/test/test_deposition_bridge.py src/lunabot_drivetrain/test/test_sabertooth_serial.py`

Jetson:

```text
50 passed in 0.77s
```

Command run on Jetson:

```bash
source /opt/ros/humble/setup.bash
source install/setup.bash
PYTHONPATH=src/lunabot_drivetrain:src/lunabot_control:$PYTHONPATH \
  python3 -m pytest \
  src/lunabot_drivetrain/test/test_sabertooth_serial.py \
  src/lunabot_drivetrain/test/test_velocity_gate.py \
  src/lunabot_control/test/test_deposition_bridge.py
```
