### PR TITLE
Consolidate ROS message field helpers

### DIFF
--- a/src/lunabot_bringup/lunabot_bringup/hardware_fault_injection.py
+++ b/src/lunabot_bringup/lunabot_bringup/hardware_fault_injection.py
@@ -20,6 +20,8 @@ from rclpy.qos import (
 )
 from rosidl_runtime_py.utilities import get_message
 
+from lunabot_bringup.message_fields import write_message_field
+
 
 @dataclass(frozen=True)
 class TopicInjection:
@@ -49,47 +51,12 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     return data
 
 
-def _field_tokens(path: str) -> list[str | int]:
-    """Split a field path such as controller_online[0]."""
-    tokens: list[str | int] = []
-    for part in path.split("."):
-        if not part:
-            raise ValueError(f"Invalid empty field in path '{path}'")
-        name, bracket, rest = part.partition("[")
-        if name:
-            tokens.append(name)
-        while bracket:
-            index_text, close, rest = rest.partition("]")
-            if not close or not index_text.isdigit():
-                raise ValueError(f"Invalid list index in field path '{path}'")
-            tokens.append(int(index_text))
-            bracket, rest = rest[:1], rest[1:]
-    return tokens
-
-
-def _set_field(message: Any, path: str, value: Any) -> None:
-    """Set a simple or indexed message field."""
-    tokens = _field_tokens(path)
-    if not tokens:
-        raise ValueError("field path must not be empty")
-
-    target = message
-    for token in tokens[:-1]:
-        target = target[token] if isinstance(token, int) else getattr(target, token)
-
-    last = tokens[-1]
-    if isinstance(last, int):
-        target[last] = value
-    else:
-        setattr(target, last, value)
-
-
 def _message_from_config(type_name: str, fields: dict[str, Any]):
     """Build a ROS message from a type name and field mapping."""
     message_type = get_message(type_name)
     message = message_type()
     for path, value in fields.items():
-        _set_field(message, path, value)
+        write_message_field(message, path, value)
     return message
 
 

--- a/src/lunabot_bringup/lunabot_bringup/message_fields.py
+++ b/src/lunabot_bringup/lunabot_bringup/message_fields.py
@@ -1,0 +1,50 @@
+"""Helpers for dotted ROS message field paths."""
+
+from __future__ import annotations
+
+from typing import Any
+
+FieldToken = str | int
+
+
+def parse_field_path(path: str) -> list[FieldToken]:
+    """Split a field path such as ``header.stamp.sec`` or ``values[0]``."""
+    tokens: list[FieldToken] = []
+    for part in path.split("."):
+        if not part:
+            raise ValueError(f"Invalid empty field in path '{path}'")
+        name, bracket, rest = part.partition("[")
+        if name:
+            tokens.append(name)
+        while bracket:
+            index_text, close, rest = rest.partition("]")
+            if not close or not index_text.isdigit():
+                raise ValueError(f"Invalid list index in field path '{path}'")
+            tokens.append(int(index_text))
+            bracket, rest = rest[:1], rest[1:]
+    return tokens
+
+
+def read_message_field(message: Any, path: str) -> Any:
+    """Read a nested ROS message field using dotted and indexed path syntax."""
+    value: Any = message
+    for token in parse_field_path(path):
+        value = value[token] if isinstance(token, int) else getattr(value, token)
+    return value
+
+
+def write_message_field(message: Any, path: str, value: Any) -> None:
+    """Set a nested ROS message field using dotted and indexed path syntax."""
+    tokens = parse_field_path(path)
+    if not tokens:
+        raise ValueError("field path must not be empty")
+
+    target = message
+    for token in tokens[:-1]:
+        target = target[token] if isinstance(token, int) else getattr(target, token)
+
+    last = tokens[-1]
+    if isinstance(last, int):
+        target[last] = value
+    else:
+        setattr(target, last, value)

--- a/src/lunabot_bringup/lunabot_bringup/preflight_check.py
+++ b/src/lunabot_bringup/lunabot_bringup/preflight_check.py
@@ -28,6 +28,7 @@ from rclpy.utilities import remove_ros_args
 from rosidl_runtime_py.utilities import get_message
 from tf2_ros import Buffer, TransformListener
 
+from lunabot_bringup.message_fields import read_message_field
 from lunabot_bringup.preflight_profiles import (
     PHASE_FULL,
     VALID_PHASES,
@@ -57,37 +58,11 @@ DURABILITY_MAP = {
 }
 
 
-def _field_tokens(path: str) -> list[str | int]:
-    """Split a message field path into attribute and list-index tokens."""
-    tokens: list[str | int] = []
-    for part in path.split("."):
-        if not part:
-            raise ValueError(f"Invalid empty field in path '{path}'")
-        name, bracket, rest = part.partition("[")
-        if name:
-            tokens.append(name)
-        while bracket:
-            index_text, close, rest = rest.partition("]")
-            if not close or not index_text.isdigit():
-                raise ValueError(f"Invalid list index in field path '{path}'")
-            tokens.append(int(index_text))
-            bracket, rest = rest[:1], rest[1:]
-    return tokens
-
-
-def _read_field(message: Any, path: str) -> Any:
-    """Read a possibly nested message field such as controller_online[0]."""
-    value: Any = message
-    for token in _field_tokens(path):
-        value = value[token] if isinstance(token, int) else getattr(value, token)
-    return value
-
-
 def _fields_match(message: Any, expected_fields: dict[str, Any]) -> tuple[bool, str]:
     """Return whether a message satisfies the configured field expectations."""
     for path, expected in expected_fields.items():
         try:
-            actual = _read_field(message, path)
+            actual = read_message_field(message, path)
         except (AttributeError, IndexError, TypeError, ValueError) as exc:
             return False, f"{path} unreadable: {exc}"
         if actual != expected:

--- a/src/lunabot_bringup/test/test_hardware_fault_injection.py
+++ b/src/lunabot_bringup/test/test_hardware_fault_injection.py
@@ -7,11 +7,11 @@ from rosidl_runtime_py.utilities import get_message
 
 from lunabot_bringup.hardware_fault_injection import (
     _message_from_config,
-    _set_field,
     load_scenarios,
     scenario_needs_live_topic_ack,
     validate_live_topic_ack,
 )
+from lunabot_bringup.message_fields import write_message_field
 
 
 def _config_path() -> Path:
@@ -82,8 +82,8 @@ def test_set_field_supports_indexed_arrays():
     status_type = get_message("lunabot_interfaces/msg/DrivetrainStatus")
     message = status_type()
 
-    _set_field(message, "controller_online[0]", True)
-    _set_field(message, "controller_online[1]", False)
+    write_message_field(message, "controller_online[0]", True)
+    write_message_field(message, "controller_online[1]", False)
 
     assert list(message.controller_online) == [True, False]
 

--- a/src/lunabot_bringup/test/test_message_fields.py
+++ b/src/lunabot_bringup/test/test_message_fields.py
@@ -1,0 +1,37 @@
+"""Tests for shared ROS message field-path helpers."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from lunabot_bringup.message_fields import (
+    parse_field_path,
+    read_message_field,
+    write_message_field,
+)
+
+
+def test_parse_field_path_supports_nested_attributes_and_indices():
+    assert parse_field_path("header.stamp.sec") == ["header", "stamp", "sec"]
+    assert parse_field_path("controller_online[1]") == ["controller_online", 1]
+
+
+def test_read_and_write_message_field_supports_nested_paths():
+    message = SimpleNamespace(
+        controller_online=[False, False],
+        nested=SimpleNamespace(state="idle"),
+    )
+
+    write_message_field(message, "controller_online[0]", True)
+    write_message_field(message, "nested.state", "ready")
+
+    assert read_message_field(message, "controller_online[0]") is True
+    assert read_message_field(message, "nested.state") == "ready"
+
+
+def test_parse_field_path_rejects_invalid_paths():
+    with pytest.raises(ValueError, match="Invalid empty field"):
+        parse_field_path("header..stamp")
+
+    with pytest.raises(ValueError, match="Invalid list index"):
+        parse_field_path("controller_online[first]")

--- a/src/lunabot_bringup/test/test_preflight_profiles.py
+++ b/src/lunabot_bringup/test/test_preflight_profiles.py
@@ -17,10 +17,10 @@ from lunabot_bringup.preflight_check import (
     _merge_contract_requirements,
     _parse_bool_text,
     _parse_qos_policy,
-    _read_field,
     _strip_ros_cli_args,
 )
 from lunabot_bringup.preflight_profiles import filter_preflight_config, validate_phase
+from lunabot_bringup.message_fields import read_message_field
 
 
 def test_filter_preflight_config_keeps_all_checks_in_full_phase():
@@ -237,9 +237,9 @@ def test_read_field_supports_indexed_message_fields():
         nested=SimpleNamespace(state="ready"),
     )
 
-    assert _read_field(message, "controller_online[0]") is True
-    assert _read_field(message, "controller_online[1]") is False
-    assert _read_field(message, "nested.state") == "ready"
+    assert read_message_field(message, "controller_online[0]") is True
+    assert read_message_field(message, "controller_online[1]") is False
+    assert read_message_field(message, "nested.state") == "ready"
 
 
 def test_fields_match_reports_first_mismatch():

--- a/src/lunabot_bringup/test/test_preflight_profiles.py
+++ b/src/lunabot_bringup/test/test_preflight_profiles.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 import yaml
 
+from lunabot_bringup.message_fields import read_message_field
 from lunabot_bringup.preflight_check import (
     ACTION_TYPE_MAP,
     DURABILITY_MAP,
@@ -20,7 +21,6 @@ from lunabot_bringup.preflight_check import (
     _strip_ros_cli_args,
 )
 from lunabot_bringup.preflight_profiles import filter_preflight_config, validate_phase
-from lunabot_bringup.message_fields import read_message_field
 
 
 def test_filter_preflight_config_keeps_all_checks_in_full_phase():


### PR DESCRIPTION
## Summary
- add a shared typed helper for dotted/indexed ROS message field paths
- refactor preflight expected-field checks and hardware fault injection message building to use the same helper
- add focused tests for parsing, reading and writing field paths

Linear: https://linear.app/kjdotio/issue/INX-52/typing-and-dry-cleanup-consolidate-ros-message-field-helpers

## Validation
- `python3 -m compileall src/lunabot_bringup/lunabot_bringup/message_fields.py src/lunabot_bringup/lunabot_bringup/preflight_check.py src/lunabot_bringup/lunabot_bringup/hardware_fault_injection.py src/lunabot_bringup/test/test_message_fields.py src/lunabot_bringup/test/test_preflight_profiles.py src/lunabot_bringup/test/test_hardware_fault_injection.py`
- `uv run ruff check src/lunabot_bringup/lunabot_bringup/message_fields.py src/lunabot_bringup/lunabot_bringup/preflight_check.py src/lunabot_bringup/lunabot_bringup/hardware_fault_injection.py src/lunabot_bringup/test/test_message_fields.py src/lunabot_bringup/test/test_preflight_profiles.py src/lunabot_bringup/test/test_hardware_fault_injection.py`
- Local helper-only test: `PYTHONPATH=src/lunabot_bringup uv run pytest src/lunabot_bringup/test/test_message_fields.py`
- Jetson: `colcon build --packages-select lunabot_bringup --symlink-install`
- Jetson: `source /opt/ros/humble/setup.bash && source install/setup.bash && python3 -m pytest src/lunabot_bringup/test/test_message_fields.py src/lunabot_bringup/test/test_preflight_profiles.py src/lunabot_bringup/test/test_hardware_fault_injection.py`

Note: the full local bringup pytest collection needs the ROS workspace overlay and generated `lunabot_interfaces`; that was validated on the Jetson.
