### PR TITLE
Service mission manager callbacks during mission loop

### DIFF
--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import math
+import time
 from enum import IntEnum
 
 import rclpy
 from action_msgs.msg import GoalStatus
 from nav2_msgs.action import NavigateToPose
 from rclpy.action import ActionClient
+from rclpy.executors import (
+    ShutdownException,
+    SingleThreadedExecutor,
+    TimeoutException,
+)
 from rclpy.node import Node
 from rclpy.qos import (
     DurabilityPolicy,
@@ -277,7 +283,26 @@ class MissionManager(Node):
 
     def _service_callbacks(self) -> None:
         """Service timers and subscriptions while the FSM owns the thread."""
-        rclpy.spin_once(self, timeout_sec=0.0)
+        executor = SingleThreadedExecutor(context=self.context)
+        node_was_added = executor.add_node(self)
+        if not node_was_added:
+            return
+
+        try:
+            while True:
+                try:
+                    handler, _, _ = executor.wait_for_ready_callbacks(
+                        timeout_sec=0.0,
+                        nodes=[self],
+                    )
+                except (ShutdownException, TimeoutException):
+                    return
+
+                handler()
+                if handler.exception() is not None:
+                    raise handler.exception()
+        finally:
+            executor.remove_node(self)
 
     # ------------------------------------------------------------------
     # FSM dispatcher
@@ -552,8 +577,18 @@ class MissionManager(Node):
         timeout_s: float = 30.0,
     ) -> tuple[bool, str]:
         """Block until an action server is available."""
-        if client.wait_for_server(timeout_sec=timeout_s):
-            return True, f"{action_name} server available"
+        deadline = time.monotonic() + timeout_s
+        while True:
+            self._service_callbacks()
+            if not self._is_safe():
+                return False, f"{action_name}: safety stop active while waiting"
+            if client.server_is_ready():
+                return True, f"{action_name} server available"
+            remaining_s = deadline - time.monotonic()
+            if remaining_s <= 0.0:
+                break
+            time.sleep(min(0.05, remaining_s))
+
         return False, f"{action_name} server unavailable after {timeout_s}s"
 
     def _build_nav_goal(self, x: float, y: float, yaw: float) -> NavigateToPose.Goal:

--- a/src/lunabot_bringup/lunabot_bringup/mission_manager.py
+++ b/src/lunabot_bringup/lunabot_bringup/mission_manager.py
@@ -259,6 +259,7 @@ class MissionManager(Node):
         self._mission_active = True
         self._publish_operator_state()
         while self._state != MissionState.HALT_MISSION:
+            self._service_callbacks()
             if not self._is_safe():
                 reason = "Safety stop during mission"
                 self.get_logger().error(f"{reason} — halting")
@@ -273,6 +274,10 @@ class MissionManager(Node):
         self.get_logger().info(
             f"Mission halted after {self._cycle_count} cycles."
         )
+
+    def _service_callbacks(self) -> None:
+        """Service timers and subscriptions while the FSM owns the thread."""
+        rclpy.spin_once(self, timeout_sec=0.0)
 
     # ------------------------------------------------------------------
     # FSM dispatcher

--- a/src/lunabot_bringup/test/test_mission_manager.py
+++ b/src/lunabot_bringup/test/test_mission_manager.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import lunabot_bringup.mission_manager as mission_manager
 from lunabot_bringup.mission_manager import MissionManager, MissionState
 from lunabot_bringup.mission_timer import MissionTimer
 
@@ -48,6 +49,7 @@ def _make_manager(monkeypatch):
     manager._motion_inhibited = False
     manager._last_failure_reason = ""
     manager._mission_active = False
+    manager._context = MagicMock()
     manager._mission_state_pub = _fake_publisher()
     manager._autonomy_mode_pub = _fake_publisher()
     manager._time_remaining_pub = _fake_publisher()
@@ -127,15 +129,50 @@ def test_run_mission_services_callbacks_before_safety_check(monkeypatch):
     )
 
 
-def test_service_callbacks_spins_node_without_blocking(monkeypatch):
-    """Mission callback service point should use the normal rclpy executor API."""
+def test_service_callbacks_drains_ready_callbacks_without_blocking(monkeypatch):
+    """Mission callback service point should drain all currently ready callbacks."""
     manager = _make_manager(monkeypatch)
-    spin_once = MagicMock()
-    monkeypatch.setattr("rclpy.spin_once", spin_once)
+    call_order = []
+
+    class ReadyHandler:
+        def __init__(self, callback):
+            self._callback = callback
+
+        def __call__(self):
+            self._callback()
+
+        def exception(self):
+            return None
+
+    class FakeExecutor:
+        def __init__(self, *, context):
+            self.context = context
+            self.handlers = [
+                ReadyHandler(lambda: call_order.append("operator_timer")),
+                ReadyHandler(lambda: manager._inhibit_cb(SimpleNamespace(data=True))),
+            ]
+            self.removed_node = None
+
+        def add_node(self, node):
+            assert node is manager
+            return True
+
+        def wait_for_ready_callbacks(self, *, timeout_sec, nodes):
+            assert timeout_sec == 0.0
+            assert nodes == [manager]
+            if self.handlers:
+                return self.handlers.pop(0), None, manager
+            raise mission_manager.TimeoutException()
+
+        def remove_node(self, node):
+            self.removed_node = node
+
+    monkeypatch.setattr(mission_manager, "SingleThreadedExecutor", FakeExecutor)
 
     manager._service_callbacks()
 
-    spin_once.assert_called_once_with(manager, timeout_sec=0.0)
+    assert call_order == ["operator_timer"]
+    assert manager._motion_inhibited is True
 
 
 # ------------------------------------------------------------------
@@ -412,6 +449,42 @@ def test_nav_sequence_stops_when_safety_trips_between_legs(monkeypatch):
         "navigate_to_excavation: safety stop active before navigate_to_excavation"
     )
     assert sent == [("navigate_to_mid_obstacle", first_goal)]
+
+
+def test_wait_for_server_services_callbacks_while_waiting(monkeypatch):
+    """Server waits must keep timers and subscriptions moving."""
+    manager = _make_manager(monkeypatch)
+    client = MagicMock()
+    client.server_is_ready.side_effect = [False, False, True]
+    service_callbacks = MagicMock()
+    monkeypatch.setattr(manager, "_service_callbacks", service_callbacks)
+    monkeypatch.setattr(mission_manager.time, "sleep", lambda _duration: None)
+
+    success, detail = manager._wait_for_server(client, "navigate")
+
+    assert success
+    assert detail == "navigate server available"
+    assert service_callbacks.call_count == 3
+
+
+def test_wait_for_server_stops_when_safety_callback_trips(monkeypatch):
+    """Server waits should not ignore a queued safety stop."""
+    manager = _make_manager(monkeypatch)
+    client = MagicMock()
+    client.server_is_ready.return_value = False
+
+    def _trip_estop():
+        manager._estop_cb(SimpleNamespace(data=True))
+
+    monkeypatch.setattr(manager, "_service_callbacks", _trip_estop)
+    sleep = MagicMock()
+    monkeypatch.setattr(mission_manager.time, "sleep", sleep)
+
+    success, detail = manager._wait_for_server(client, "navigate")
+
+    assert not success
+    assert detail == "navigate: safety stop active while waiting"
+    sleep.assert_not_called()
 
 
 def test_deposit_success_transitions_to_check_next_cycle_time(monkeypatch):

--- a/src/lunabot_bringup/test/test_mission_manager.py
+++ b/src/lunabot_bringup/test/test_mission_manager.py
@@ -107,6 +107,37 @@ def test_set_failure_reason_updates_operator_topic(monkeypatch):
     assert manager._failure_reason_pub.messages[-1].data == "Navigation failed"
 
 
+def test_run_mission_services_callbacks_before_safety_check(monkeypatch):
+    """Mission loop must process safety subscriptions before each FSM step."""
+    manager = _make_manager(monkeypatch)
+
+    def _trip_motion_inhibit():
+        manager._motion_inhibited = True
+
+    monkeypatch.setattr(manager, "_service_callbacks", _trip_motion_inhibit)
+    manager._step = MagicMock()
+
+    manager.run_mission()
+
+    manager._step.assert_not_called()
+    assert manager._state == MissionState.HALT_MISSION
+    assert manager._last_failure_reason == "Safety stop during mission"
+    assert manager._failure_reason_pub.messages[-1].data == (
+        "Safety stop during mission"
+    )
+
+
+def test_service_callbacks_spins_node_without_blocking(monkeypatch):
+    """Mission callback service point should use the normal rclpy executor API."""
+    manager = _make_manager(monkeypatch)
+    spin_once = MagicMock()
+    monkeypatch.setattr("rclpy.spin_once", spin_once)
+
+    manager._service_callbacks()
+
+    spin_once.assert_called_once_with(manager, timeout_sec=0.0)
+
+
 # ------------------------------------------------------------------
 # INITIALIZE_MISSION
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- service ROS callbacks inside the mission manager FSM loop before each safety check
- keep operator telemetry timers and safety subscriptions responsive while `run_mission()` owns the thread
- add regression coverage for callback servicing before safety-state evaluation

Linear: https://linear.app/kjdotio/issue/INX-53/mission-manager-service-ros-callbacks-during-mission-execution

## Validation
- `python3 -m compileall src/lunabot_bringup/lunabot_bringup/mission_manager.py src/lunabot_bringup/test/test_mission_manager.py`
- `uv run ruff check src/lunabot_bringup/lunabot_bringup/mission_manager.py src/lunabot_bringup/test/test_mission_manager.py`
- Jetson: `source /opt/ros/humble/setup.bash && source install/setup.bash && python3 -m pytest src/lunabot_bringup/test/test_mission_manager.py src/lunabot_bringup/test/test_mission_manager_launch.py src/lunabot_bringup/test/test_mission_shuttle_evidence_launch.py`
- Jetson: `source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select lunabot_bringup`

Note: local pytest collection for this file requires ROS 2 Python packages such as `rclpy`, so the focused pytest run was performed on the Jetson.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes the mission manager's responsiveness to ROS callbacks during mission execution. The mission manager was blocking operator telemetry timers and safety subscriptions while the `run_mission()` method owned the thread, preventing timely safety-related responses.

## Changes

**Mission Manager Execution Loop**
- Modified `run_mission()` to service ROS callbacks inside the main FSM loop prior to each safety check, ensuring subscriptions and timers remain responsive while the mission thread is active

**Server Availability Checks**
- Refactored `_wait_for_server()` from a blocking call to a polling loop that continues servicing callbacks during the wait
- Added early abort capability when a safety stop is triggered during server polling

**Test Coverage**
- Added regression tests covering callback servicing before safety state evaluation
- New tests verify:
  - Callbacks are processed before safety checks occur
  - Ready callbacks drain without blocking
  - Callbacks are serviced while waiting for server readiness
  - Safety events interrupt server wait operations early

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->