### PR TITLE
Handle crater detector TF future offsets

### DIFF
--- a/src/lunabot_perception/lunabot_perception/crater_detection.py
+++ b/src/lunabot_perception/lunabot_perception/crater_detection.py
@@ -31,7 +31,7 @@ from scipy.spatial.transform import Rotation
 from sensor_msgs.msg import PointCloud2
 from sensor_msgs_py.point_cloud2 import create_cloud_xyz32, read_points_numpy
 from std_msgs.msg import Header
-from tf2_ros import TransformException
+from tf2_ros import ExtrapolationException, TransformException
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 
@@ -137,19 +137,8 @@ class CraterDetectionNode(Node):
 
     def _cloud_callback(self, msg: PointCloud2):
         """Transform incoming cloud to odom frame and accumulate elevation."""
-        try:
-            tf = self.tf_buffer.lookup_transform(
-                self.target_frame,
-                msg.header.frame_id,
-                Time.from_msg(msg.header.stamp),
-                timeout=Duration(seconds=0.2),
-            )
-        except TransformException as e:
-            self.get_logger().warning(
-                f"TF lookup {msg.header.frame_id} -> {self.target_frame} "
-                f"failed: {e}",
-                throttle_duration_sec=5.0,
-            )
+        tf = self._lookup_cloud_transform(msg)
+        if tf is None:
             return
 
         points = read_points_numpy(msg, field_names=["x", "y", "z"], skip_nans=True)
@@ -185,6 +174,52 @@ class CraterDetectionNode(Node):
 
         np.add.at(self._z_sum, (row, col), z)
         np.add.at(self._z_count, (row, col), 1.0)
+
+    def _lookup_cloud_transform(self, msg: PointCloud2):
+        """Return the transform for a cloud, tolerating small future TF offsets."""
+        cloud_time = Time.from_msg(msg.header.stamp)
+        try:
+            return self.tf_buffer.lookup_transform(
+                self.target_frame,
+                msg.header.frame_id,
+                cloud_time,
+                timeout=Duration(seconds=0.0),
+            )
+        except ExtrapolationException as e:
+            if "future" not in str(e).lower():
+                self._log_tf_lookup_failure(msg, e)
+                return None
+
+            try:
+                latest_tf = self.tf_buffer.lookup_transform(
+                    self.target_frame,
+                    msg.header.frame_id,
+                    Time(),
+                    timeout=Duration(seconds=0.0),
+                )
+            except TransformException as latest_error:
+                self._log_tf_lookup_failure(msg, latest_error)
+                return None
+
+            self.get_logger().warning(
+                f"TF lookup {msg.header.frame_id} -> {self.target_frame} "
+                f"needed a future transform; using latest available transform: {e}",
+                throttle_duration_sec=5.0,
+            )
+            return latest_tf
+        except TransformException as e:
+            self._log_tf_lookup_failure(msg, e)
+            return None
+
+    def _log_tf_lookup_failure(
+        self, msg: PointCloud2, error: TransformException
+    ) -> None:
+        """Log a throttled TF lookup failure for an incoming cloud."""
+        self.get_logger().warning(
+            f"TF lookup {msg.header.frame_id} -> {self.target_frame} "
+            f"failed: {error}",
+            throttle_duration_sec=5.0,
+        )
 
     def _publish_grid(self):
         """Compute crater grid and publish OccupancyGrid."""

--- a/src/lunabot_perception/test/test_crater_detection.py
+++ b/src/lunabot_perception/test/test_crater_detection.py
@@ -1,0 +1,100 @@
+# Copyright 2026 University of Leicester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for crater detection timing behaviour."""
+
+from unittest.mock import Mock
+
+from rclpy.time import Time
+from sensor_msgs.msg import PointCloud2
+from tf2_ros import ExtrapolationException, LookupException
+
+from lunabot_perception.crater_detection import CraterDetectionNode
+
+
+def _node_with_buffer(tf_buffer: Mock) -> CraterDetectionNode:
+    node = object.__new__(CraterDetectionNode)
+    node.tf_buffer = tf_buffer
+    node.target_frame = "odom"
+    node.get_logger = Mock(return_value=Mock())
+    return node
+
+
+def _point_cloud() -> PointCloud2:
+    msg = PointCloud2()
+    msg.header.frame_id = "camera_front_rgb_camera_optical_frame"
+    msg.header.stamp.sec = 42
+    msg.header.stamp.nanosec = 123
+    return msg
+
+
+def test_lookup_cloud_transform_uses_cloud_stamp_first():
+    """Stamped TF lookup is used when the buffer has the exact transform."""
+    expected_tf = object()
+    tf_buffer = Mock()
+    tf_buffer.lookup_transform.return_value = expected_tf
+    node = _node_with_buffer(tf_buffer)
+    msg = _point_cloud()
+
+    result = node._lookup_cloud_transform(msg)
+
+    assert result is expected_tf
+    tf_buffer.lookup_transform.assert_called_once()
+    _, _, lookup_time = tf_buffer.lookup_transform.call_args.args
+    assert lookup_time.nanoseconds == Time.from_msg(msg.header.stamp).nanoseconds
+
+
+def test_lookup_cloud_transform_falls_back_to_latest_for_future_extrapolation():
+    """Small future extrapolation uses the latest available TF instead."""
+    exact_error = ExtrapolationException(
+        "Lookup would require extrapolation into the future"
+    )
+    latest_tf = object()
+    tf_buffer = Mock()
+    tf_buffer.lookup_transform.side_effect = [exact_error, latest_tf]
+    node = _node_with_buffer(tf_buffer)
+    msg = _point_cloud()
+
+    result = node._lookup_cloud_transform(msg)
+
+    assert result is latest_tf
+    assert tf_buffer.lookup_transform.call_count == 2
+    _, _, fallback_time = tf_buffer.lookup_transform.call_args.args
+    assert fallback_time.nanoseconds == Time().nanoseconds
+
+
+def test_lookup_cloud_transform_does_not_fallback_for_past_extrapolation():
+    """Past extrapolation is not silently converted into a latest-TF lookup."""
+    tf_buffer = Mock()
+    tf_buffer.lookup_transform.side_effect = ExtrapolationException(
+        "Lookup would require extrapolation into the past"
+    )
+    node = _node_with_buffer(tf_buffer)
+
+    result = node._lookup_cloud_transform(_point_cloud())
+
+    assert result is None
+    tf_buffer.lookup_transform.assert_called_once()
+
+
+def test_lookup_cloud_transform_returns_none_when_tf_missing():
+    """Missing frame data drops the update cleanly."""
+    tf_buffer = Mock()
+    tf_buffer.lookup_transform.side_effect = LookupException("frame does not exist")
+    node = _node_with_buffer(tf_buffer)
+
+    result = node._lookup_cloud_transform(_point_cloud())
+
+    assert result is None
+    tf_buffer.lookup_transform.assert_called_once()


### PR DESCRIPTION
## Summary
- Add a crater detector TF lookup helper that tries the cloud timestamp first.
- Fall back to the latest available TF only when tf2 reports future extrapolation.
- Add focused tests for exact lookup, future fallback, past extrapolation, and missing TF.

## Research
- ROS 2 tf2 docs describe buffered transforms over time and timestamped lookups: https://docs.ros.org/en/humble/Concepts/Intermediate/About-Tf2.html
- ROS 2 tf2 time docs note that lookup_transform can block for a timeout and fail when data is in the future: https://docs.ros.org/en/galactic/Tutorials/Intermediate/Tf2/Learning-About-Tf2-And-Time-Py.html

## Validation
- Local: `python3 -m compileall src/lunabot_perception/lunabot_perception/crater_detection.py src/lunabot_perception/test/test_crater_detection.py`
- Local: `uv run ruff check src/lunabot_perception/lunabot_perception/crater_detection.py src/lunabot_perception/test/test_crater_detection.py`
- Jetson: `colcon build --symlink-install --packages-select lunabot_perception`
- Jetson: `cd src/lunabot_perception && python3 -m pytest test/test_crater_detection.py` -> 4 passed
- Jetson: `colcon test --packages-select lunabot_perception --pytest-args test/test_crater_detection.py`, then checked `build/lunabot_perception/pytest.xml` -> 4 tests, 0 failures, 0 errors

Note: running package linter tests from the repo root scans stale generated `build/` and `install/` files on the Jetson, so that was not used as the acceptance signal for this PR.

Linear: INX-54


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR addresses crater detector transform (TF) lookup failures by implementing intelligent fallback behavior when cloud timestamps are slightly ahead of available transforms.

## Problem Solved
The crater detection node previously failed when attempting to look up transforms using a point cloud's timestamp that was ahead of the available TF data (future extrapolation). This is a common issue in robotics when sensor timestamps and transform data are not perfectly synchronized.

## Solution
Introduced a dedicated TF lookup helper that:
- Attempts to look up transforms using the point cloud's exact timestamp as the primary approach
- Falls back to requesting the latest available transform when TF reports a future extrapolation error
- Properly distinguishes future extrapolation from other lookup failures and handles them appropriately

## Testing
Added comprehensive unit tests covering:
- Exact timestamp lookups when transform data exists
- Future timestamp fallback behavior
- Proper failure handling for past extrapolation scenarios
- Missing transform data handling

All tests pass successfully, and validation included Python compilation checks, linting, colcon builds, and pytest execution (4 tests, 0 failures).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/307)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->