### PR TITLE
Synchronise sim CameraInfo for localisation

### DIFF
--- a/src/lunabot_bringup/launch/mission_shuttle_evidence.launch.py
+++ b/src/lunabot_bringup/launch/mission_shuttle_evidence.launch.py
@@ -73,6 +73,8 @@ def generate_launch_description():
             "launch_rviz": launch_rviz,
             "enforce_preflight": enforce_preflight,
             "disable_nav_gate": disable_nav_gate,
+            "camera_info_topic": "/camera_front/camera_info_synced",
+            "sync_sim_camera_info": "true",
         }.items(),
     )
 

--- a/src/lunabot_bringup/launch/navigation.launch.py
+++ b/src/lunabot_bringup/launch/navigation.launch.py
@@ -170,6 +170,8 @@ def generate_launch_description():
     launch_rviz = LaunchConfiguration("launch_rviz")
     use_sim_time = LaunchConfiguration("use_sim_time")
     enable_apriltag_debug = LaunchConfiguration("enable_apriltag_debug")
+    camera_info_topic = LaunchConfiguration("camera_info_topic")
+    sync_sim_camera_info = LaunchConfiguration("sync_sim_camera_info")
     enable_teleop = LaunchConfiguration("enable_teleop")
     enforce_preflight = LaunchConfiguration("enforce_preflight")
     preflight_config = LaunchConfiguration("preflight_config")
@@ -186,6 +188,8 @@ def generate_launch_description():
             "use_sim_time": use_sim_time,
             "enable_apriltag_debug": enable_apriltag_debug,
             "cmd_vel_topic": localiser_cmd_vel_topic,
+            "camera_info_topic": camera_info_topic,
+            "sync_sim_camera_info": sync_sim_camera_info,
         }.items(),
     )
 
@@ -377,6 +381,21 @@ def generate_launch_description():
                 description=(
                     "Launch the apriltag_draw overlay for annotated front "
                     "camera debugging."
+                ),
+            ),
+            DeclareLaunchArgument(
+                "camera_info_topic",
+                default_value="/camera_front/camera_info",
+                description=(
+                    "Front RGB CameraInfo topic used by localisation consumers."
+                ),
+            ),
+            DeclareLaunchArgument(
+                "sync_sim_camera_info",
+                default_value="false",
+                description=(
+                    "Enable the sim-only CameraInfo stamp aligner before "
+                    "localisation consumers."
                 ),
             ),
             DeclareLaunchArgument(

--- a/src/lunabot_localisation/launch/localisation.launch.py
+++ b/src/lunabot_localisation/launch/localisation.launch.py
@@ -83,6 +83,7 @@ def _validate_boolean_launch_arguments(context):
         "lidar_costmap_phase",
         "use_sim_time",
         "enable_apriltag_debug",
+        "sync_sim_camera_info",
     ):
         _normalise_bool_text(
             LaunchConfiguration(argument_name).perform(context),
@@ -113,6 +114,8 @@ def generate_launch_description():
     use_sim_time = LaunchConfiguration("use_sim_time")
     enable_apriltag_debug = LaunchConfiguration("enable_apriltag_debug")
     cmd_vel_topic = LaunchConfiguration("cmd_vel_topic")
+    camera_info_topic = LaunchConfiguration("camera_info_topic")
+    sync_sim_camera_info = LaunchConfiguration("sync_sim_camera_info")
     tag_map_x = LaunchConfiguration("tag_map_x")
     tag_map_y = LaunchConfiguration("tag_map_y")
     tag_map_z = LaunchConfiguration("tag_map_z")
@@ -132,7 +135,7 @@ def generate_launch_description():
     camera_remappings = [
         ("rgb/image", "/camera_front/image"),
         ("depth/image", "/camera_front/depth_image"),
-        ("rgb/camera_info", "/camera_front/camera_info"),
+        ("rgb/camera_info", camera_info_topic),
     ]
 
     return LaunchDescription(
@@ -162,6 +165,21 @@ def generate_launch_description():
                 default_value="cmd_vel",
                 description=(
                     "Velocity command topic used by the start-zone localiser."
+                ),
+            ),
+            DeclareLaunchArgument(
+                "camera_info_topic",
+                default_value="/camera_front/camera_info",
+                description=(
+                    "Front RGB CameraInfo topic used by AprilTag and RTAB-Map."
+                ),
+            ),
+            DeclareLaunchArgument(
+                "sync_sim_camera_info",
+                default_value="false",
+                description=(
+                    "Republish sim CameraInfo with image timestamps before "
+                    "feeding image-sync consumers."
                 ),
             ),
             DeclareLaunchArgument(
@@ -254,10 +272,33 @@ def generate_launch_description():
                 ],
                 remappings=[
                     ("image_rect", "/camera_front/image"),
-                    ("camera_info", "/camera_front/camera_info"),
+                    ("camera_info", camera_info_topic),
                     ("detections", "/camera_front/tags"),
                 ],
                 condition=normal_mode,
+            ),
+            Node(
+                package="lunabot_localisation",
+                executable="camera_info_stamp_aligner",
+                name="camera_info_stamp_aligner",
+                output="screen",
+                parameters=[
+                    {"use_sim_time": use_sim_time},
+                    {
+                        "image_topic": "/camera_front/image",
+                        "camera_info_topic": "/camera_front/camera_info",
+                        "aligned_camera_info_topic": "/camera_front/camera_info_synced",
+                    },
+                ],
+                condition=IfCondition(
+                    PythonExpression(
+                        [
+                            _is_falsey(lidar_costmap_phase),
+                            " and ",
+                            _is_truthy(sync_sim_camera_info),
+                        ]
+                    )
+                ),
             ),
             # --- AprilTag debug overlay (optional) ---
             IncludeLaunchDescription(

--- a/src/lunabot_localisation/lunabot_localisation/camera_info_stamp_aligner.py
+++ b/src/lunabot_localisation/lunabot_localisation/camera_info_stamp_aligner.py
@@ -1,0 +1,90 @@
+# Copyright 2026 University of Leicester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Republish CameraInfo with image timestamps for simulation-only consumers."""
+
+from copy import deepcopy
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import CameraInfo, Image
+
+
+class CameraInfoStampAligner(Node):
+    """Align simulated CameraInfo stamps to the latest front-camera image."""
+
+    def __init__(self):
+        """Create subscriptions and the aligned CameraInfo publisher."""
+        super().__init__("camera_info_stamp_aligner")
+
+        self.declare_parameter("image_topic", "/camera_front/image")
+        self.declare_parameter("camera_info_topic", "/camera_front/camera_info")
+        self.declare_parameter(
+            "aligned_camera_info_topic",
+            "/camera_front/camera_info_synced",
+        )
+
+        image_topic = self.get_parameter("image_topic").value
+        camera_info_topic = self.get_parameter("camera_info_topic").value
+        aligned_camera_info_topic = self.get_parameter(
+            "aligned_camera_info_topic"
+        ).value
+
+        self.latest_camera_info: CameraInfo | None = None
+        self.aligned_pub = self.create_publisher(
+            CameraInfo,
+            aligned_camera_info_topic,
+            10,
+        )
+        self.create_subscription(
+            CameraInfo,
+            camera_info_topic,
+            self._camera_info_callback,
+            qos_profile_sensor_data,
+        )
+        self.create_subscription(
+            Image,
+            image_topic,
+            self._image_callback,
+            qos_profile_sensor_data,
+        )
+
+        self.get_logger().info(
+            f"Aligning {camera_info_topic} stamps to {image_topic} on "
+            f"{aligned_camera_info_topic}"
+        )
+
+    def _camera_info_callback(self, msg: CameraInfo) -> None:
+        """Store the most recent camera calibration message."""
+        self.latest_camera_info = msg
+
+    def _image_callback(self, msg: Image) -> None:
+        """Publish camera info with the current image timestamp."""
+        if self.latest_camera_info is None:
+            return
+
+        aligned_info = deepcopy(self.latest_camera_info)
+        aligned_info.header.stamp = msg.header.stamp
+        aligned_info.header.frame_id = msg.header.frame_id
+        self.aligned_pub.publish(aligned_info)
+
+
+def main(args=None) -> None:
+    """Run the camera-info stamp aligner."""
+    rclpy.init(args=args)
+    node = CameraInfoStampAligner()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()

--- a/src/lunabot_localisation/setup.py
+++ b/src/lunabot_localisation/setup.py
@@ -39,6 +39,8 @@ setup(
     extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
+            "camera_info_stamp_aligner = "
+            "lunabot_localisation.camera_info_stamp_aligner:main",
             "start_zone_localiser = lunabot_localisation.start_zone_localiser:main",
             "tag_pose_publisher = lunabot_localisation.tag_pose_publisher:main",
         ],

--- a/src/lunabot_localisation/test/test_camera_info_stamp_aligner.py
+++ b/src/lunabot_localisation/test/test_camera_info_stamp_aligner.py
@@ -1,0 +1,64 @@
+# Copyright 2026 University of Leicester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the simulation CameraInfo stamp aligner."""
+
+from unittest.mock import Mock
+
+from sensor_msgs.msg import CameraInfo, Image
+
+from lunabot_localisation.camera_info_stamp_aligner import CameraInfoStampAligner
+
+
+def _aligner_with_publisher() -> tuple[CameraInfoStampAligner, Mock]:
+    node = object.__new__(CameraInfoStampAligner)
+    publisher = Mock()
+    node.aligned_pub = publisher
+    node.latest_camera_info = None
+    return node, publisher
+
+
+def test_image_callback_waits_for_camera_info():
+    """Image messages are ignored until calibration data is available."""
+    node, publisher = _aligner_with_publisher()
+
+    node._image_callback(Image())
+
+    publisher.publish.assert_not_called()
+
+
+def test_image_callback_republishes_camera_info_with_image_header():
+    """The aligned CameraInfo uses the image stamp and frame."""
+    node, publisher = _aligner_with_publisher()
+    camera_info = CameraInfo()
+    camera_info.header.stamp.sec = 1
+    camera_info.header.frame_id = "old_frame"
+    camera_info.width = 1280
+    camera_info.height = 720
+    image = Image()
+    image.header.stamp.sec = 42
+    image.header.stamp.nanosec = 123
+    image.header.frame_id = "camera_front_rgb_camera_optical_frame"
+
+    node._camera_info_callback(camera_info)
+    node._image_callback(image)
+
+    publisher.publish.assert_called_once()
+    published = publisher.publish.call_args.args[0]
+    assert published.header.stamp == image.header.stamp
+    assert published.header.frame_id == image.header.frame_id
+    assert published.width == 1280
+    assert published.height == 720
+    assert camera_info.header.stamp.sec == 1
+    assert camera_info.header.frame_id == "old_frame"

--- a/src/lunabot_localisation/test/test_localisation_launch.py
+++ b/src/lunabot_localisation/test/test_localisation_launch.py
@@ -103,12 +103,13 @@ def test_validate_boolean_launch_arguments_rejects_invalid_launch_value():
     context.launch_configurations["lidar_costmap_phase"] = "treu"
     context.launch_configurations["use_sim_time"] = "true"
     context.launch_configurations["enable_apriltag_debug"] = "false"
+    context.launch_configurations["sync_sim_camera_info"] = "false"
 
     with pytest.raises(ValueError, match="lidar_costmap_phase"):
         launch_module._validate_boolean_launch_arguments(context)
 
 
-def test_generate_launch_description_has_validation_and_one_tag_pose_node(
+def test_generate_launch_description_has_validation_and_sim_camera_info_aligner(
     monkeypatch: pytest.MonkeyPatch,
 ):
     launch_module = _load_launch_module()
@@ -128,9 +129,16 @@ def test_generate_launch_description_has_validation_and_one_tag_pose_node(
         if isinstance(entity, Node)
         and entity.__dict__.get("_Node__node_name") == "tag_pose_publisher"
     ]
+    camera_info_aligners = [
+        entity
+        for entity in description.entities
+        if isinstance(entity, Node)
+        and entity.__dict__.get("_Node__node_name") == "camera_info_stamp_aligner"
+    ]
 
     assert len(validators) == 1
     assert len(tag_pose_publishers) == 1
+    assert len(camera_info_aligners) == 1
 
 
 def test_no_global_ekf_in_launch_description(


### PR DESCRIPTION
## Summary
- Add a small `camera_info_stamp_aligner` node for simulation-only camera-info stamp alignment.
- Let localisation consumers use a configurable front CameraInfo topic.
- Wire mission evidence simulation runs to use `/camera_front/camera_info_synced` without changing the default hardware path.

## Research
- `message_filters`/image consumers synchronise image and camera-info messages by header timestamps: https://docs.ros.org/en/humble/p/message_filters/generated/classmessage__filters_1_1TimeSynchronizer.html
- Related AprilTag ROS users hit the same image/camera-info synchronisation class of issue: https://github.com/christianrauch/apriltag_ros/issues/33

## Validation
- Local: `python3 -m compileall` on the modified launch/tests/node files.
- Local: `uv --cache-dir /private/tmp/uv-cache run ruff check ...` passed.
- Local pytest could not run because this Mac does not have ROS Python packages (`sensor_msgs`, `launch`) installed.
- Jetson: `colcon build --symlink-install --packages-select lunabot_localisation lunabot_bringup` passed.
- Jetson: `cd src/lunabot_localisation && python3 -m pytest test/test_camera_info_stamp_aligner.py test/test_localisation_launch.py` -> 30 passed.
- Jetson: `python3 -m pytest src/lunabot_bringup/test/test_mission_shuttle_evidence_launch.py` -> 1 passed.
- Jetson live sim smoke: `mission_shuttle_evidence.launch.py max_shuttle_cycles:=0` starts `camera_info_stamp_aligner`; RTAB-Map subscribes to `/camera_front/camera_info_synced`; AprilTag process is remapped with `camera_info:=/camera_front/camera_info_synced`.
- Jetson ROS integration check: synthetic Image + CameraInfo through the installed aligner produced aligned CameraInfo `42.000000123`, frame `camera_front_rgb_camera_optical_frame`, size `1280x720`.

Notes:
- The live sim still shows the pre-existing crater TF warnings because this branch is based on `main` and does not include PR #307.
- AprilTag's image_transport warning text prints the base camera topic name even with remapping; process args confirm the detector is consuming the synced topic.

Linear: INX-55
