### PR TITLE
docs: align rulebook readiness guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ If you rename a topic, action, or TF link, update the contract JSON in the same 
 - Architecture: https://github.com/KJdotIO/innex1-rover/wiki/SoftwareArchitecture
 - Operations: https://github.com/KJdotIO/innex1-rover/wiki/Operations
 - Contracts: https://github.com/KJdotIO/innex1-rover/wiki/Contracts
+- Local inspection packet: [docs/competition_inspection_packet.md](docs/competition_inspection_packet.md)
 
 ## Contributing and licence
 

--- a/docs/active_runtime_paths.md
+++ b/docs/active_runtime_paths.md
@@ -1,8 +1,8 @@
 # Active Runtime Paths
 
-This page lists the launch paths that are current enough to use for hardware
-week work. If a launch file is not listed here, treat it as package-local
-debugging or implementation detail until it is added deliberately.
+The launch paths below are current enough for hardware-week work. If a launch
+file is not listed here, treat it as package-local debugging or implementation
+detail until it is added deliberately.
 
 The map follows the current repo shape rather than an ideal ROS 2 layout. The
 aim is to make the active paths obvious before adding more hardware-facing code.
@@ -85,9 +85,9 @@ The command path is:
   -> drivetrain_bridge
 ```
 
-The velocity gate should stay in this path for hardware work. Do not command
-the drivetrain directly unless you are running a controlled bench test and have
-a stop plan.
+Keep the velocity gate in this path for hardware work. Do not command the
+drivetrain directly unless you are running a controlled bench test and have a
+stop plan.
 
 ## Excavation And Deposition Bring-Up
 

--- a/docs/competition_inspection_packet.md
+++ b/docs/competition_inspection_packet.md
@@ -1,0 +1,136 @@
+# Competition Inspection Packet
+
+The printable inspection and day-of compliance checklist travels with the
+software. The wiki gives the broader reasoning.
+
+The UK Lunabotics rulebook is the authority for the final numbers. Where older
+NASA/UCF material differs, use the UK figure for this rover.
+
+## Packet Contents
+
+Bring these in printed or offline form:
+
+- current UK Lunabotics rulebook;
+- assigned SSID, router settings and radio settings;
+- manufacturer datasheets for any Bluetooth or non-Wi-Fi radio part;
+- power logger make, model, serial number, wiring position and readout steps;
+- battery type, charger, storage and handling notes;
+- robot mass, stowed dimensions, deployed dimensions and lifting point photos;
+- autonomy sensor explanation and banned-sensor declaration;
+- this repo's runtime profile output for `hardware_competition`;
+- the Mission Control Foxglove layout and topic allowlist.
+
+## E-stop And Motion Inhibit
+
+The physical E-stop must latch. Releasing it must not resume rover motion.
+
+Software mirrors that behaviour:
+
+- `/safety/estop` reports the physical E-stop state.
+- `/safety/motion_inhibit` latches the software inhibit.
+- `/safety/reset_motion_inhibit` is the explicit reset path after E-stop is
+  clear.
+
+Inspection demo:
+
+1. Command a low-speed movement.
+2. Press E-stop and show motion stops.
+3. Release E-stop and show motion does not resume.
+4. Confirm `/safety/estop` is false.
+5. Publish `/safety/reset_motion_inhibit`.
+6. Confirm `/safety/motion_inhibit` is false before any further motion.
+
+## Power Logger And Batteries
+
+The COTS power logger is an inspection item. `/power/telemetry` is the ROS view
+of the same power story, not a replacement for a physical logger.
+
+Document the logger wiring once electrical integration is final. The logger
+needs to be visible or quickly readable by a judge, and its record needs to
+survive E-stop.
+
+Battery handling checklist:
+
+- charge only while attended;
+- unplug chargers overnight;
+- store packs upright and separated;
+- inspect dropped, hot, swollen or damaged packs;
+- keep compute power and motive power assumptions written down;
+- know where fire-safe storage is and who calls for help.
+
+## Communications
+
+The competition link is planned as 2.4 GHz Wi-Fi. Use 5 GHz only as an approved
+fallback, not as the normal competition path.
+
+Check before comm inspection:
+
+- assigned SSID is visible;
+- encryption is enabled;
+- hidden network mode is off;
+- 2.4 GHz channel width is `20 MHz`;
+- the required comm-check channel is selected when instructed;
+- average data use stays at or below `4,000 Kbps`;
+- phone hotspots, tethering and spare backchannels are off;
+- Bluetooth or non-Wi-Fi radios have printed manufacturer evidence.
+
+Run the software profile check:
+
+```bash
+ros2 run lunabot_bringup runtime_profile check
+ros2 run lunabot_bringup runtime_profile show --profile hardware_competition
+```
+
+## Autonomy Legality
+
+Explain autonomy in one plain paragraph:
+
+The rover uses onboard sensors and onboard software. It does not use arena
+walls for mapping, localisation, autonomous navigation, collision avoidance or
+autonomy sensing. It does not use GPS, compass heading, ultrasonic proximity
+sensing, touch sensors for obstacle avoidance, or uploaded obstacle locations.
+
+Allowed and intended autonomy inputs:
+
+- wheel odometry;
+- IMU data with no magnetic-heading dependency;
+- AprilTag detection in the start zone;
+- front and rear camera data for tag detection, operator view and close-range
+  hazard evidence;
+- OS1-128 LiDAR once mounted, after wall-region filtering;
+- live costmaps generated from legal onboard sensor data.
+
+Show these topics or views if asked:
+
+- `/localisation/start_zone_status`;
+- AprilTag detections or tag pose output;
+- `/odometry/local`;
+- filtered point-cloud or obstacle evidence;
+- `/mission/autonomy_mode`;
+- `/safety/motion_inhibit`;
+- evidence pack manifest from `mission_evidence`.
+
+## Mission Control Conduct
+
+Mission Control is for mission-critical equipment only. Keep phones, tablets,
+extra laptops, smart watches and personal radios out of the MCC.
+
+Autonomy callouts:
+
+1. Tell the Mission Control Judge which autonomy attempt is starting.
+2. Start the attempt.
+3. Keep hands off controls and laptops during the attempt.
+4. Announce completion or failure before touching controls again.
+
+At the end of the run, stop or inhibit further rover action first. Keep comms
+and evidence intact until the judge releases the team.
+
+## Related Docs
+
+- `docs/hardware_week_runbook.md`
+- `docs/jetson_runtime_profiles.md`
+- `docs/mission_evidence_workflow.md`
+- `docs/foxglove/README.md`
+- `src/lunabot_safety/README.md`
+- `src/lunabot_localisation/README.md`
+- `src/lunabot_bringup/config/runtime_profiles.yaml`

--- a/docs/foxglove/README.md
+++ b/docs/foxglove/README.md
@@ -43,7 +43,7 @@ ros2 launch lunabot_bringup foxglove_ground_control.launch.py \
 
 ## Foxglove or RViz
 
-Use Foxglove for operating the rover. It should answer the basic questions:
+Use Foxglove for operating the rover. The operator view answers the basic questions:
 
 - What state is the mission in?
 - Is motion inhibited or E-stop active?

--- a/docs/hardware_week_runbook.md
+++ b/docs/hardware_week_runbook.md
@@ -14,6 +14,9 @@ The rulebook constraints that shape this are simple:
 - average comms use must stay at or below 4,000 Kbps;
 - only mission-critical electronics come into Mission Control.
 
+For inspection and competition-day paperwork, keep
+`docs/competition_inspection_packet.md` with the rover.
+
 ## Before You Leave The Pit
 
 Run these checks before the rover is in the arena.
@@ -108,6 +111,25 @@ sar -n DEV 1 10
 If `sar` is not installed, use the router dashboard, `ifstat`, or `nload`. The
 limit applies to the robot comms link, not to an individual ROS topic.
 
+## Comms And MCC Compliance
+
+Before entering comm check or Mission Control, confirm:
+
+- the rover is using the assigned visible SSID;
+- encryption is enabled;
+- hidden network mode is off;
+- 2.4 GHz channel width is `20 MHz`;
+- the router is on the organiser's required channel when instructed;
+- 5 GHz is disabled unless an approved fallback is being tested;
+- phone hotspots, tethering and spare backchannels are off;
+- Bluetooth or non-Wi-Fi radio parts have printed manufacturer evidence;
+- only mission-critical electronics are going into the MCC.
+
+Do not take phones, tablets, spare laptops, smart watches or personal radios
+into Mission Control. During the run, do not use external communications. The
+only exception is the organiser-provided setup radio path when the rules allow
+it.
+
 ## First Motion
 
 Do not start with full autonomy. Start with something you can stop.
@@ -164,6 +186,10 @@ Use `lipo_4s` if the rover is on a 4S pack. The default voltage is unavailable,
 so diagnostics will say power telemetry is missing until someone enters a real
 value.
 
+The physical COTS power logger is still required for inspection. Treat
+`/power/telemetry` as the operator and evidence view of that power story, not as
+a substitute for the logger itself.
+
 ## Before Autonomy
 
 The minimum useful checks are:
@@ -196,6 +222,9 @@ For autonomy scoring, use explicit callouts:
 
 Do this every time. The judge needs to know when autonomy starts, when it ends,
 and whether manual control has resumed.
+
+Do not enter obstacle locations into the rover after seeing the arena. Evidence
+bags are for review and proof, not for creating a later autonomy route.
 
 ## Evidence Bags
 
@@ -282,6 +311,10 @@ When the run ends, stop the rover first:
 ```bash
 ros2 topic pub --once /cmd_vel_safe geometry_msgs/msg/Twist "{linear: {x: 0.0}, angular: {z: 0.0}}"
 ```
+
+If an autonomy attempt is still active, inhibit further action immediately. The
+repo should grow a dedicated end-of-run inhibit command, but the operating rule
+is already fixed: stop first, preserve comms and evidence, then wait.
 
 Do not disconnect the robot or pack Mission Control until the judge says so.
 The rulebook allows the robot to need relocation or unloading after the timer.

--- a/docs/jetson_runtime_profiles.md
+++ b/docs/jetson_runtime_profiles.md
@@ -2,8 +2,9 @@
 
 The competition communications rule that matters most for software is simple:
 average data utilisation must stay at or below **4,000 Kbps**. There is no peak
-limit. We still keep the average low because the operator link needs to stay
-stable.
+limit. Older NASA/UCF public material has used **5,000 Kbps**, but the UK
+rulebook is stricter, so this repo uses **4,000 Kbps**. We still keep the
+average low because the operator link needs to stay stable.
 
 The default competition posture is:
 
@@ -14,6 +15,11 @@ The default competition posture is:
   default;
 - record evidence locally with the minimal rosbag profile unless debugging
   requires more.
+
+This profile is also part of the comm-check story: Mission Control should show
+only robot-originating telemetry/video and the official competition monitors.
+Raw debug streams are useful in the lab, but they are not the scored-run
+operator view.
 
 The machine-readable source of truth is:
 
@@ -54,6 +60,10 @@ Do not expose raw camera images, depth images, point clouds, debug costmap
 panels or the heavy rosbag profile during a scored run. If a raw stream is
 needed for diagnosis, use `hardware_bringup` or `sim_debug`, say why, and turn
 it back off before the run.
+
+Do not add phone hotspots, tethering, spare laptops or browser-based
+backchannels to work around this allowlist. If the operator cannot see enough
+through the competition profile, fix the profile deliberately before the run.
 
 Start Foxglove through the project launch file so the allowlist and camera
 compression stay consistent:
@@ -117,7 +127,7 @@ ros2 launch lunabot_bringup navigation.launch.py \
   enable_apriltag_debug:=false
 ```
 
-Evidence capture should stay lean:
+Keep evidence capture lean:
 
 ```bash
 ros2 run lunabot_bringup mission_evidence \

--- a/docs/mission_evidence_workflow.md
+++ b/docs/mission_evidence_workflow.md
@@ -1,10 +1,15 @@
 # Mission evidence workflow
 
-Use this workflow to record runs that should be reviewed later.
+Mission evidence records runs that need later review.
 
 Do not keep every run as evidence. If the stack was half-launched, the rover was
 already in an unusual pose, or parameters were changing mid-run, keep the bag
 only when it explains a specific fault.
+
+Evidence bags are not autonomy inputs. Do not use a bag, replay, screenshot or
+operator observation to upload judged obstacle locations into a later autonomy
+attempt. A bag can prove what the rover saw and did; it must not become a route
+planning shortcut after the field has been seen.
 
 ## Golden shuttle bag
 
@@ -39,7 +44,7 @@ ros2 run lunabot_bringup mission_evidence \
     max_shuttle_cycles:=1
 ```
 
-The pack lands under `~/innex1_mission_evidence/`. It should contain:
+A complete pack lands under `~/innex1_mission_evidence/` and contains:
 
 - `bag/`
 - `logs/mission_command.log`
@@ -93,3 +98,18 @@ scan, map, costmaps, and action status.
 
 Use `heavy` only for short perception investigations. It records raw image and
 point-cloud topics and can use disk space quickly.
+
+## Sensor Claims
+
+Each competition evidence pack should be understandable without a long verbal
+explanation. The manifest should make these claims clear, either directly or in
+the run note:
+
+- autonomy used onboard sensor data and onboard software;
+- arena walls were not used for mapping, localisation, autonomous navigation or
+  collision avoidance;
+- no GPS, compass heading, ultrasonic proximity sensing or touch sensing for
+  obstacle avoidance was used;
+- no obstacle-location upload was made after seeing the arena;
+- Mission Control telemetry was passive and did not create an extra command
+  path during hands-free autonomy.

--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -1,6 +1,6 @@
 # lunabot_bringup
 
-This package contains launch entrypoints that start integrated stack configurations.
+`lunabot_bringup` provides the launch entrypoints for integrated stack configurations.
 
 ## What this package is responsible for
 
@@ -77,6 +77,9 @@ The mission manager publishes a small Foxglove-friendly state contract:
 
 These topics are passive telemetry only. They are safe to show in Foxglove
 during autonomy because they do not provide a command path back into the rover.
+They also keep Mission Control inside the rulebook posture: robot-originating
+state only, no backchannel instructions, and no obstacle-location upload path
+during hands-free autonomy.
 
 ## Mission Dry Run
 
@@ -230,12 +233,16 @@ visible meter:
 ros2 run lunabot_bringup manual_power_telemetry --ros-args -p profile:=lipo_6s -p bus_voltage_v:=22.2
 ```
 
+The physical COTS power logger remains the inspection artefact. `/power/telemetry`
+is the operator and evidence topic that should mirror the logger or bridge once
+electrical integration is final.
+
 ## Common failure modes
 
 - Launch starts successfully but one critical node crashes shortly after (dependency mismatch).
 - Lifecycle nodes stay unconfigured due to invalid params in one server config.
 - Nodes appear alive but key topic links fail due to QoS incompatibility.
 
-## Where to read next
+## Related docs
 
 - Wiki: [Operations](https://github.com/KJdotIO/innex1-rover/wiki/Operations), [SoftwareArchitecture](https://github.com/KJdotIO/innex1-rover/wiki/SoftwareArchitecture), [Autonomy-cycle-walkthrough](https://github.com/KJdotIO/innex1-rover/wiki/Autonomy-cycle-walkthrough), [Contracts](https://github.com/KJdotIO/innex1-rover/wiki/Contracts)

--- a/src/lunabot_excavation/README.md
+++ b/src/lunabot_excavation/README.md
@@ -1,6 +1,6 @@
 # Excavation Bench Tooling
 
-This package includes a small bench-facing path for the excavation subsystem.
+`lunabot_excavation` provides the bench-facing path for the excavation subsystem.
 
 The important bit is that the bench path still goes through the excavation controller. It does
 not bypass the controller and poke raw hardware commands directly.

--- a/src/lunabot_interfaces/README.md
+++ b/src/lunabot_interfaces/README.md
@@ -1,6 +1,6 @@
 # Material Handling Interface Notes
 
-This package contains mechanism-agnostic action contracts for excavation and deposition.
+Mechanism-agnostic action contracts define how mission code requests excavation and deposition.
 
 ## Actions
 
@@ -212,10 +212,12 @@ Added under issue [#277](https://github.com/KJdotIO/innex1-rover/issues/277).
 
 - `/power/telemetry` uses `lunabot_interfaces/msg/PowerTelemetry`
 
-This topic is the rover software view of the main battery bus. During early
-hardware runs it may come from `manual_power_telemetry`, with values entered by
-the operator from the visible power meter. Once the electrical path is settled,
-replace that source with the chosen sensor or logger bridge without changing
+This topic is the rover software view of the main battery bus. The physical
+COTS power logger remains the inspection record; `/power/telemetry` is the ROS
+view used by operators, diagnostics and evidence bags. During early hardware
+runs it may come from `manual_power_telemetry`, with values entered by the
+operator from the visible power meter. Once the electrical path is settled,
+replace that source with the chosen logger or sensor bridge without changing
 the topic contract.
 
 ### PowerTelemetry
@@ -224,8 +226,8 @@ Fields:
 
 - `profile` — battery profile used for thresholds, currently `lipo_4s` or
   `lipo_6s`.
-- `source` — `manual`, `meter_bridge`, `sensor_bridge`, or another short source
-  name.
+- `source` — `manual`, `cots_logger_bridge`, `meter_bridge`, `sensor_bridge`,
+  or another short source name.
 - `bus_voltage_v`, `bus_current_a`, `energy_wh` — measured or manually entered
   bus values.
 - `warning_voltage_v`, `critical_voltage_v` — thresholds used to classify the

--- a/src/lunabot_localisation/README.md
+++ b/src/lunabot_localisation/README.md
@@ -16,6 +16,16 @@ The global EKF has been removed. RTAB-Map handles drift correction directly
 through its pose graph optimiser, which is the same pattern used by multiple
 Lunabotics teams (College of DuPage, Chicago Robotics/EDT).
 
+## Competition legality
+
+The localisation path must be explainable to inspection judges. It uses wheel
+odometry, IMU data, front RGB-D data, AprilTags and TF. Future LiDAR-inertial
+work may use the OS1-128 after wall-region filtering is in place.
+
+It must not use GPS, compass heading, ultrasonic proximity sensing, touch
+sensors for obstacle avoidance, arena walls as localisation features, or
+uploaded obstacle locations.
+
 ## Start-zone localisation
 
 The `start_zone_localiser` node spins in the start zone to acquire a stable
@@ -37,9 +47,10 @@ landmarks, aligning the map frame with the known tag position.
 - Covariances set unrealistically low, making the filter overconfident.
 - RTAB-Map not receiving depth images (check topic names and QoS).
 - Missing `map -> tag36h11:0` static TF preventing landmark alignment.
+- Wall points or simulation boundary geometry reaching a localisation backend
+  that will later be claimed as competition-legal.
 
-## Where to read next
+## Related docs
 
 - Wiki: [Localisation](https://github.com/KJdotIO/innex1-rover/wiki/Localisation), [Design-decisions](https://github.com/KJdotIO/innex1-rover/wiki/Design-decisions)
 - External: [RTAB-Map ROS2](https://github.com/introlab/rtabmap_ros), [robot_localization](https://index.ros.org/p/robot_localization/), [REP-105](https://www.ros.org/reps/rep-0105.html)
-

--- a/src/lunabot_navigation/README.md
+++ b/src/lunabot_navigation/README.md
@@ -1,7 +1,7 @@
 # lunabot_navigation
 
-This package contains Nav2 configuration and behaviour tree assets used by the
-rover navigation stack.
+`lunabot_navigation` holds the Nav2 configuration and behaviour tree assets used
+by the rover navigation stack.
 
 ## What this package is responsible for
 
@@ -36,6 +36,6 @@ sends goals into this package through the standard navigation action path.
 - TF mismatch between localisation outputs and Nav2 frame config.
 - Controller/planner parameters tuned for a different environment.
 
-## Where to read next
+## Related docs
 
 - Wiki: [SoftwareArchitecture](https://github.com/KJdotIO/innex1-rover/wiki/SoftwareArchitecture), [Planning](https://github.com/KJdotIO/innex1-rover/wiki/Planning), [StateManagement](https://github.com/KJdotIO/innex1-rover/wiki/StateManagement), [Design-decisions](https://github.com/KJdotIO/innex1-rover/wiki/Design-decisions), [Contracts](https://github.com/KJdotIO/innex1-rover/wiki/Contracts)

--- a/src/lunabot_perception/README.md
+++ b/src/lunabot_perception/README.md
@@ -58,7 +58,7 @@ stack (obstacle layer + crater layer + inflation layer).
   "Can't update static costmap layer, no map received" and craters will not
   appear in the costmap.
 
-## Where to read next
+## Related docs
 
 - Wiki: [Perception](https://github.com/KJdotIO/innex1-rover/wiki/Perception), [Sensors](https://github.com/KJdotIO/innex1-rover/wiki/Sensors), [SoftwareArchitecture](https://github.com/KJdotIO/innex1-rover/wiki/SoftwareArchitecture), [Contracts](https://github.com/KJdotIO/innex1-rover/wiki/Contracts)
 - [Nav2 Costmap2D configuration](https://docs.nav2.org/configuration/packages/configuring-costmaps.html)

--- a/src/lunabot_safety/README.md
+++ b/src/lunabot_safety/README.md
@@ -4,8 +4,8 @@ Safety package for the E-stop to motion-inhibit bridge on the INNEX-1 rover.
 
 ## Current state
 
-This package contains a single node. The bulk of the rover's safety behaviour
-is currently distributed across other packages:
+One node lives here. The rest of the rover's safety behaviour is currently
+distributed across other packages:
 
 | Safety function | Where it lives |
 |-----------------|----------------|

--- a/src/lunabot_simulation/README.md
+++ b/src/lunabot_simulation/README.md
@@ -13,6 +13,10 @@ UK Lunabotics arena (7.9 m x 4.4 m).
 Both worlds include arena boundary walls and an AprilTag beacon for
 start-zone localisation.
 
+The boundary walls are simulation geometry only. Do not treat them as legal
+localisation, mapping, autonomous navigation or collision-avoidance cues for
+competition autonomy.
+
 ## Launch
 
 ```bash


### PR DESCRIPTION
## Summary
- add a competition inspection packet for rulebook-facing readiness
- align runbook/runtime/evidence docs with UK Lunabotics comms, MCC, safety and autonomy constraints
- remove meta-documentation phrasing from touched docs so they read as direct rover guidance

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR establishes and reinforces competition rulebook readiness across rover documentation by introducing a formal inspection packet and aligning operational, runtime, and autonomy guidance with UK Lunabotics communications, Mission Control Center (MCC), safety, and autonomy constraints. Meta-documentation phrasing has been replaced with direct rover operational guidance.

## Key Changes

### New Documentation
- **Competition Inspection Packet** (`docs/competition_inspection_packet.md`): A new comprehensive checklist covering rulebook and hardware/software artifacts, E-stop and motion inhibit inspection steps, power logger and battery handling, communications requirements, autonomy legality explanations, and Mission Control conduct guidance.

### Autonomy & Evidence Clarifications
- **Mission Evidence Workflow** and **Hardware Week Runbook**: Added explicit constraints that evidence bags are not autonomy inputs and must not be used to upload obstacle locations into later autonomy attempts. Strengthened guidance against building autonomy routes based on arena observation.
- **Mission Evidence Workflow**: New "Sensor Claims" section specifying what must be documented (e.g., onboard sensor data only, no GPS/compass/proximity usage for obstacle avoidance, no post-observation arena uploads).

### Communications & MCC Compliance
- **Hardware Week Runbook**: New "Comms And MCC Compliance" section defining pre-MCC Wi-Fi/comms checks (SSID, encryption, channel widths) and restrictions on devices entering Mission Control.
- **Jetson Runtime Profiles**: Clarified 4,000 Kbps average utilization rule and alignment with competition profile (robot-originating telemetry/video only). Strengthened guidance against operator workarounds like phone hotspots or browser-based backchannels.

### Power Telemetry & Physical Hardware
- **Bringup and Interface Documentation**: Clarified that physical COTS power logger remains the inspection artifact and that `/power/telemetry` is the operator/evidence ROS topic, not a substitute.
- **Interface Contracts**: Updated power telemetry contract field documentation to align with physical logger sourcing.

### Autonomy Legality & Constraints
- **Localisation Package**: Added "Competition legality" section specifying allowed inputs (wheel odometry, IMU, RGB-D, AprilTags, TF) and disallowed usage (GPS, compass, ultrasonic proximity, arena wall geometry for mapping/localization/collision avoidance).
- **Simulation Package**: Clarified that arena boundary walls are simulation-only geometry and must not inform localization, mapping, or autonomous navigation.

### Operational Adjustments
- **Hardware Week Runbook**: Emphasized immediate motion inhibition if autonomy attempt is still active at end-of-run (stop first, preserve comms and evidence, then wait).
- **Runtime Paths**: Reworded drivetrain bring-up guidance around velocity gating while preserving safety intent.
- **Package Documentation**: Removed meta-documentation language and standardized section headers for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->