### PR TITLE
Add Ouster LiDAR Foxglove debug launch

### DIFF
--- a/docs/foxglove/README.md
+++ b/docs/foxglove/README.md
@@ -56,6 +56,37 @@ debugging. If you need TF, robot model, costmap layers, point clouds, local
 planner behaviour, or camera geometry, keep that out of the scored-run operator
 layout.
 
+## Ouster LiDAR Debug
+
+Use `ouster_lidar_debug.layout.json` for a live Ouster-only debug view. This is
+for bring-up and mapping checks, not for the scored-run operator layout.
+
+Connect the Ouster to the Jetson Ethernet port, then check the Jetson Ethernet
+address:
+
+```bash
+ip -br addr show
+```
+
+If the Ethernet address is not `169.254.86.134`, edit `udp_dest` in
+`src/lunabot_bringup/config/ouster_lidar_debug.yaml` or pass a copied parameter
+file with the correct address. Then start the debug stack:
+
+```bash
+ros2 launch lunabot_bringup ouster_lidar_foxglove_debug.launch.py
+```
+
+Open Foxglove on the ground-control laptop and connect to:
+
+```text
+ws://<jetson-tailscale-or-router-ip>:8765
+```
+
+The debug launch exposes `/ouster/points`, `/ouster/imu`, `/ouster/scan`,
+`/ouster/metadata`, `/ouster/telemetry`, and TF. Keep this separate from the
+competition layout because point clouds are too heavy for the 4,000 Kbps
+telemetry budget.
+
 The layout includes `/power/telemetry`. If the power telemetry PR has not
 merged yet, that panel will simply be empty.
 

--- a/docs/foxglove/ouster_lidar_debug.layout.json
+++ b/docs/foxglove/ouster_lidar_debug.layout.json
@@ -1,0 +1,127 @@
+{
+  "configById": {
+    "3D!ouster_lidar": {
+      "cameraState": {
+        "distance": 12,
+        "perspective": true,
+        "phi": 0.9,
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "targetOffset": [
+          0,
+          0,
+          0
+        ],
+        "targetOrientation": [
+          0,
+          0,
+          0,
+          1
+        ],
+        "thetaOffset": 0,
+        "fovy": 0.7853981633974483,
+        "near": 0.01,
+        "far": 1000
+      },
+      "followTf": "os_lidar",
+      "scene": {
+        "labelScaleFactor": 1
+      },
+      "transforms": {
+        "os_sensor": {
+          "visible": true
+        },
+        "os_lidar": {
+          "visible": true
+        },
+        "os_imu": {
+          "visible": true
+        }
+      },
+      "topics": {
+        "/ouster/points": {
+          "visible": true
+        },
+        "/ouster/scan": {
+          "visible": false
+        }
+      },
+      "layers": {
+        "ouster-grid": {
+          "visible": true,
+          "frameLocked": true,
+          "label": "Grid",
+          "instanceId": "ouster-grid",
+          "layerId": "foxglove.Grid",
+          "frameId": "os_lidar",
+          "divisions": 10,
+          "lineWidth": 0.02,
+          "color": "#808080",
+          "position": [
+            0,
+            0,
+            0
+          ],
+          "rotation": [
+            0,
+            0,
+            0
+          ],
+          "order": 1,
+          "size": 20
+        }
+      },
+      "publish": {
+        "type": "point",
+        "poseTopic": "/goal_pose",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      }
+    },
+    "RawMessages!imu": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/ouster/imu"
+    },
+    "RawMessages!telemetry": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/ouster/telemetry"
+    },
+    "RawMessages!metadata": {
+      "diffEnabled": false,
+      "diffMethod": "custom",
+      "showFullMessageForDiff": false,
+      "topicPath": "/ouster/metadata"
+    }
+  },
+  "globalVariables": {},
+  "layout": {
+    "direction": "row",
+    "first": "3D!ouster_lidar",
+    "second": {
+      "direction": "column",
+      "first": "RawMessages!imu",
+      "second": {
+        "direction": "column",
+        "first": "RawMessages!telemetry",
+        "second": "RawMessages!metadata",
+        "splitPercentage": 50
+      },
+      "splitPercentage": 45
+    },
+    "splitPercentage": 72
+  },
+  "playbackConfig": {
+    "speed": 1
+  },
+  "userNodes": {}
+}

--- a/src/lunabot_bringup/config/ouster_lidar_debug.yaml
+++ b/src/lunabot_bringup/config/ouster_lidar_debug.yaml
@@ -1,0 +1,28 @@
+ouster/os_driver:
+  ros__parameters:
+    sensor_hostname: os-122610007923.local
+    udp_dest: 169.254.86.134
+    mtp_main: true
+    lidar_mode: 1024x10
+    timestamp_mode: TIME_FROM_ROS_TIME
+    udp_profile_lidar: RNG15_RFL8_NIR8
+    lidar_port: 7502
+    imu_port: 7503
+    sensor_frame: os_sensor
+    lidar_frame: os_lidar
+    imu_frame: os_imu
+    point_cloud_frame: os_lidar
+    pub_static_tf: true
+    proc_mask: IMU|PCL|SCAN|TLM
+    scan_ring: 64
+    use_system_default_qos: false
+    point_type: native
+    operating_mode: NORMAL
+    signal_multiplier: 1.0
+    persist_config: false
+    attempt_reconnect: true
+    organized: true
+    destagger: true
+    min_range: 0.2
+    max_range: 30.0
+    v_reduction: 1

--- a/src/lunabot_bringup/launch/ouster_lidar_foxglove_debug.launch.py
+++ b/src/lunabot_bringup/launch/ouster_lidar_foxglove_debug.launch.py
@@ -1,0 +1,84 @@
+"""Launch the Ouster OS1 debug stream with a Foxglove bridge."""
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def generate_launch_description():
+    """Generate the Ouster LiDAR debug launch description."""
+    bringup_share = Path(get_package_share_directory("lunabot_bringup"))
+    ouster_share = Path(get_package_share_directory("ouster_ros"))
+
+    params_file = LaunchConfiguration("params_file")
+    foxglove_port = LaunchConfiguration("foxglove_port")
+    send_buffer_limit = LaunchConfiguration("send_buffer_limit")
+    default_params_file = bringup_share / "config" / "ouster_lidar_debug.yaml"
+
+    ouster_driver = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            str(ouster_share / "launch" / "driver.launch.py")
+        ),
+        launch_arguments={
+            "params_file": params_file,
+            "viz": "False",
+            "ouster_ns": "ouster",
+            "os_driver_name": "os_driver",
+        }.items(),
+    )
+
+    foxglove_bridge = Node(
+        package="foxglove_bridge",
+        executable="foxglove_bridge",
+        name="ouster_foxglove_bridge",
+        output="screen",
+        parameters=[
+            {
+                "port": ParameterValue(foxglove_port, value_type=int),
+                "send_buffer_limit": ParameterValue(
+                    send_buffer_limit,
+                    value_type=int,
+                ),
+                "topic_whitelist": [
+                    "/ouster/points",
+                    "/ouster/imu",
+                    "/ouster/scan",
+                    "/ouster/metadata",
+                    "/ouster/telemetry",
+                    "/tf",
+                    "/tf_static",
+                ],
+                "capabilities": ["clientPublish"],
+            }
+        ],
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "params_file",
+                default_value=str(default_params_file),
+                description="Ouster ROS driver parameter file.",
+            ),
+            DeclareLaunchArgument(
+                "foxglove_port",
+                default_value="8765",
+                description="Foxglove WebSocket port for the Ouster debug view.",
+            ),
+            DeclareLaunchArgument(
+                "send_buffer_limit",
+                default_value="100000000",
+                description=(
+                    "Foxglove per-client send buffer in bytes for point cloud debug."
+                ),
+            ),
+            ouster_driver,
+            foxglove_bridge,
+        ]
+    )

--- a/src/lunabot_bringup/package.xml
+++ b/src/lunabot_bringup/package.xml
@@ -12,6 +12,7 @@
   <exec_depend>compressed_image_transport</exec_depend>
   <exec_depend>foxglove_bridge</exec_depend>
   <exec_depend>image_transport</exec_depend>
+  <exec_depend>ouster_ros</exec_depend>
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/src/lunabot_bringup/test/test_ouster_lidar_foxglove_debug_launch.py
+++ b/src/lunabot_bringup/test/test_ouster_lidar_foxglove_debug_launch.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PACKAGE_ROOT.parents[1]
+LAUNCH_PATH = PACKAGE_ROOT / "launch" / "ouster_lidar_foxglove_debug.launch.py"
+CONFIG_PATH = PACKAGE_ROOT / "config" / "ouster_lidar_debug.yaml"
+LAYOUT_PATH = REPO_ROOT / "docs" / "foxglove" / "ouster_lidar_debug.layout.json"
+
+
+def test_ouster_debug_launch_includes_driver_and_foxglove_bridge():
+    launch_text = LAUNCH_PATH.read_text(encoding="utf-8")
+
+    assert "driver.launch.py" in launch_text
+    assert 'package="foxglove_bridge"' in launch_text
+    assert "/ouster/points" in launch_text
+    assert "/ouster/imu" in launch_text
+    assert "topic_whitelist" in launch_text
+
+
+def test_ouster_debug_config_matches_successful_bringup_topics():
+    config_text = CONFIG_PATH.read_text(encoding="utf-8")
+
+    assert "sensor_hostname: os-122610007923.local" in config_text
+    assert "lidar_mode: 1024x10" in config_text
+    assert "udp_profile_lidar: RNG15_RFL8_NIR8" in config_text
+    assert "proc_mask: IMU|PCL|SCAN|TLM" in config_text
+    assert "point_type: native" in config_text
+
+
+def test_ouster_debug_layout_covers_lidar_topics():
+    layout = json.loads(LAYOUT_PATH.read_text(encoding="utf-8"))
+    topics = set()
+    for config in layout["configById"].values():
+        topic = config.get("topicPath") or config.get("cameraTopic")
+        if topic:
+            topics.add(topic)
+        topics.update(config.get("topics", {}))
+
+    assert "/ouster/points" in topics
+    assert "/ouster/imu" in topics
+    assert "/ouster/telemetry" in topics

--- a/src/lunabot_bringup/test/test_ouster_lidar_foxglove_debug_launch.py
+++ b/src/lunabot_bringup/test/test_ouster_lidar_foxglove_debug_launch.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = PACKAGE_ROOT.parents[1]
 LAUNCH_PATH = PACKAGE_ROOT / "launch" / "ouster_lidar_foxglove_debug.launch.py"


### PR DESCRIPTION
## Summary
- add a reusable Ouster OS1 debug parameter file from the successful Jetson bring-up
- add a launch wrapper that starts the Ouster ROS driver without RViz and exposes LiDAR topics through Foxglove
- add a Foxglove Ouster debug layout and docs for connecting from ground control

## Testing
- python3 -m py_compile src/lunabot_bringup/launch/ouster_lidar_foxglove_debug.launch.py src/lunabot_bringup/test/test_ouster_lidar_foxglove_debug_launch.py
- python3 -m json.tool docs/foxglove/ouster_lidar_debug.layout.json
- python3 -m pytest src/lunabot_bringup/test/test_ouster_lidar_foxglove_debug_launch.py src/lunabot_bringup/test/test_foxglove_layout.py -q
- Jetson: python3 -m pytest src/lunabot_bringup/test/test_ouster_lidar_foxglove_debug_launch.py src/lunabot_bringup/test/test_foxglove_layout.py -q
- Jetson: colcon build --packages-up-to lunabot_bringup --symlink-install
- Jetson: ros2 launch lunabot_bringup ouster_lidar_foxglove_debug.launch.py --show-args

## Notes
- The generated Ouster metadata JSON was intentionally not committed.
- This is a debug/bring-up view. It is not intended for the scored-run telemetry layout because point clouds are too heavy for the telemetry budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds an Ouster OS1 Foxglove debug workflow to enable live, RViz-free LiDAR bring-up and troubleshooting by bridging selected Ouster topics to Foxglove.

## Changes

- Adds a reusable Ouster OS1 parameter file (src/lunabot_bringup/config/ouster_lidar_debug.yaml) tuned for Jetson bring-up.
- Adds a launch wrapper (src/lunabot_bringup/launch/ouster_lidar_foxglove_debug.launch.py) that starts the Ouster driver and exposes selected LiDAR/IMU/telemetry/metadata topics to Foxglove via a foxglove_bridge.
- Adds a Foxglove layout (docs/foxglove/ouster_lidar_debug.layout.json) with a 3D point cloud view and message panels for IMU, telemetry, and metadata.
- Updates Foxglove documentation (docs/foxglove/README.md) with usage and Jetson network/udp_dest notes.
- Declares runtime dependency on ouster_ros in package.xml.
- Adds pytest tests validating the launch file contents, YAML config values, and layout topic coverage.

## Notes

- The generated Ouster metadata JSON was intentionally excluded from the commit.
- Intended for debug/bring-up only (point clouds exceed telemetry/bandwidth limits and are not suitable for scored-run telemetry).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->