### PR TITLE
Add advisory movement watchdog

### DIFF
--- a/.github/contracts/interface_contracts.json
+++ b/.github/contracts/interface_contracts.json
@@ -75,6 +75,13 @@
       "kind": "publisher",
       "source": "src/lunabot_bringup/lunabot_bringup/power_telemetry.py",
       "phases": ["runtime", "hardware"]
+    },
+    {
+      "name": "/mission/movement_watchdog/armed",
+      "type": "std_srvs/srv/SetBool",
+      "kind": "service_server",
+      "source": "src/lunabot_bringup/lunabot_bringup/movement_watchdog.py",
+      "phases": ["runtime", "hardware"]
     }
   ],
   "tf_links": [

--- a/.github/scripts/check_interface_contracts.py
+++ b/.github/scripts/check_interface_contracts.py
@@ -50,6 +50,9 @@ def _extract_python_interfaces(path: Path) -> list[dict[str, str]]:
                 elif module.endswith(".action"):
                     package = module.rsplit(".", 1)[0]
                     import_aliases[local_name] = f"{package}/action/{alias.name}"
+                elif module.endswith(".srv"):
+                    package = module.rsplit(".", 1)[0]
+                    import_aliases[local_name] = f"{package}/srv/{alias.name}"
                 else:
                     import_aliases[local_name] = f"{module}.{alias.name}"
 
@@ -76,6 +79,17 @@ def _extract_python_interfaces(path: Path) -> list[dict[str, str]]:
                         if func_name == "create_publisher"
                         else "subscription",
                         "name": topic,
+                        "type": _resolve_type(node.args[0], import_aliases),
+                    }
+                )
+
+        if func_name == "create_service" and len(node.args) >= 2:
+            service_name = _constant_string(node.args[1])
+            if service_name:
+                interfaces.append(
+                    {
+                        "kind": "service_server",
+                        "name": service_name,
                         "type": _resolve_type(node.args[0], import_aliases),
                     }
                 )

--- a/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
+++ b/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
@@ -16,6 +16,7 @@ profiles:
       - /safety/motion_inhibit
       - /safety/reset_motion_inhibit
       - /drivetrain/status
+      - /odometry/local
       - /localisation/start_zone_status
       - /excavation/status
       - /cmd_vel_gated
@@ -43,7 +44,9 @@ profiles:
       - /excavation/telemetry
       - /cmd_vel_gated
       - /cmd_vel_safe
+      - /odometry/local
       - /odom
+      - /odom_wheels
       - /scan
       - /map
       - /global_costmap/costmap
@@ -72,7 +75,9 @@ profiles:
       - /excavation/telemetry
       - /cmd_vel_gated
       - /cmd_vel_safe
+      - /odometry/local
       - /odom
+      - /odom_wheels
       - /scan
       - /map
       - /global_costmap/costmap

--- a/src/lunabot_bringup/launch/mission_shuttle_evidence.launch.py
+++ b/src/lunabot_bringup/launch/mission_shuttle_evidence.launch.py
@@ -113,6 +113,19 @@ def generate_launch_description():
         parameters=[{"use_sim_time": ParameterValue(use_sim_time, value_type=bool)}],
     )
 
+    movement_watchdog = Node(
+        package="lunabot_bringup",
+        executable="movement_watchdog",
+        name="movement_watchdog",
+        output="screen",
+        parameters=[
+            {
+                "use_sim_time": ParameterValue(use_sim_time, value_type=bool),
+                "auto_arm": False,
+            }
+        ],
+    )
+
     mission_manager = Node(
         package="lunabot_bringup",
         executable="mission_manager",
@@ -162,6 +175,7 @@ def generate_launch_description():
             estop_node,
             deposit_action_server,
             rover_diagnostics,
+            movement_watchdog,
             TimerAction(period=45.0, actions=[mission_manager]),
             mission_exit_handler,
         ]

--- a/src/lunabot_bringup/launch/rover_diagnostics.launch.py
+++ b/src/lunabot_bringup/launch/rover_diagnostics.launch.py
@@ -11,6 +11,9 @@ def generate_launch_description():
     """Generate the rover diagnostics launch description."""
     stale_timeout_s = LaunchConfiguration("stale_timeout_s")
     publish_hz = LaunchConfiguration("publish_hz")
+    movement_timeout_s = LaunchConfiguration("movement_timeout_s")
+    movement_warn_s = LaunchConfiguration("movement_warn_s")
+    movement_auto_arm = LaunchConfiguration("movement_auto_arm")
 
     diagnostics = Node(
         package="lunabot_bringup",
@@ -23,6 +26,27 @@ def generate_launch_description():
                     stale_timeout_s, value_type=float
                 ),
                 "publish_hz": ParameterValue(publish_hz, value_type=float),
+            }
+        ],
+    )
+    movement_watchdog = Node(
+        package="lunabot_bringup",
+        executable="movement_watchdog",
+        name="movement_watchdog",
+        output="screen",
+        parameters=[
+            {
+                "timeout_s": ParameterValue(
+                    movement_timeout_s, value_type=float
+                ),
+                "warn_s": ParameterValue(movement_warn_s, value_type=float),
+                "stale_timeout_s": ParameterValue(
+                    stale_timeout_s, value_type=float
+                ),
+                "publish_hz": ParameterValue(publish_hz, value_type=float),
+                "auto_arm": ParameterValue(
+                    movement_auto_arm, value_type=bool
+                ),
             }
         ],
     )
@@ -39,6 +63,22 @@ def generate_launch_description():
                 default_value="1.0",
                 description="DiagnosticArray publish rate.",
             ),
+            DeclareLaunchArgument(
+                "movement_timeout_s",
+                default_value="300.0",
+                description="Seconds without confirmed movement before ERROR.",
+            ),
+            DeclareLaunchArgument(
+                "movement_warn_s",
+                default_value="240.0",
+                description="Seconds without confirmed movement before WARN.",
+            ),
+            DeclareLaunchArgument(
+                "movement_auto_arm",
+                default_value="false",
+                description="Arm the movement watchdog at launch.",
+            ),
             diagnostics,
+            movement_watchdog,
         ]
     )

--- a/src/lunabot_bringup/lunabot_bringup/movement_watchdog.py
+++ b/src/lunabot_bringup/lunabot_bringup/movement_watchdog.py
@@ -131,6 +131,10 @@ class MovementWatchdog:
         self.armed_at_s = now_s if armed else None
         for source in self.sources.values():
             source.reset_motion_window(now_s)
+            source.last_received_s = None
+            source.last_position = None
+            source.last_yaw = None
+            source.last_encoder_ticks = None
 
     def update_drivetrain_status(self, msg: Any) -> None:
         """Store command-derived drivetrain state only as diagnostic context."""
@@ -193,7 +197,9 @@ class MovementWatchdog:
 
         encoder_delta = sum(
             abs(current - previous)
-            for current, previous in zip(encoder_ticks, source.last_encoder_ticks)
+            for current, previous in zip(
+                encoder_ticks, source.last_encoder_ticks, strict=False
+            )
         )
         source.last_encoder_ticks = encoder_ticks
         source.last_received_s = now_s

--- a/src/lunabot_bringup/lunabot_bringup/movement_watchdog.py
+++ b/src/lunabot_bringup/lunabot_bringup/movement_watchdog.py
@@ -1,0 +1,448 @@
+"""Advisory mission movement watchdog diagnostics."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import rclpy
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
+from nav_msgs.msg import Odometry
+from rclpy.node import Node
+from std_srvs.srv import SetBool
+
+from lunabot_interfaces import msg as lunabot_msgs
+
+LEVEL_OK = DiagnosticStatus.OK
+LEVEL_WARN = DiagnosticStatus.WARN
+LEVEL_ERROR = DiagnosticStatus.ERROR
+LEVEL_STALE = DiagnosticStatus.STALE
+
+DrivetrainStatus: Any = lunabot_msgs.__dict__["DrivetrainStatus"]
+DrivetrainTelemetry: Any = lunabot_msgs.__dict__["DrivetrainTelemetry"]
+
+
+def _key_value(key: str, value: object) -> KeyValue:
+    item = KeyValue()
+    item.key = key
+    item.value = str(value)
+    return item
+
+
+def _yaw_from_quaternion(orientation: Any) -> float:
+    siny_cosp = 2.0 * (orientation.w * orientation.z + orientation.x * orientation.y)
+    cosy_cosp = 1.0 - 2.0 * (
+        orientation.y * orientation.y + orientation.z * orientation.z
+    )
+    return math.atan2(siny_cosp, cosy_cosp)
+
+
+def _angle_delta(a: float, b: float) -> float:
+    return abs(math.atan2(math.sin(a - b), math.cos(a - b)))
+
+
+def _distance_2d(a: tuple[float, float], b: tuple[float, float]) -> float:
+    return math.hypot(a[0] - b[0], a[1] - b[1])
+
+
+@dataclass
+class EvidenceSource:
+    """Movement evidence accumulated for one physical feedback source."""
+
+    name: str
+    priority: int
+    last_received_s: float | None = None
+    last_position: tuple[float, float] | None = None
+    last_yaw: float | None = None
+    last_encoder_ticks: tuple[int, ...] | None = None
+    motion_window_started_s: float | None = None
+    accumulated_translation_m: float = 0.0
+    accumulated_yaw_rad: float = 0.0
+    accumulated_encoder_ticks: int = 0
+    max_wheel_velocity_rps: float = 0.0
+
+    def age_s(self, now_s: float) -> float | None:
+        """Return source age in seconds, or None if it has never published."""
+        if self.last_received_s is None:
+            return None
+        return max(0.0, now_s - self.last_received_s)
+
+    def fresh(self, now_s: float, stale_timeout_s: float) -> bool:
+        """Return whether this source is fresh enough to use."""
+        age_s = self.age_s(now_s)
+        return age_s is not None and age_s <= stale_timeout_s
+
+    def reset_motion_window(self, now_s: float) -> None:
+        """Reset short-window accumulation after stillness or confirmation."""
+        self.motion_window_started_s = now_s
+        self.accumulated_translation_m = 0.0
+        self.accumulated_yaw_rad = 0.0
+        self.accumulated_encoder_ticks = 0
+        self.max_wheel_velocity_rps = 0.0
+
+
+@dataclass
+class MovementWatchdogConfig:
+    """Configurable thresholds for rulebook movement evidence."""
+
+    timeout_s: float = 300.0
+    warn_s: float = 240.0
+    stale_timeout_s: float = 2.5
+    confirmation_window_s: float = 1.0
+    min_translation_m: float = 0.05
+    min_yaw_rad: float = 0.05
+    min_wheel_velocity_rps: float = 0.05
+    min_encoder_ticks: int = 4
+    max_odom_jump_m: float = 2.0
+    max_odom_jump_rad: float = math.pi
+
+
+@dataclass
+class MovementWatchdog:
+    """Track confirmed physical movement for the 5-minute mission anomaly."""
+
+    config: MovementWatchdogConfig = field(default_factory=MovementWatchdogConfig)
+    odom_topics: tuple[str, ...] = ("/odometry/local", "/odom", "/odom_wheels")
+    telemetry_topic: str = "/drivetrain/telemetry"
+    armed: bool = False
+    ever_moved: bool = False
+    armed_at_s: float | None = None
+    last_confirmed_motion_s: float | None = None
+    last_motion_source: str = ""
+    drivetrain_state: int | str = "unknown"
+    fault_code: int | str = "unknown"
+    sources: dict[str, EvidenceSource] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for priority, topic in enumerate(self.odom_topics):
+            self.sources[topic] = EvidenceSource(topic, priority)
+        self.sources[self.telemetry_topic] = EvidenceSource(
+            self.telemetry_topic, len(self.odom_topics)
+        )
+
+    def set_armed(self, armed: bool, now_s: float) -> None:
+        """Arm/reset or disarm the watchdog."""
+        self.armed = armed
+        self.ever_moved = False
+        self.last_confirmed_motion_s = None
+        self.last_motion_source = ""
+        self.armed_at_s = now_s if armed else None
+        for source in self.sources.values():
+            source.reset_motion_window(now_s)
+
+    def update_drivetrain_status(self, msg: Any) -> None:
+        """Store command-derived drivetrain state only as diagnostic context."""
+        self.drivetrain_state = msg.state
+        self.fault_code = msg.fault_code
+
+    def update_odom(self, topic: str, msg: Odometry, now_s: float) -> None:
+        """Update odometry-derived physical movement evidence."""
+        source = self.sources[topic]
+        position = (
+            float(msg.pose.pose.position.x),
+            float(msg.pose.pose.position.y),
+        )
+        yaw = _yaw_from_quaternion(msg.pose.pose.orientation)
+
+        if source.last_position is None or source.last_yaw is None:
+            source.last_position = position
+            source.last_yaw = yaw
+            source.last_received_s = now_s
+            source.reset_motion_window(now_s)
+            return
+
+        translation_m = _distance_2d(position, source.last_position)
+        yaw_delta_rad = _angle_delta(yaw, source.last_yaw)
+        source.last_position = position
+        source.last_yaw = yaw
+        source.last_received_s = now_s
+
+        if (
+            translation_m > self.config.max_odom_jump_m
+            or yaw_delta_rad > self.config.max_odom_jump_rad
+        ):
+            source.reset_motion_window(now_s)
+            return
+
+        if translation_m <= 0.0 and yaw_delta_rad <= 0.0:
+            source.reset_motion_window(now_s)
+            return
+
+        self._accumulate_source_motion(
+            source,
+            now_s=now_s,
+            translation_m=translation_m,
+            yaw_delta_rad=yaw_delta_rad,
+        )
+
+    def update_telemetry(self, msg: Any, now_s: float) -> None:
+        """Update drivetrain telemetry fallback movement evidence."""
+        source = self.sources[self.telemetry_topic]
+        wheel_velocity = tuple(float(v) for v in msg.wheel_velocity_rps)
+        encoder_ticks = tuple(int(v) for v in msg.encoder_ticks)
+        max_velocity = max((abs(v) for v in wheel_velocity), default=0.0)
+
+        if source.last_encoder_ticks is None:
+            source.last_encoder_ticks = encoder_ticks
+            source.last_received_s = now_s
+            source.reset_motion_window(now_s)
+            source.max_wheel_velocity_rps = max_velocity
+            return
+
+        encoder_delta = sum(
+            abs(current - previous)
+            for current, previous in zip(encoder_ticks, source.last_encoder_ticks)
+        )
+        source.last_encoder_ticks = encoder_ticks
+        source.last_received_s = now_s
+
+        if max_velocity <= 0.0 and encoder_delta <= 0:
+            source.reset_motion_window(now_s)
+            return
+
+        self._accumulate_source_motion(
+            source,
+            now_s=now_s,
+            max_wheel_velocity_rps=max_velocity,
+            encoder_delta=encoder_delta,
+        )
+
+    def _accumulate_source_motion(
+        self,
+        source: EvidenceSource,
+        *,
+        now_s: float,
+        translation_m: float = 0.0,
+        yaw_delta_rad: float = 0.0,
+        max_wheel_velocity_rps: float = 0.0,
+        encoder_delta: int = 0,
+    ) -> None:
+        if source.motion_window_started_s is None:
+            source.reset_motion_window(now_s)
+        source.accumulated_translation_m += translation_m
+        source.accumulated_yaw_rad += yaw_delta_rad
+        source.accumulated_encoder_ticks += encoder_delta
+        source.max_wheel_velocity_rps = max(
+            source.max_wheel_velocity_rps, max_wheel_velocity_rps
+        )
+
+        window_started_s = (
+            source.motion_window_started_s
+            if source.motion_window_started_s is not None
+            else now_s
+        )
+        window_age_s = now_s - window_started_s
+        if window_age_s < self.config.confirmation_window_s:
+            return
+
+        odom_confirmed = (
+            source.accumulated_translation_m >= self.config.min_translation_m
+            or source.accumulated_yaw_rad >= self.config.min_yaw_rad
+        )
+        telemetry_confirmed = (
+            source.max_wheel_velocity_rps >= self.config.min_wheel_velocity_rps
+            and source.accumulated_encoder_ticks >= self.config.min_encoder_ticks
+        )
+        if odom_confirmed or telemetry_confirmed:
+            self.ever_moved = True
+            self.last_confirmed_motion_s = now_s
+            self.last_motion_source = source.name
+            source.reset_motion_window(now_s)
+
+    def selected_source(self, now_s: float) -> EvidenceSource | None:
+        """Return the highest-priority fresh source, if any."""
+        fresh_sources = [
+            source
+            for source in self.sources.values()
+            if source.fresh(now_s, self.config.stale_timeout_s)
+        ]
+        if not fresh_sources:
+            return None
+        return min(fresh_sources, key=lambda source: source.priority)
+
+    def diagnostic(self, now_s: float) -> DiagnosticStatus:
+        """Build the advisory diagnostic status."""
+        selected = self.selected_source(now_s)
+        elapsed_s = 0.0
+        if self.armed and self.armed_at_s is not None:
+            basis_s = self.last_confirmed_motion_s or self.armed_at_s
+            elapsed_s = max(0.0, now_s - basis_s)
+
+        values = {
+            "armed": self.armed,
+            "ever_moved": self.ever_moved,
+            "seconds_since_confirmed_motion": f"{elapsed_s:.2f}",
+            "timeout_s": f"{self.config.timeout_s:.2f}",
+            "warn_s": f"{self.config.warn_s:.2f}",
+            "last_motion_source": self.last_motion_source or "none",
+            "selected_source": selected.name if selected is not None else "none",
+            "drivetrain_state": self.drivetrain_state,
+            "fault_code": self.fault_code,
+        }
+        for source in self.sources.values():
+            age_s = source.age_s(now_s)
+            values[f"{source.name}.age_s"] = (
+                f"{age_s:.2f}" if age_s is not None else "never"
+            )
+        if selected is not None:
+            values.update(
+                {
+                    "odom_delta_m": f"{selected.accumulated_translation_m:.3f}",
+                    "yaw_delta_rad": f"{selected.accumulated_yaw_rad:.3f}",
+                    "max_wheel_velocity_rps": (
+                        f"{selected.max_wheel_velocity_rps:.3f}"
+                    ),
+                }
+            )
+
+        status = DiagnosticStatus()
+        status.name = "mission/movement_watchdog"
+        status.hardware_id = "innex1_rover"
+        status.values = [_key_value(key, value) for key, value in values.items()]
+
+        if not self.armed:
+            status.level = LEVEL_OK
+            status.message = "Movement watchdog disarmed"
+            return status
+        if selected is None:
+            status.level = LEVEL_STALE
+            status.message = "No fresh physical movement evidence"
+            return status
+        if elapsed_s >= self.config.timeout_s:
+            status.level = LEVEL_ERROR
+            status.message = "No confirmed rover movement for timeout"
+            return status
+        if elapsed_s >= self.config.warn_s:
+            status.level = LEVEL_WARN
+            status.message = "No confirmed rover movement near timeout"
+            return status
+        status.level = LEVEL_OK
+        status.message = (
+            "Movement confirmed recently"
+            if self.ever_moved
+            else "Awaiting confirmed rover movement"
+        )
+        return status
+
+
+class MovementWatchdogNode(Node):
+    """ROS wrapper for the advisory movement watchdog."""
+
+    def __init__(self) -> None:
+        super().__init__("movement_watchdog")
+        self.declare_parameter(
+            "odom_topics", ["/odometry/local", "/odom", "/odom_wheels"]
+        )
+        self.declare_parameter("telemetry_topic", "/drivetrain/telemetry")
+        self.declare_parameter("timeout_s", 300.0)
+        self.declare_parameter("warn_s", 240.0)
+        self.declare_parameter("stale_timeout_s", 2.5)
+        self.declare_parameter("confirmation_window_s", 1.0)
+        self.declare_parameter("min_translation_m", 0.05)
+        self.declare_parameter("min_yaw_rad", 0.05)
+        self.declare_parameter("min_wheel_velocity_rps", 0.05)
+        self.declare_parameter("min_encoder_ticks", 4)
+        self.declare_parameter("publish_hz", 1.0)
+        self.declare_parameter("auto_arm", False)
+
+        odom_topics = tuple(
+            str(topic) for topic in self.get_parameter("odom_topics").value
+        )
+        telemetry_topic = str(self.get_parameter("telemetry_topic").value)
+        config = MovementWatchdogConfig(
+            timeout_s=float(self.get_parameter("timeout_s").value),
+            warn_s=float(self.get_parameter("warn_s").value),
+            stale_timeout_s=float(self.get_parameter("stale_timeout_s").value),
+            confirmation_window_s=float(
+                self.get_parameter("confirmation_window_s").value
+            ),
+            min_translation_m=float(self.get_parameter("min_translation_m").value),
+            min_yaw_rad=float(self.get_parameter("min_yaw_rad").value),
+            min_wheel_velocity_rps=float(
+                self.get_parameter("min_wheel_velocity_rps").value
+            ),
+            min_encoder_ticks=int(self.get_parameter("min_encoder_ticks").value),
+        )
+        publish_hz = float(self.get_parameter("publish_hz").value)
+        if publish_hz <= 0.0:
+            raise ValueError("publish_hz must be positive")
+        if config.timeout_s <= 0.0:
+            raise ValueError("timeout_s must be positive")
+        if config.warn_s < 0.0 or config.warn_s > config.timeout_s:
+            raise ValueError("warn_s must be between zero and timeout_s")
+        if config.stale_timeout_s <= 0.0:
+            raise ValueError("stale_timeout_s must be positive")
+        if config.confirmation_window_s < 0.0:
+            raise ValueError("confirmation_window_s must be non-negative")
+
+        self._watchdog = MovementWatchdog(
+            config=config,
+            odom_topics=odom_topics,
+            telemetry_topic=telemetry_topic,
+        )
+        if bool(self.get_parameter("auto_arm").value):
+            self._watchdog.set_armed(True, time.monotonic())
+
+        for topic in odom_topics:
+            self.create_subscription(
+                Odometry,
+                topic,
+                lambda msg, topic=topic: self._watchdog.update_odom(
+                    topic, msg, time.monotonic()
+                ),
+                10,
+            )
+        self.create_subscription(
+            DrivetrainTelemetry,
+            telemetry_topic,
+            lambda msg: self._watchdog.update_telemetry(msg, time.monotonic()),
+            10,
+        )
+        self.create_subscription(
+            DrivetrainStatus,
+            "/drivetrain/status",
+            self._watchdog.update_drivetrain_status,
+            10,
+        )
+        self.create_service(
+            SetBool,
+            "/mission/movement_watchdog/armed",
+            self._set_armed,
+        )
+        self._publisher = self.create_publisher(DiagnosticArray, "/diagnostics", 10)
+        self.create_timer(1.0 / publish_hz, self._publish)
+        self.get_logger().info(
+            "Movement watchdog publishing advisory diagnostics on /diagnostics"
+        )
+
+    def _set_armed(
+        self, request: SetBool.Request, response: SetBool.Response
+    ) -> SetBool.Response:
+        self._watchdog.set_armed(bool(request.data), time.monotonic())
+        response.success = True
+        response.message = (
+            "Movement watchdog armed" if request.data else "Movement watchdog disarmed"
+        )
+        return response
+
+    def _publish(self) -> None:
+        msg = DiagnosticArray()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.status = [self._watchdog.diagnostic(time.monotonic())]
+        self._publisher.publish(msg)
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = MovementWatchdogNode()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lunabot_bringup/package.xml
+++ b/src/lunabot_bringup/package.xml
@@ -23,8 +23,10 @@
   <exec_depend>action_msgs</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
   <exec_depend>nav2_msgs</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
   <exec_depend>ros2bag</exec_depend>

--- a/src/lunabot_bringup/setup.py
+++ b/src/lunabot_bringup/setup.py
@@ -56,6 +56,7 @@ setup(
             "hardware_fault_injector = lunabot_bringup.hardware_fault_injection:main",
             "runtime_profile = lunabot_bringup.runtime_profile:main",
             "rover_diagnostics = lunabot_bringup.rover_diagnostics:main",
+            "movement_watchdog = lunabot_bringup.movement_watchdog:main",
             "manual_power_telemetry = lunabot_bringup.power_telemetry:main",
         ],
     },

--- a/src/lunabot_bringup/test/test_mission_evidence.py
+++ b/src/lunabot_bringup/test/test_mission_evidence.py
@@ -41,6 +41,7 @@ def test_load_profiles_reads_minimal_topic_allowlist():
 
     assert "/mission/state" in minimal.topics
     assert "/diagnostics" in minimal.topics
+    assert "/odometry/local" in minimal.topics
     assert "/power/telemetry" in minimal.topics
     assert "/ouster/points" not in minimal.topics
     assert profiles["heavy"].topics[-1] == "/ouster/points"

--- a/src/lunabot_bringup/test/test_mission_shuttle_evidence_launch.py
+++ b/src/lunabot_bringup/test/test_mission_shuttle_evidence_launch.py
@@ -58,6 +58,7 @@ def test_mission_shuttle_evidence_launch_composes_one_cycle_stack():
         "estop_node",
         "material_action_server",
         "rover_diagnostics",
+        "movement_watchdog",
     ]
     assert len(timers) == 1
     assert timers[0].period == 45.0

--- a/src/lunabot_bringup/test/test_movement_watchdog.py
+++ b/src/lunabot_bringup/test/test_movement_watchdog.py
@@ -1,0 +1,285 @@
+"""Unit tests for the advisory movement watchdog."""
+
+import math
+import sys
+import types
+
+
+def _install_ros_stubs():
+    diagnostic_msgs = types.ModuleType("diagnostic_msgs")
+    diagnostic_msgs_msg = types.ModuleType("diagnostic_msgs.msg")
+
+    class DiagnosticStatus:
+        OK = 0
+        WARN = 1
+        ERROR = 2
+        STALE = 3
+
+        def __init__(self):
+            self.name = ""
+            self.hardware_id = ""
+            self.level = self.OK
+            self.message = ""
+            self.values = []
+
+    class DiagnosticArray:
+        def __init__(self):
+            self.header = types.SimpleNamespace(stamp=None)
+            self.status = []
+
+    class KeyValue:
+        def __init__(self):
+            self.key = ""
+            self.value = ""
+
+    diagnostic_msgs_msg.DiagnosticArray = DiagnosticArray
+    diagnostic_msgs_msg.DiagnosticStatus = DiagnosticStatus
+    diagnostic_msgs_msg.KeyValue = KeyValue
+
+    nav_msgs = types.ModuleType("nav_msgs")
+    nav_msgs_msg = types.ModuleType("nav_msgs.msg")
+
+    class Odometry:
+        def __init__(self):
+            orientation = types.SimpleNamespace(x=0.0, y=0.0, z=0.0, w=1.0)
+            position = types.SimpleNamespace(x=0.0, y=0.0, z=0.0)
+            pose = types.SimpleNamespace(position=position, orientation=orientation)
+            self.pose = types.SimpleNamespace(pose=pose)
+
+    nav_msgs_msg.Odometry = Odometry
+
+    rclpy = types.ModuleType("rclpy")
+    rclpy_node = types.ModuleType("rclpy.node")
+
+    class Node:
+        pass
+
+    rclpy_node.Node = Node
+
+    std_srvs = types.ModuleType("std_srvs")
+    std_srvs_srv = types.ModuleType("std_srvs.srv")
+
+    class SetBool:
+        class Request:
+            data = False
+
+        class Response:
+            success = False
+            message = ""
+
+    std_srvs_srv.SetBool = SetBool
+
+    lunabot_interfaces = types.ModuleType("lunabot_interfaces")
+    lunabot_interfaces_msg = types.ModuleType("lunabot_interfaces.msg")
+
+    class DrivetrainStatus:
+        STATE_DRIVING = 2
+        FAULT_NONE = 0
+
+        def __init__(self):
+            self.state = 0
+            self.fault_code = self.FAULT_NONE
+
+    class DrivetrainTelemetry:
+        def __init__(self):
+            self.wheel_velocity_rps = [0.0, 0.0, 0.0, 0.0]
+            self.encoder_ticks = [0, 0, 0, 0]
+
+    lunabot_interfaces_msg.DrivetrainStatus = DrivetrainStatus
+    lunabot_interfaces_msg.DrivetrainTelemetry = DrivetrainTelemetry
+    lunabot_interfaces.msg = lunabot_interfaces_msg
+
+    sys.modules.setdefault("diagnostic_msgs", diagnostic_msgs)
+    sys.modules.setdefault("diagnostic_msgs.msg", diagnostic_msgs_msg)
+    sys.modules.setdefault("nav_msgs", nav_msgs)
+    sys.modules.setdefault("nav_msgs.msg", nav_msgs_msg)
+    sys.modules.setdefault("rclpy", rclpy)
+    sys.modules.setdefault("rclpy.node", rclpy_node)
+    sys.modules.setdefault("std_srvs", std_srvs)
+    sys.modules.setdefault("std_srvs.srv", std_srvs_srv)
+    sys.modules.setdefault("lunabot_interfaces", lunabot_interfaces)
+    sys.modules.setdefault("lunabot_interfaces.msg", lunabot_interfaces_msg)
+
+
+try:
+    from nav_msgs.msg import Odometry
+except ModuleNotFoundError:
+    _install_ros_stubs()
+    from nav_msgs.msg import Odometry
+
+from lunabot_bringup.movement_watchdog import (  # noqa: E402
+    LEVEL_ERROR,
+    LEVEL_OK,
+    LEVEL_STALE,
+    LEVEL_WARN,
+    MovementWatchdog,
+    MovementWatchdogConfig,
+)
+from lunabot_interfaces.msg import (  # noqa: E402
+    DrivetrainStatus,
+    DrivetrainTelemetry,
+)
+
+
+def _watchdog(**config_overrides):
+    config = MovementWatchdogConfig(
+        timeout_s=10.0,
+        warn_s=8.0,
+        stale_timeout_s=2.0,
+        confirmation_window_s=1.0,
+        min_translation_m=0.10,
+        min_yaw_rad=0.10,
+        min_wheel_velocity_rps=0.20,
+        min_encoder_ticks=5,
+    )
+    for key, value in config_overrides.items():
+        setattr(config, key, value)
+    return MovementWatchdog(config=config)
+
+
+def _odom(x=0.0, y=0.0, yaw=0.0):
+    msg = Odometry()
+    msg.pose.pose.position.x = x
+    msg.pose.pose.position.y = y
+    msg.pose.pose.orientation.z = math.sin(yaw / 2.0)
+    msg.pose.pose.orientation.w = math.cos(yaw / 2.0)
+    return msg
+
+
+def _values(status):
+    return {item.key: item.value for item in status.values}
+
+
+def test_disarmed_watchdog_is_ok_without_sources():
+    watchdog = _watchdog()
+
+    status = watchdog.diagnostic(now_s=100.0)
+
+    assert status.level == LEVEL_OK
+    assert status.message == "Movement watchdog disarmed"
+    assert _values(status)["armed"] == "False"
+
+
+def test_armed_watchdog_is_stale_without_physical_evidence():
+    watchdog = _watchdog()
+    watchdog.set_armed(True, now_s=0.0)
+
+    status = watchdog.diagnostic(now_s=1.0)
+
+    assert status.level == LEVEL_STALE
+    assert "No fresh physical movement evidence" in status.message
+
+
+def test_fresh_odom_without_movement_warns_then_errors():
+    watchdog = _watchdog()
+    watchdog.set_armed(True, now_s=0.0)
+    watchdog.update_odom("/odometry/local", _odom(), now_s=0.5)
+    watchdog.update_odom("/odometry/local", _odom(), now_s=7.9)
+
+    warning = watchdog.diagnostic(now_s=8.0)
+    watchdog.update_odom("/odometry/local", _odom(), now_s=9.9)
+    error = watchdog.diagnostic(now_s=10.0)
+
+    assert warning.level == LEVEL_WARN
+    assert error.level == LEVEL_ERROR
+    assert _values(error)["ever_moved"] == "False"
+
+
+def test_sustained_odom_translation_confirms_movement_before_timeout():
+    watchdog = _watchdog()
+    watchdog.set_armed(True, now_s=0.0)
+    watchdog.update_odom("/odometry/local", _odom(x=0.00), now_s=0.0)
+    watchdog.update_odom("/odometry/local", _odom(x=0.06), now_s=0.5)
+    watchdog.update_odom("/odometry/local", _odom(x=0.12), now_s=1.1)
+    watchdog.update_odom("/odometry/local", _odom(x=0.12), now_s=6.9)
+
+    status = watchdog.diagnostic(now_s=7.0)
+
+    assert status.level == LEVEL_OK
+    assert watchdog.ever_moved is True
+    assert _values(status)["last_motion_source"] == "/odometry/local"
+    assert _values(status)["seconds_since_confirmed_motion"] == "5.90"
+
+
+def test_sustained_rotation_counts_as_movement():
+    watchdog = _watchdog()
+    watchdog.set_armed(True, now_s=0.0)
+    watchdog.update_odom("/odometry/local", _odom(yaw=0.00), now_s=0.0)
+    watchdog.update_odom("/odometry/local", _odom(yaw=0.06), now_s=0.5)
+    watchdog.update_odom("/odometry/local", _odom(yaw=0.12), now_s=1.1)
+
+    status = watchdog.diagnostic(now_s=2.0)
+
+    assert status.level == LEVEL_OK
+    assert watchdog.ever_moved is True
+
+
+def test_intermittent_twitch_does_not_confirm_movement():
+    watchdog = _watchdog()
+    watchdog.set_armed(True, now_s=0.0)
+    watchdog.update_odom("/odometry/local", _odom(x=0.00), now_s=0.0)
+    watchdog.update_odom("/odometry/local", _odom(x=0.12), now_s=0.1)
+    watchdog.update_odom("/odometry/local", _odom(x=0.12), now_s=0.2)
+    watchdog.update_odom("/odometry/local", _odom(x=0.12), now_s=7.9)
+
+    status = watchdog.diagnostic(now_s=8.0)
+
+    assert watchdog.ever_moved is False
+    assert status.level == LEVEL_WARN
+
+
+def test_drivetrain_state_driving_does_not_count_as_movement_evidence():
+    watchdog = _watchdog()
+    watchdog.set_armed(True, now_s=0.0)
+    msg = DrivetrainStatus()
+    msg.state = DrivetrainStatus.STATE_DRIVING
+    msg.fault_code = DrivetrainStatus.FAULT_NONE
+
+    watchdog.update_drivetrain_status(msg)
+    status = watchdog.diagnostic(now_s=10.0)
+
+    assert status.level == LEVEL_STALE
+    assert watchdog.ever_moved is False
+    assert _values(status)["drivetrain_state"] == str(DrivetrainStatus.STATE_DRIVING)
+
+
+def test_prefers_local_odometry_over_fresh_fallback_source():
+    watchdog = _watchdog()
+    watchdog.set_armed(True, now_s=0.0)
+    watchdog.update_odom("/odom", _odom(x=0.0), now_s=0.1)
+    watchdog.update_odom("/odometry/local", _odom(x=0.0), now_s=0.2)
+
+    status = watchdog.diagnostic(now_s=1.0)
+
+    assert _values(status)["selected_source"] == "/odometry/local"
+
+
+def test_falls_back_to_odom_when_local_odometry_is_stale():
+    watchdog = _watchdog()
+    watchdog.set_armed(True, now_s=0.0)
+    watchdog.update_odom("/odometry/local", _odom(x=0.0), now_s=0.1)
+    watchdog.update_odom("/odom", _odom(x=0.0), now_s=3.0)
+
+    status = watchdog.diagnostic(now_s=3.5)
+
+    assert status.level == LEVEL_OK
+    assert _values(status)["selected_source"] == "/odom"
+
+
+def test_sustained_drivetrain_telemetry_is_last_resort_movement_evidence():
+    watchdog = _watchdog()
+    watchdog.set_armed(True, now_s=0.0)
+    first = DrivetrainTelemetry()
+    first.wheel_velocity_rps = [0.3, 0.3, 0.3, 0.3]
+    first.encoder_ticks = [0, 0, 0, 0]
+    second = DrivetrainTelemetry()
+    second.wheel_velocity_rps = [0.3, 0.3, 0.3, 0.3]
+    second.encoder_ticks = [2, 2, 2, 2]
+
+    watchdog.update_telemetry(first, now_s=0.0)
+    watchdog.update_telemetry(second, now_s=1.1)
+    status = watchdog.diagnostic(now_s=2.0)
+
+    assert status.level == LEVEL_OK
+    assert watchdog.ever_moved is True
+    assert _values(status)["last_motion_source"] == "/drivetrain/telemetry"

--- a/src/lunabot_bringup/test/test_movement_watchdog.py
+++ b/src/lunabot_bringup/test/test_movement_watchdog.py
@@ -1,5 +1,6 @@
 """Unit tests for the advisory movement watchdog."""
 
+import importlib
 import math
 import sys
 import types
@@ -107,18 +108,17 @@ except ModuleNotFoundError:
     _install_ros_stubs()
     from nav_msgs.msg import Odometry
 
-from lunabot_bringup.movement_watchdog import (  # noqa: E402
-    LEVEL_ERROR,
-    LEVEL_OK,
-    LEVEL_STALE,
-    LEVEL_WARN,
-    MovementWatchdog,
-    MovementWatchdogConfig,
-)
-from lunabot_interfaces.msg import (  # noqa: E402
-    DrivetrainStatus,
-    DrivetrainTelemetry,
-)
+movement_watchdog = importlib.import_module("lunabot_bringup.movement_watchdog")
+lunabot_interface_msgs = importlib.import_module("lunabot_interfaces.msg")
+
+LEVEL_ERROR = movement_watchdog.LEVEL_ERROR
+LEVEL_OK = movement_watchdog.LEVEL_OK
+LEVEL_STALE = movement_watchdog.LEVEL_STALE
+LEVEL_WARN = movement_watchdog.LEVEL_WARN
+MovementWatchdog = movement_watchdog.MovementWatchdog
+MovementWatchdogConfig = movement_watchdog.MovementWatchdogConfig
+DrivetrainStatus = lunabot_interface_msgs.DrivetrainStatus
+DrivetrainTelemetry = lunabot_interface_msgs.DrivetrainTelemetry
 
 
 def _watchdog(**config_overrides):
@@ -199,6 +199,20 @@ def test_sustained_odom_translation_confirms_movement_before_timeout():
     assert watchdog.ever_moved is True
     assert _values(status)["last_motion_source"] == "/odometry/local"
     assert _values(status)["seconds_since_confirmed_motion"] == "5.90"
+
+
+def test_pre_arm_motion_is_not_counted_after_arming():
+    watchdog = _watchdog()
+    watchdog.update_odom("/odometry/local", _odom(x=0.00), now_s=0.0)
+    watchdog.update_odom("/odometry/local", _odom(x=0.20), now_s=2.0)
+
+    watchdog.set_armed(True, now_s=3.0)
+    watchdog.update_odom("/odometry/local", _odom(x=0.20), now_s=3.1)
+    status = watchdog.diagnostic(now_s=3.2)
+
+    assert watchdog.ever_moved is False
+    assert status.level == LEVEL_OK
+    assert status.message == "Awaiting confirmed rover movement"
 
 
 def test_sustained_rotation_counts_as_movement():

--- a/src/lunabot_bringup/test/test_rover_diagnostics_launch.py
+++ b/src/lunabot_bringup/test/test_rover_diagnostics_launch.py
@@ -1,0 +1,46 @@
+"""Tests for the rover diagnostics launch file."""
+
+import importlib.util
+from pathlib import Path
+
+from launch.actions import DeclareLaunchArgument
+from launch_ros.actions import Node
+
+
+def _load_launch_module():
+    launch_path = (
+        Path(__file__).resolve().parents[1] / "launch" / "rover_diagnostics.launch.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "rover_diagnostics_launch",
+        launch_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_rover_diagnostics_launch_starts_movement_watchdog():
+    module = _load_launch_module()
+    description = module.generate_launch_description()
+
+    declared_arguments = [
+        entity.name
+        for entity in description.entities
+        if isinstance(entity, DeclareLaunchArgument)
+    ]
+    nodes = [entity for entity in description.entities if isinstance(entity, Node)]
+
+    assert declared_arguments == [
+        "stale_timeout_s",
+        "publish_hz",
+        "movement_timeout_s",
+        "movement_warn_s",
+        "movement_auto_arm",
+    ]
+    assert [node.node_executable for node in nodes] == [
+        "rover_diagnostics",
+        "movement_watchdog",
+    ]


### PR DESCRIPTION
## Summary

Adds a standalone advisory movement watchdog for the 5-minute movement anomaly rule. The node lives in `lunabot_bringup`, arms via `/mission/movement_watchdog/armed`, and publishes `mission/movement_watchdog` status on `/diagnostics`.

Movement evidence is physical only: `/odometry/local` is preferred, then `/odom`, `/odom_wheels`, and finally `/drivetrain/telemetry`. Command intent and drivetrain `STATE_DRIVING` are context only and do not reset the watchdog.

## Changes

- Added `lunabot_bringup.movement_watchdog` with `std_srvs/SetBool` arming and advisory diagnostics.
- Wired the watchdog into `rover_diagnostics.launch.py` and `mission_shuttle_evidence.launch.py`, with auto-arming disabled by default.
- Added `/odometry/local` to minimal evidence, and `/odometry/local` plus `/odom_wheels` to debug/heavy profiles.
- Added unit and launch coverage for watchdog timing, source priority, stale evidence, telemetry fallback, and evidence launch wiring.

## Local evidence

- `ruff check ...` passed.
- `ruff format --check ...` passed.
- `python3 -m compileall -q ...` passed.
- `PYTHONPATH=src/lunabot_bringup pytest src/lunabot_bringup/test/test_movement_watchdog.py src/lunabot_bringup/test/test_mission_evidence.py` passed: 19 tests.
- ROS launch tests could not run on the Mac development machine because ROS `launch` Python modules are not installed there.

## Jetson evidence

Validated on `innex1-jetson` at `b6348b2` in a detached worktree:

- `source /opt/ros/humble/setup.bash && colcon build --packages-up-to lunabot_bringup --symlink-install --event-handlers console_direct+` passed: 12 packages finished.
- `python3 -m pytest -q src/lunabot_bringup/test/test_movement_watchdog.py src/lunabot_bringup/test/test_mission_evidence.py src/lunabot_bringup/test/test_rover_diagnostics_launch.py src/lunabot_bringup/test/test_mission_shuttle_evidence_launch.py` passed: 21 tests.
- `rover_diagnostics.launch.py` smoke test confirmed `/mission/movement_watchdog/armed` exists and `/diagnostics` includes `mission/movement_watchdog`.
- Synthetic `/odometry/local` evidence confirmed `ever_moved=True`, `selected_source=/odometry/local`, and `last_motion_source=/odometry/local` after arming.
- Source priority checked: `/odom` is selected when it is the only fresh source, then `/odometry/local` supersedes it when fresh.

Bench safety: no drivetrain commands were sent and no physical motion was requested. Movement evidence checks used synthetic `nav_msgs/Odometry` only, and validation ROS processes were stopped afterwards.

## Review notes for humans

- The watchdog publishes directly to `/diagnostics` alongside `rover_diagnostics`. Multiple publishers on `/diagnostics` are normal ROS practice, but downstream tooling should not assume a single publisher.
- This adds a new external service, `/mission/movement_watchdog/armed`. The current `.github/contracts/interface_contracts.json` appears focused on topics/TF, so this service is not captured there yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds an advisory movement watchdog to lunabot_bringup that monitors physical movement and publishes diagnostic advisories when anomalies are detected.

What changed
- New movement_watchdog node
  - Publishes advisory DiagnosticArray on /diagnostics
  - Arms/disarms via /mission/movement_watchdog/armed (std_srvs/SetBool)
  - Monitors physical telemetry with prioritized sources (prefers /odometry/local, then /odom, /odom_wheels, then drivetrain telemetry fallback)
  - Reports OK/WARN/ERROR/STALE based on evidence freshness and a configurable timeout (default 5 minutes); command intent and STATE_DRIVING are only contextual and do not reset the watchdog

- Launch and config updates
  - movement_watchdog added to rover_diagnostics.launch.py and mission_shuttle_evidence.launch.py (auto-arm disabled by default)
  - Added launch args for movement timeout, warning threshold, and auto-arm
  - rosbag evidence profiles updated: minimal includes /odometry/local; debug/heavy include /odometry/local and /odom_wheels

- Tests and packaging
  - New unit tests and launch tests covering timing, source priority, stale evidence handling, telemetry fallback, and pre-arm behavior
  - Added console entry point for the node and updated package.xml to include nav_msgs and std_srvs
  - Interface contract tooling extended to detect Python service servers and the repository’s interface contracts file updated to include /mission/movement_watchdog/armed

Validation
- Local: lint/format/byte-compile checks and 19 pytest unit tests passed
- Jetson: colcon build succeeded; 21 pytest tests including launch tests passed; smoke tests confirmed service/topic presence and correct source selection using synthetic odometry

Notes
- The watchdog publishes directly to /diagnostics alongside existing diagnostics (multiple publishers expected).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->