### PR TITLE
[codex] Implement arena wall exclusion filter

### DIFF
--- a/docs/active_runtime_paths.md
+++ b/docs/active_runtime_paths.md
@@ -21,6 +21,8 @@ ros2 launch lunabot_bringup navigation.launch.py
 
 - `lunabot_bringup/localisation.launch.py`
 - `lunabot_bringup/nav2_navigation.launch.py`
+- `lunabot_perception/arena_boundary_filter` for front/rear camera clouds and
+  Ouster clouds
 - `lunabot_perception/crater_detection`
 - `lunabot_bringup/navigate_to_pose_gate`
 - optional joystick teleop and `twist_mux`
@@ -135,8 +137,8 @@ These are still useful, but they are not the default hardware-week path:
 
 ## Current Simplification Notes
 
-- `lunabot_perception` is active because `navigation.launch.py` starts
-  `crater_detection`.
+- `lunabot_perception` is active because `navigation.launch.py` starts the
+  arena boundary filters and `crater_detection`.
 - `lunabot_safety` is active because mission evidence and hardware motion use
   the E-stop to motion-inhibit bridge.
 - `lunabot_navigation` owns Nav2 config and behaviour tree assets, not custom

--- a/docs/mission_evidence_workflow.md
+++ b/docs/mission_evidence_workflow.md
@@ -94,10 +94,11 @@ Use `minimal` for normal mission evidence. It records operator state, safety
 state, diagnostics, status topics, TF, and command topics.
 
 Use `debug` when a run failed and you need navigation state. It adds odometry,
-scan, map, costmaps, and action status.
+scan, map, costmaps, action status, and wall-excluded point-cloud topics.
 
 Use `heavy` only for short perception investigations. It records raw image and
-point-cloud topics and can use disk space quickly.
+point-cloud topics alongside the filtered autonomy inputs and can use disk
+space quickly.
 
 ## Sensor Claims
 
@@ -107,7 +108,8 @@ the run note:
 
 - autonomy used onboard sensor data and onboard software;
 - arena walls were not used for mapping, localisation, autonomous navigation or
-  collision avoidance;
+  collision avoidance; wall-capable point clouds were filtered before Nav2,
+  collision monitor, and crater detection consumed them;
 - no GPS, compass heading, ultrasonic proximity sensing or touch sensing for
   obstacle avoidance was used;
 - no obstacle-location upload was made after seeing the arena;

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -13,7 +13,7 @@
 | `lunabot_description` | ament_cmake | URDF/Xacro assets only — robot model |
 | `lunabot_simulation` | ament_cmake | Gazebo worlds (`moon_yard.sdf`), sim launch |
 | `lunabot_teleop` | ament_python | Joystick control |
-| `lunabot_perception` | ament_python | `crater_detection` — publishes `/crater_grid` for Nav2 costmaps |
+| `lunabot_perception` | ament_python | `arena_boundary_filter` — publishes wall-excluded point clouds; `crater_detection` — publishes `/crater_grid` for Nav2 costmaps |
 | `lunabot_safety` | ament_python | `estop_node` — subscribes `/safety/estop` and `/safety/reset_motion_inhibit`, publishes `/safety/motion_inhibit` |
 
 ## External (vendored)

--- a/src/lunabot_bringup/config/preflight_checks.yaml
+++ b/src/lunabot_bringup/config/preflight_checks.yaml
@@ -36,7 +36,19 @@ preflight:
       type: sensor_msgs/msg/PointCloud2
       min_messages: 1
       critical: false
+    - name: /perception/arena_boundary/camera_front/points
+      type: sensor_msgs/msg/PointCloud2
+      min_messages: 1
+      critical: true
+    - name: /perception/arena_boundary/camera_rear/points
+      type: sensor_msgs/msg/PointCloud2
+      min_messages: 1
+      critical: false
     - name: /ouster/points
+      type: sensor_msgs/msg/PointCloud2
+      min_messages: 1
+      critical: false
+    - name: /perception/arena_boundary/ouster/points
       type: sensor_msgs/msg/PointCloud2
       min_messages: 1
       critical: false
@@ -92,6 +104,12 @@ preflight:
     - name: controller_server
       critical: true
       phases: [runtime]
+    - name: arena_boundary_filter_camera_front
+      critical: true
+    - name: arena_boundary_filter_camera_rear
+      critical: false
+    - name: arena_boundary_filter_ouster
+      critical: false
     - name: rtabmap
       critical: false
     - name: start_zone_localiser

--- a/src/lunabot_bringup/config/preflight_checks_dry_run.yaml
+++ b/src/lunabot_bringup/config/preflight_checks_dry_run.yaml
@@ -37,14 +37,26 @@ preflight:
       type: sensor_msgs/msg/PointCloud2
       min_messages: 1
       critical: false
+    - name: /perception/arena_boundary/camera_front/points
+      type: sensor_msgs/msg/PointCloud2
+      min_messages: 1
+      critical: true
+    - name: /perception/arena_boundary/camera_rear/points
+      type: sensor_msgs/msg/PointCloud2
+      min_messages: 1
+      critical: false
     - name: /ouster/points
+      type: sensor_msgs/msg/PointCloud2
+      min_messages: 1
+      critical: true
+    - name: /perception/arena_boundary/ouster/points
       type: sensor_msgs/msg/PointCloud2
       min_messages: 1
       critical: true
     - name: /map
       type: nav_msgs/msg/OccupancyGrid
       min_messages: 1
-      critical: true
+      critical: false
       reliability: reliable
       durability: transient_local
     - name: /odometry/local
@@ -112,6 +124,12 @@ preflight:
     - name: controller_server
       critical: true
       phases: [runtime]
+    - name: arena_boundary_filter_camera_front
+      critical: true
+    - name: arena_boundary_filter_camera_rear
+      critical: false
+    - name: arena_boundary_filter_ouster
+      critical: true
     - name: rtabmap
       critical: false
     - name: start_zone_localiser

--- a/src/lunabot_bringup/config/preflight_checks_lidar_debug.yaml
+++ b/src/lunabot_bringup/config/preflight_checks_lidar_debug.yaml
@@ -36,14 +36,26 @@ preflight:
       type: sensor_msgs/msg/PointCloud2
       min_messages: 1
       critical: false
+    - name: /perception/arena_boundary/camera_front/points
+      type: sensor_msgs/msg/PointCloud2
+      min_messages: 1
+      critical: false
+    - name: /perception/arena_boundary/camera_rear/points
+      type: sensor_msgs/msg/PointCloud2
+      min_messages: 1
+      critical: false
     - name: /ouster/points
+      type: sensor_msgs/msg/PointCloud2
+      min_messages: 1
+      critical: true
+    - name: /perception/arena_boundary/ouster/points
       type: sensor_msgs/msg/PointCloud2
       min_messages: 1
       critical: true
     - name: /map
       type: nav_msgs/msg/OccupancyGrid
       min_messages: 1
-      critical: true
+      critical: false
       reliability: reliable
       durability: transient_local
     - name: /odometry/local
@@ -86,6 +98,12 @@ preflight:
     - name: controller_server
       critical: true
       phases: [runtime]
+    - name: arena_boundary_filter_camera_front
+      critical: false
+    - name: arena_boundary_filter_camera_rear
+      critical: false
+    - name: arena_boundary_filter_ouster
+      critical: true
     - name: rtabmap
       critical: false
     - name: planner_server

--- a/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
+++ b/src/lunabot_bringup/config/rosbag_evidence_profiles.yaml
@@ -52,6 +52,9 @@ profiles:
       - /global_costmap/costmap
       - /local_costmap/costmap
       - /navigate_to_pose_gate/_action/status
+      - /perception/arena_boundary/camera_front/points
+      - /perception/arena_boundary/camera_rear/points
+      - /perception/arena_boundary/ouster/points
   heavy:
     description: Deliberate high-bandwidth capture for short perception investigations only.
     topics:
@@ -83,6 +86,9 @@ profiles:
       - /global_costmap/costmap
       - /local_costmap/costmap
       - /navigate_to_pose_gate/_action/status
+      - /perception/arena_boundary/camera_front/points
+      - /perception/arena_boundary/camera_rear/points
+      - /perception/arena_boundary/ouster/points
       - /camera/image_raw
       - /camera/depth/image_raw
       - /camera/camera_info

--- a/src/lunabot_bringup/config/runtime_profiles.yaml
+++ b/src/lunabot_bringup/config/runtime_profiles.yaml
@@ -39,8 +39,8 @@ profiles:
       - /map
       - /local_costmap/costmap
       - /global_costmap/costmap
-      - /ouster/points
-      - /camera_front/points
+      - /perception/arena_boundary/ouster/points
+      - /perception/arena_boundary/camera_front/points
     telemetry_topics:
       - name: /mission/state
         max_hz: 1.0

--- a/src/lunabot_bringup/launch/navigation.launch.py
+++ b/src/lunabot_bringup/launch/navigation.launch.py
@@ -96,6 +96,30 @@ def _select_localiser_cmd_vel_topic(enable_teleop):
     )
 
 
+def _arena_boundary_filter_node(source_name, input_topic, output_topic, use_sim_time):
+    """Return one wall-exclusion filter for an autonomy sensor stream."""
+    return Node(
+        package="lunabot_perception",
+        executable="arena_boundary_filter",
+        name=f"arena_boundary_filter_{source_name}",
+        output="screen",
+        parameters=[
+            {"use_sim_time": use_sim_time},
+            {
+                "source_name": source_name,
+                "input_topic": input_topic,
+                "output_topic": output_topic,
+                "target_frame": "odom",
+                "arena_min_x": -1.0,
+                "arena_max_x": 6.9,
+                "arena_min_y": -3.3,
+                "arena_max_y": 1.1,
+                "wall_exclusion_margin_m": 0.35,
+            },
+        ],
+    )
+
+
 def _handle_preflight_exit(
     event,
     _context,
@@ -198,8 +222,34 @@ def generate_launch_description():
         executable="crater_detection",
         name="crater_detection",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}],
+        parameters=[
+            {"use_sim_time": use_sim_time},
+            {
+                "input_cloud_topic": ("/perception/arena_boundary/camera_front/points"),
+            },
+        ],
     )
+
+    arena_boundary_filters = [
+        _arena_boundary_filter_node(
+            "camera_front",
+            "/camera_front/points",
+            "/perception/arena_boundary/camera_front/points",
+            use_sim_time,
+        ),
+        _arena_boundary_filter_node(
+            "camera_rear",
+            "/camera_rear/points",
+            "/perception/arena_boundary/camera_rear/points",
+            use_sim_time,
+        ),
+        _arena_boundary_filter_node(
+            "ouster",
+            "/ouster/points",
+            "/perception/arena_boundary/ouster/points",
+            use_sim_time,
+        ),
+    ]
 
     navigate_to_pose_gate = Node(
         package="lunabot_bringup",
@@ -437,6 +487,7 @@ def generate_launch_description():
                 ),
             ),
             localisation_launch,
+            *arena_boundary_filters,
             crater_detection,
             navigate_to_pose_gate,
             teleop_launch,

--- a/src/lunabot_bringup/rviz/navigation.rviz
+++ b/src/lunabot_bringup/rviz/navigation.rviz
@@ -56,7 +56,7 @@ Visualization Manager:
         Value: /local_costmap/costmap
     - Class: rviz_default_plugins/PointCloud2
       Enabled: true
-      Name: Ouster Points
+      Name: Filtered Ouster Points
       Position Transformer: XYZ
       Size (Pixels): 2
       Style: Flat Squares
@@ -64,7 +64,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Best Effort
-        Value: /ouster/points
+        Value: /perception/arena_boundary/ouster/points
       Use Fixed Frame: true
     - Class: rviz_default_plugins/Image
       Enabled: true

--- a/src/lunabot_bringup/test/test_navigation_launch.py
+++ b/src/lunabot_bringup/test/test_navigation_launch.py
@@ -1,0 +1,106 @@
+"""Unit tests for the top-level navigation launch wiring."""
+
+import importlib.util
+from pathlib import Path
+
+from launch import LaunchContext
+from launch_ros.actions import Node
+
+
+def _load_launch_module():
+    """Import navigation.launch.py as a Python module."""
+    launch_path = (
+        Path(__file__).resolve().parents[1] / "launch" / "navigation.launch.py"
+    )
+    spec = importlib.util.spec_from_file_location("navigation_launch", launch_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _node_named(description, name: str) -> Node:
+    """Return a node by configured launch name."""
+    matches = [
+        entity
+        for entity in description.entities
+        if isinstance(entity, Node) and entity.__dict__.get("_Node__node_name") == name
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _normalised_parameters(node: Node) -> dict:
+    """Return node parameter dictionaries with launch substitutions resolved."""
+    context = LaunchContext()
+    context.launch_configurations["use_sim_time"] = "true"
+    params = {}
+    for param_group in node.__dict__["_Node__parameters"]:
+        for key, value in param_group.items():
+            normalised_key = "".join(part.perform(context) for part in key)
+            if isinstance(value, tuple):
+                normalised_value = "".join(
+                    part.perform(context) for part in value
+                ).splitlines()[0]
+            else:
+                normalised_value = value
+            params[normalised_key] = normalised_value
+    return params
+
+
+def test_navigation_launch_starts_wall_exclusion_filters(monkeypatch):
+    """Raw point clouds are filtered before autonomy consumers start."""
+    module = _load_launch_module()
+    monkeypatch.setattr(
+        module,
+        "get_package_share_directory",
+        lambda package: f"/tmp/{package}",
+    )
+
+    description = module.generate_launch_description()
+
+    for name, input_topic, output_topic in (
+        (
+            "arena_boundary_filter_camera_front",
+            "/camera_front/points",
+            "/perception/arena_boundary/camera_front/points",
+        ),
+        (
+            "arena_boundary_filter_camera_rear",
+            "/camera_rear/points",
+            "/perception/arena_boundary/camera_rear/points",
+        ),
+        (
+            "arena_boundary_filter_ouster",
+            "/ouster/points",
+            "/perception/arena_boundary/ouster/points",
+        ),
+    ):
+        node = _node_named(description, name)
+        params = _normalised_parameters(node)
+        assert node.__dict__["_Node__package"] == "lunabot_perception"
+        assert node.__dict__["_Node__node_executable"] == "arena_boundary_filter"
+        assert params["input_topic"] == input_topic
+        assert params["output_topic"] == output_topic
+        assert params["target_frame"] == "odom"
+
+
+def test_navigation_launch_feeds_crater_detection_from_filtered_front_cloud(
+    monkeypatch,
+):
+    """Crater detection consumes the filtered front point cloud."""
+    module = _load_launch_module()
+    monkeypatch.setattr(
+        module,
+        "get_package_share_directory",
+        lambda package: f"/tmp/{package}",
+    )
+
+    description = module.generate_launch_description()
+    crater_detection = _node_named(description, "crater_detection")
+
+    assert crater_detection.__dict__["_Node__node_executable"] == "crater_detection"
+    assert _normalised_parameters(crater_detection)["input_cloud_topic"] == (
+        "/perception/arena_boundary/camera_front/points"
+    )

--- a/src/lunabot_localisation/README.md
+++ b/src/lunabot_localisation/README.md
@@ -8,18 +8,21 @@ The localisation pipeline has two layers:
 
 1. **Local EKF** (`robot_localization`): fuses wheel odometry + IMU to produce
   a smooth `odom -> base_footprint` transform and `/odometry/local`.
-2. **RTAB-Map SLAM** (`rtabmap_slam`): subscribes to RGB-D images from the
-  front depth camera and `/odometry/local`. Publishes the `map -> odom`
-  correction via visual loop closure and AprilTag landmark constraints.
+2. **Optional RTAB-Map SLAM** (`rtabmap_slam`): when
+  `enable_visual_slam:=true`, subscribes to RGB-D images from the front depth
+  camera and `/odometry/local`. It publishes the `map -> odom` correction via
+  visual loop closure and AprilTag landmark constraints.
 
-The global EKF has been removed. RTAB-Map handles drift correction directly
-through its pose graph optimiser, which is the same pattern used by multiple
-Lunabotics teams (College of DuPage, Chicago Robotics/EDT).
+The competition default keeps `enable_visual_slam:=false` and publishes an
+identity `map -> odom` transform. That avoids using arena wall features for
+localisation while the local EKF, start-zone AprilTag gate, and odometry frame
+remain available.
 
 ## Competition legality
 
 The localisation path must be explainable to inspection judges. It uses wheel
-odometry, IMU data, front RGB-D data, AprilTags and TF. Future LiDAR-inertial
+odometry, IMU data, AprilTags and TF. Experimental visual SLAM is opt-in until
+we can prove its inputs do not use arena-wall features. Future LiDAR-inertial
 work may use the OS1-128 after wall-region filtering is in place.
 
 It must not use GPS, compass heading, ultrasonic proximity sensing, touch
@@ -30,8 +33,9 @@ uploaded obstacle locations.
 
 The `start_zone_localiser` node spins in the start zone to acquire a stable
 AprilTag lock. Once the lock is stable, it publishes a READY status so that
-travel autonomy may begin. RTAB-Map receives the same AprilTag detections as
-landmarks, aligning the map frame with the known tag position.
+travel autonomy may begin. When visual SLAM is enabled for experiments,
+RTAB-Map receives the same AprilTag detections as landmarks, aligning the map
+frame with the known tag position.
 
 ## Key files
 

--- a/src/lunabot_localisation/launch/localisation.launch.py
+++ b/src/lunabot_localisation/launch/localisation.launch.py
@@ -81,6 +81,7 @@ def _validate_boolean_launch_arguments(context):
     """Reject invalid boolean-style launch argument values early."""
     for argument_name in (
         "lidar_costmap_phase",
+        "enable_visual_slam",
         "use_sim_time",
         "enable_apriltag_debug",
         "sync_sim_camera_info",
@@ -111,6 +112,7 @@ def generate_launch_description():
         "start_zone_localisation.yaml",
     )
     lidar_costmap_phase = LaunchConfiguration("lidar_costmap_phase")
+    enable_visual_slam = LaunchConfiguration("enable_visual_slam")
     use_sim_time = LaunchConfiguration("use_sim_time")
     enable_apriltag_debug = LaunchConfiguration("enable_apriltag_debug")
     cmd_vel_topic = LaunchConfiguration("cmd_vel_topic")
@@ -122,6 +124,24 @@ def generate_launch_description():
     tag_map_yaw = LaunchConfiguration("tag_map_yaw")
 
     normal_mode = IfCondition(_is_falsey(lidar_costmap_phase))
+    visual_slam_condition = IfCondition(
+        PythonExpression(
+            [
+                _is_falsey(lidar_costmap_phase),
+                " and ",
+                _is_truthy(enable_visual_slam),
+            ]
+        )
+    )
+    identity_map_to_odom_condition = IfCondition(
+        PythonExpression(
+            [
+                _is_truthy(lidar_costmap_phase),
+                " or ",
+                _is_falsey(enable_visual_slam),
+            ]
+        )
+    )
     apriltag_debug_condition = IfCondition(
         PythonExpression(
             [
@@ -151,6 +171,14 @@ def generate_launch_description():
                 "use_sim_time",
                 default_value="true",
                 description=("Use /clock instead of wall time for all launched nodes."),
+            ),
+            DeclareLaunchArgument(
+                "enable_visual_slam",
+                default_value="false",
+                description=(
+                    "Enable RTAB-Map RGB-D SLAM. Keep false for the "
+                    "wall-excluded competition autonomy path."
+                ),
             ),
             DeclareLaunchArgument(
                 "enable_apriltag_debug",
@@ -240,7 +268,7 @@ def generate_launch_description():
                     "--child-frame-id",
                     "odom",
                 ],
-                condition=IfCondition(_is_truthy(lidar_costmap_phase)),
+                condition=identity_map_to_odom_condition,
             ),
             # --- RTAB-Map SLAM: map -> odom via loop closure ---
             Node(
@@ -258,7 +286,7 @@ def generate_launch_description():
                     ("tag_detections", "/camera_front/tags"),
                 ],
                 arguments=["-d"],
-                condition=normal_mode,
+                condition=visual_slam_condition,
             ),
             # --- AprilTag detector ---
             Node(

--- a/src/lunabot_localisation/test/test_localisation_launch.py
+++ b/src/lunabot_localisation/test/test_localisation_launch.py
@@ -23,6 +23,26 @@ def _load_launch_module():
     return module
 
 
+def _condition_text(condition) -> str:
+    """Return launch condition substitutions as a readable string."""
+    return _substitution_text(
+        condition.__dict__.get("_IfCondition__predicate_expression", [])
+    )
+
+
+def _substitution_text(value) -> str:
+    """Return nested launch substitution internals as readable text."""
+    if isinstance(value, list):
+        return "".join(_substitution_text(part) for part in value)
+    if "_TextSubstitution__text" in value.__dict__:
+        return value.__dict__["_TextSubstitution__text"]
+    if "_LaunchConfiguration__variable_name" in value.__dict__:
+        return _substitution_text(value.__dict__["_LaunchConfiguration__variable_name"])
+    if "_PythonExpression__expression" in value.__dict__:
+        return _substitution_text(value.__dict__["_PythonExpression__expression"])
+    return str(value)
+
+
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
@@ -101,6 +121,7 @@ def test_validate_boolean_launch_arguments_rejects_invalid_launch_value():
     launch_module = _load_launch_module()
     context = LaunchContext()
     context.launch_configurations["lidar_costmap_phase"] = "treu"
+    context.launch_configurations["enable_visual_slam"] = "false"
     context.launch_configurations["use_sim_time"] = "true"
     context.launch_configurations["enable_apriltag_debug"] = "false"
     context.launch_configurations["sync_sim_camera_info"] = "false"
@@ -183,6 +204,32 @@ def test_rtabmap_node_present_in_launch_description(
     ]
 
     assert len(rtabmap_nodes) == 1
+    assert "enable_visual_slam" in _condition_text(rtabmap_nodes[0].condition)
+
+
+def test_identity_map_to_odom_runs_when_visual_slam_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The default competition path still has a map->odom TF without RTAB-Map."""
+    launch_module = _load_launch_module()
+    monkeypatch.setattr(
+        launch_module,
+        "get_package_share_directory",
+        lambda _package: "/tmp/lunabot_localisation",
+    )
+    description = launch_module.generate_launch_description()
+
+    static_tf_nodes = [
+        entity
+        for entity in description.entities
+        if isinstance(entity, Node)
+        and entity.__dict__.get("_Node__package") == "tf2_ros"
+        and "--child-frame-id" in entity.__dict__.get("_Node__arguments", [])
+        and "odom" in entity.__dict__.get("_Node__arguments", [])
+    ]
+
+    assert len(static_tf_nodes) == 1
+    assert "enable_visual_slam" in _condition_text(static_tf_nodes[0].condition)
 
 
 @pytest.mark.parametrize("config_name", ["ekf.yaml", "ekf_lidar_phase.yaml"])

--- a/src/lunabot_navigation/README.md
+++ b/src/lunabot_navigation/README.md
@@ -13,10 +13,14 @@ costmaps.
 ## Inputs this package depends on
 
 At runtime, navigation expects:
-- fused odometry from localisation (`/odometry/filtered`),
+- fused odometry from localisation (`/odometry/local`),
 - TF chain including `map`, `odom`, `base_footprint`,
-- direct sensor observation sources used by costmaps,
+- wall-excluded sensor observation sources under `/perception/arena_boundary/`,
 - configured mission or operator navigation goals.
+
+Raw camera and LiDAR point clouds are not autonomy inputs. The boundary filter
+in `lunabot_perception` republishes legal arena-interior clouds before Nav2
+costmaps and collision monitor consume them.
 
 ## Key files
 

--- a/src/lunabot_navigation/config/collision_monitor.yaml
+++ b/src/lunabot_navigation/config/collision_monitor.yaml
@@ -1,8 +1,8 @@
 # Nav2 Collision Monitor — last-resort velocity safety layer
 #
 # Sits between the Nav2 velocity output and the robot/bridge. If obstacle
-# points from the front depth camera appear inside the stop or slowdown
-# polygons, the commanded velocity is reduced or zeroed.
+# points from the wall-excluded depth camera topics appear inside the stop or
+# slowdown polygons, the commanded velocity is reduced or zeroed.
 #
 # Polygon coordinates are in base_footprint frame (X forward, Y left).
 # Robot approximate envelope: ~0.40m long, ~0.36m wide (wheel-to-wheel).
@@ -44,14 +44,14 @@ collision_monitor:
 
     front_camera:
       type: "pointcloud"
-      topic: "/camera_front/points"
+      topic: "/perception/arena_boundary/camera_front/points"
       min_height: 0.10
       max_height: 0.60
       enabled: true
 
     rear_camera:
       type: "pointcloud"
-      topic: "/camera_rear/points"
+      topic: "/perception/arena_boundary/camera_rear/points"
       min_height: 0.10
       max_height: 0.60
       enabled: true

--- a/src/lunabot_navigation/config/nav2_params.yaml
+++ b/src/lunabot_navigation/config/nav2_params.yaml
@@ -94,7 +94,7 @@ global_costmap:
         enabled: true
         observation_sources: camera_front_points camera_rear_points
         camera_front_points:
-          topic: /camera_front/points
+          topic: /perception/arena_boundary/camera_front/points
           data_type: "PointCloud2"
           min_obstacle_height: 0.15
           max_obstacle_height: 0.8
@@ -105,7 +105,7 @@ global_costmap:
           obstacle_max_range: 2.5
           obstacle_min_range: 0.0
         camera_rear_points:
-          topic: /camera_rear/points
+          topic: /perception/arena_boundary/camera_rear/points
           data_type: "PointCloud2"
           min_obstacle_height: 0.15
           max_obstacle_height: 0.8
@@ -127,7 +127,7 @@ global_costmap:
         origin_z: 0.0
         mark_threshold: 2
         lidar_points:
-          topic: /ouster/points
+          topic: /perception/arena_boundary/ouster/points
           data_type: "PointCloud2"
           min_obstacle_height: 0.10
           max_obstacle_height: 0.80
@@ -177,7 +177,7 @@ local_costmap:
         enabled: true
         observation_sources: camera_front_points camera_rear_points
         camera_front_points:
-          topic: /camera_front/points
+          topic: /perception/arena_boundary/camera_front/points
           data_type: "PointCloud2"
           min_obstacle_height: 0.15
           max_obstacle_height: 0.8
@@ -188,7 +188,7 @@ local_costmap:
           obstacle_max_range: 2.5
           obstacle_min_range: 0.0
         camera_rear_points:
-          topic: /camera_rear/points
+          topic: /perception/arena_boundary/camera_rear/points
           data_type: "PointCloud2"
           min_obstacle_height: 0.15
           max_obstacle_height: 0.8
@@ -210,7 +210,7 @@ local_costmap:
         origin_z: 0.0
         mark_threshold: 2
         lidar_points:
-          topic: /ouster/points
+          topic: /perception/arena_boundary/ouster/points
           data_type: "PointCloud2"
           min_obstacle_height: 0.10
           max_obstacle_height: 0.80

--- a/src/lunabot_navigation/test/test_obstacle_avoidance_config.py
+++ b/src/lunabot_navigation/test/test_obstacle_avoidance_config.py
@@ -7,6 +7,14 @@ import yaml
 CONFIG_DIR = Path(__file__).resolve().parents[1] / "config"
 NAV2_PARAMS_PATH = CONFIG_DIR / "nav2_params.yaml"
 COLLISION_MONITOR_PATH = CONFIG_DIR / "collision_monitor.yaml"
+FILTERED_FRONT_TOPIC = "/perception/arena_boundary/camera_front/points"
+FILTERED_REAR_TOPIC = "/perception/arena_boundary/camera_rear/points"
+FILTERED_OUSTER_TOPIC = "/perception/arena_boundary/ouster/points"
+RAW_AUTONOMY_TOPICS = {
+    "/camera_front/points",
+    "/camera_rear/points",
+    "/ouster/points",
+}
 
 
 def _load_yaml(path: Path) -> dict:
@@ -68,13 +76,13 @@ class TestObstacleLayerConfig:
 
     def test_front_depth_camera_topic(self):
         for costmap_key, layer in self.layers:
-            assert layer["camera_front_points"]["topic"] == "/camera_front/points", (
+            assert layer["camera_front_points"]["topic"] == FILTERED_FRONT_TOPIC, (
                 f"{costmap_key}: unexpected front camera topic"
             )
 
     def test_rear_depth_camera_topic(self):
         for costmap_key, layer in self.layers:
-            assert layer["camera_rear_points"]["topic"] == "/camera_rear/points", (
+            assert layer["camera_rear_points"]["topic"] == FILTERED_REAR_TOPIC, (
                 f"{costmap_key}: unexpected rear camera topic"
             )
 
@@ -91,6 +99,40 @@ class TestObstacleLayerConfig:
                 pts = layer[source]
                 assert pts["marking"] is True
                 assert pts["clearing"] is True
+
+
+class TestWallExcludedAutonomyInputs:
+    """Verify autonomy consumers use wall-excluded point-cloud topics."""
+
+    def setup_method(self):
+        self.nav2_config = _load_yaml(NAV2_PARAMS_PATH)
+        self.collision_params = _load_yaml(COLLISION_MONITOR_PATH)["collision_monitor"][
+            "ros__parameters"
+        ]
+
+    def test_nav2_costmaps_do_not_subscribe_to_raw_wall_capable_clouds(self):
+        for key in ("global_costmap", "local_costmap"):
+            params = _costmap_params(self.nav2_config, key)
+            obstacle_layer = params["obstacle_layer"]
+            voxel_layer = params["voxel_layer"]
+            topics = {
+                obstacle_layer["camera_front_points"]["topic"],
+                obstacle_layer["camera_rear_points"]["topic"],
+                voxel_layer["lidar_points"]["topic"],
+            }
+
+            assert topics.isdisjoint(RAW_AUTONOMY_TOPICS)
+            assert FILTERED_FRONT_TOPIC in topics
+            assert FILTERED_REAR_TOPIC in topics
+            assert FILTERED_OUSTER_TOPIC in topics
+
+    def test_collision_monitor_uses_wall_excluded_clouds(self):
+        topics = {
+            self.collision_params[source_name]["topic"]
+            for source_name in self.collision_params["observation_sources"]
+        }
+
+        assert topics == {FILTERED_FRONT_TOPIC, FILTERED_REAR_TOPIC}
 
 
 class TestCraterLayerConfig:
@@ -118,12 +160,12 @@ class TestInflationLayerConfig:
 
     def setup_method(self):
         config = _load_yaml(NAV2_PARAMS_PATH)
-        self.global_inflation = _costmap_params(
-            config, "global_costmap"
-        )["inflation_layer"]
-        self.local_inflation = _costmap_params(
-            config, "local_costmap"
-        )["inflation_layer"]
+        self.global_inflation = _costmap_params(config, "global_costmap")[
+            "inflation_layer"
+        ]
+        self.local_inflation = _costmap_params(config, "local_costmap")[
+            "inflation_layer"
+        ]
 
     def test_inflation_radius_positive(self):
         assert self.global_inflation["inflation_radius"] > 0.0
@@ -142,9 +184,9 @@ class TestInflationLayerConfig:
     def test_local_inflation_matches_controller_scaling_band(self):
         config = _load_yaml(NAV2_PARAMS_PATH)
         controller = config["controller_server"]["ros__parameters"]["FollowPath"]
-        assert controller["cost_scaling_dist"] <= self.local_inflation[
-            "inflation_radius"
-        ]
+        assert (
+            controller["cost_scaling_dist"] <= self.local_inflation["inflation_radius"]
+        )
 
 
 class TestControllerGoalConfig:

--- a/src/lunabot_perception/README.md
+++ b/src/lunabot_perception/README.md
@@ -1,14 +1,58 @@
 # lunabot_perception
 
-Perception nodes for the innex1 rover, currently providing crater
-(negative obstacle) detection for Nav2 costmap integration.
+Perception nodes for the innex1 rover, providing arena wall-exclusion and
+crater (negative obstacle) detection for Nav2 costmap integration.
 
 ## Nodes
 
+### `arena_boundary_filter`
+
+Transforms an incoming `PointCloud2` into the arena frame, rejects returns
+outside the configured legal interior, and republishes the remaining points for
+autonomy consumers. Raw sensor topics stay available for debug and evidence,
+but Nav2, collision monitor, and crater detection should consume only the
+filtered `/perception/arena_boundary/...` topics.
+
+The default arena bounds match the current simulation yard interior:
+`x=[-1.0, 6.9]`, `y=[-3.3, 1.1]`, with a `0.35 m` wall-exclusion margin.
+
+**Run manually (simulation):**
+
+```bash
+ros2 run lunabot_perception arena_boundary_filter --ros-args \
+  -p use_sim_time:=true \
+  -p input_topic:=/camera_front/points \
+  -p output_topic:=/perception/arena_boundary/camera_front/points \
+  -p source_name:=camera_front
+```
+
+**Subscriptions:**
+
+| Topic | Type | Purpose |
+|-------|------|---------|
+| configurable `input_topic` | `sensor_msgs/PointCloud2` | Raw sensor cloud for one source |
+
+**Publications:**
+
+| Topic | Type | Purpose |
+|-------|------|---------|
+| configurable `output_topic` | `sensor_msgs/PointCloud2` | Wall-excluded cloud in `target_frame` |
+| `/diagnostics` | `diagnostic_msgs/DiagnosticArray` | Filter health, counts, rejected ratio and bounds |
+
+**Key parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `target_frame` | `odom` | Arena frame used for boundary checks |
+| `arena_min_x` / `arena_max_x` | `-1.0` / `6.9` | Interior x bounds before margin |
+| `arena_min_y` / `arena_max_y` | `-3.3` / `1.1` | Interior y bounds before margin |
+| `wall_exclusion_margin_m` | `0.35` | Band removed around all arena walls |
+| `stale_timeout_s` | `2.5` | Diagnostic stale threshold |
+
 ### `crater_detection`
 
-Builds a rolling 2.5D elevation grid from the front depth camera's point
-cloud, identifies cells significantly below the local ground plane, and
+Builds a rolling 2.5D elevation grid from the wall-excluded front depth camera
+point cloud, identifies cells significantly below the local ground plane, and
 publishes an `OccupancyGrid` that Nav2's costmap static layer consumes as
 lethal cost.
 
@@ -22,7 +66,7 @@ ros2 run lunabot_perception crater_detection --ros-args -p use_sim_time:=true
 
 | Topic | Type | Purpose |
 |-------|------|---------|
-| `/camera_front/points` | `sensor_msgs/PointCloud2` | Depth camera point cloud |
+| `/perception/arena_boundary/camera_front/points` | `sensor_msgs/PointCloud2` | Wall-excluded front depth camera cloud |
 
 **Publications:**
 
@@ -42,13 +86,15 @@ ros2 run lunabot_perception crater_detection --ros-args -p use_sim_time:=true
 | `inflation_cells` | `2` | Binary dilation radius around detected craters |
 | `target_frame` | `odom` | TF frame for the elevation grid |
 | `fixed_ground_z` | `NaN` | Set to a known floor height; `NaN` uses auto-percentile |
+| `input_cloud_topic` | `/perception/arena_boundary/camera_front/points` | Wall-excluded depth cloud |
 
 ## Nav2 integration
 
 The `crater_layer` in both the global and local costmaps is a
 `nav2_costmap_2d::StaticLayer` subscribing to `/crater_grid`. See
 `lunabot_navigation/config/nav2_params.yaml` for the full costmap plugin
-stack (obstacle layer + crater layer + inflation layer).
+stack. Nav2 obstacle and voxel layers should subscribe to the filtered
+`/perception/arena_boundary/...` point-cloud topics, not raw sensor topics.
 
 ## Common failure modes
 

--- a/src/lunabot_perception/lunabot_perception/arena_boundary_filter.py
+++ b/src/lunabot_perception/lunabot_perception/arena_boundary_filter.py
@@ -1,0 +1,372 @@
+# Copyright 2026 University of Leicester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Filter arena-wall point-cloud returns before autonomy consumers."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import rclpy
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
+from rclpy.duration import Duration
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from rclpy.time import Time
+from sensor_msgs.msg import PointCloud2
+from sensor_msgs_py.point_cloud2 import create_cloud_xyz32, read_points_numpy
+from std_msgs.msg import Header
+from tf2_ros import ExtrapolationException, TransformException
+from tf2_ros.buffer import Buffer
+from tf2_ros.transform_listener import TransformListener
+
+
+@dataclass(frozen=True)
+class ArenaBounds:
+    """Interior arena bounds plus a wall-exclusion margin."""
+
+    min_x: float = -1.0
+    max_x: float = 6.9
+    min_y: float = -3.3
+    max_y: float = 1.1
+    wall_exclusion_margin_m: float = 0.35
+
+    def __post_init__(self) -> None:
+        """Validate that the legal area remains non-empty."""
+        if self.min_x >= self.max_x:
+            raise ValueError("arena_min_x must be less than arena_max_x")
+        if self.min_y >= self.max_y:
+            raise ValueError("arena_min_y must be less than arena_max_y")
+        if self.wall_exclusion_margin_m < 0.0:
+            raise ValueError("wall_exclusion_margin_m must be >= 0")
+        if 2.0 * self.wall_exclusion_margin_m >= (self.max_x - self.min_x):
+            raise ValueError("wall_exclusion_margin_m removes all legal arena width")
+        if 2.0 * self.wall_exclusion_margin_m >= (self.max_y - self.min_y):
+            raise ValueError("wall_exclusion_margin_m removes all legal arena height")
+
+    @property
+    def legal_min_x(self) -> float:
+        """Lowest x coordinate allowed through the filter."""
+        return self.min_x + self.wall_exclusion_margin_m
+
+    @property
+    def legal_max_x(self) -> float:
+        """Highest x coordinate allowed through the filter."""
+        return self.max_x - self.wall_exclusion_margin_m
+
+    @property
+    def legal_min_y(self) -> float:
+        """Lowest y coordinate allowed through the filter."""
+        return self.min_y + self.wall_exclusion_margin_m
+
+    @property
+    def legal_max_y(self) -> float:
+        """Highest y coordinate allowed through the filter."""
+        return self.max_y - self.wall_exclusion_margin_m
+
+
+@dataclass(frozen=True)
+class BoundaryFilterResult:
+    """Filtered points and counts for diagnostics/evidence."""
+
+    points: np.ndarray
+    input_count: int
+    kept_count: int
+    rejected_count: int
+
+    @property
+    def reject_ratio(self) -> float:
+        """Share of finite input points rejected by the boundary filter."""
+        if self.input_count == 0:
+            return 0.0
+        return self.rejected_count / self.input_count
+
+
+def transform_points(
+    points: np.ndarray,
+    translation_xyz: tuple[float, float, float],
+    quaternion_xyzw: tuple[float, float, float, float],
+) -> np.ndarray:
+    """Apply a rigid transform to an Nx3 point array."""
+    if points.ndim != 2 or points.shape[1] != 3:
+        raise ValueError("points must be an Nx3 array")
+    x, y, z, w = quaternion_xyzw
+    norm = np.sqrt((x * x) + (y * y) + (z * z) + (w * w))
+    if norm == 0.0:
+        raise ValueError("quaternion must be non-zero")
+    x /= norm
+    y /= norm
+    z /= norm
+    w /= norm
+    rotation = np.array(
+        [
+            [1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)],
+            [2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)],
+            [2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
+    translation = np.array(translation_xyz, dtype=np.float64)
+    return (rotation @ points.T).T + translation
+
+
+def filter_points_to_arena(
+    points: np.ndarray, bounds: ArenaBounds
+) -> BoundaryFilterResult:
+    """Reject points outside the legal interior of the arena."""
+    if points.ndim != 2 or points.shape[1] != 3:
+        raise ValueError("points must be an Nx3 array")
+
+    finite_mask = np.all(np.isfinite(points), axis=1)
+    finite_points = points[finite_mask]
+    if finite_points.shape[0] == 0:
+        return BoundaryFilterResult(
+            points=np.empty((0, 3), dtype=np.float32),
+            input_count=0,
+            kept_count=0,
+            rejected_count=0,
+        )
+
+    legal_mask = (
+        (finite_points[:, 0] >= bounds.legal_min_x)
+        & (finite_points[:, 0] <= bounds.legal_max_x)
+        & (finite_points[:, 1] >= bounds.legal_min_y)
+        & (finite_points[:, 1] <= bounds.legal_max_y)
+    )
+    filtered = finite_points[legal_mask].astype(np.float32, copy=False)
+    input_count = int(finite_points.shape[0])
+    kept_count = int(filtered.shape[0])
+    return BoundaryFilterResult(
+        points=filtered,
+        input_count=input_count,
+        kept_count=kept_count,
+        rejected_count=input_count - kept_count,
+    )
+
+
+class ArenaBoundaryFilterNode(Node):
+    """Publish a wall-excluded point cloud for navigation/perception consumers."""
+
+    def __init__(self):
+        """Set up TF, cloud I/O, and diagnostics."""
+        super().__init__("arena_boundary_filter")
+
+        self.declare_parameter("input_topic", "/camera_front/points")
+        self.declare_parameter(
+            "output_topic",
+            "/perception/arena_boundary/camera_front/points",
+        )
+        self.declare_parameter("source_name", "camera_front")
+        self.declare_parameter("target_frame", "odom")
+        self.declare_parameter("arena_min_x", -1.0)
+        self.declare_parameter("arena_max_x", 6.9)
+        self.declare_parameter("arena_min_y", -3.3)
+        self.declare_parameter("arena_max_y", 1.1)
+        self.declare_parameter("wall_exclusion_margin_m", 0.35)
+        self.declare_parameter("diagnostic_publish_hz", 1.0)
+        self.declare_parameter("stale_timeout_s", 2.5)
+
+        self.input_topic = self.get_parameter("input_topic").value
+        self.output_topic = self.get_parameter("output_topic").value
+        self.source_name = self.get_parameter("source_name").value
+        self.target_frame = self.get_parameter("target_frame").value
+        self.bounds = ArenaBounds(
+            min_x=self.get_parameter("arena_min_x").value,
+            max_x=self.get_parameter("arena_max_x").value,
+            min_y=self.get_parameter("arena_min_y").value,
+            max_y=self.get_parameter("arena_max_y").value,
+            wall_exclusion_margin_m=self.get_parameter("wall_exclusion_margin_m").value,
+        )
+        self.stale_timeout_s = self.get_parameter("stale_timeout_s").value
+        diagnostic_publish_hz = self.get_parameter("diagnostic_publish_hz").value
+
+        if diagnostic_publish_hz <= 0.0:
+            raise ValueError("diagnostic_publish_hz must be > 0")
+        if self.stale_timeout_s <= 0.0:
+            raise ValueError("stale_timeout_s must be > 0")
+
+        self.tf_buffer = Buffer()
+        self.tf_listener = TransformListener(self.tf_buffer, self)
+        self.last_result: BoundaryFilterResult | None = None
+        self.last_cloud_time: Time | None = None
+        self.last_error = ""
+
+        self.cloud_pub = self.create_publisher(
+            PointCloud2,
+            self.output_topic,
+            qos_profile_sensor_data,
+        )
+        self.diagnostic_pub = self.create_publisher(
+            DiagnosticArray,
+            "/diagnostics",
+            10,
+        )
+        self.create_subscription(
+            PointCloud2,
+            self.input_topic,
+            self._cloud_callback,
+            qos_profile_sensor_data,
+        )
+        self.create_timer(1.0 / diagnostic_publish_hz, self._publish_diagnostics)
+
+        self.get_logger().info(
+            f"Arena boundary filter {self.source_name}: {self.input_topic} -> "
+            f"{self.output_topic} in {self.target_frame}; "
+            f"legal x=[{self.bounds.legal_min_x:.2f}, "
+            f"{self.bounds.legal_max_x:.2f}], "
+            f"y=[{self.bounds.legal_min_y:.2f}, {self.bounds.legal_max_y:.2f}]"
+        )
+
+    def _cloud_callback(self, msg: PointCloud2) -> None:
+        """Transform a point cloud to the arena frame and publish legal points."""
+        tf = self._lookup_cloud_transform(msg)
+        if tf is None:
+            return
+
+        points = read_points_numpy(msg, field_names=["x", "y", "z"], skip_nans=True)
+        if points.size == 0:
+            result = BoundaryFilterResult(
+                points=np.empty((0, 3), dtype=np.float32),
+                input_count=0,
+                kept_count=0,
+                rejected_count=0,
+            )
+        else:
+            q = tf.transform.rotation
+            t = tf.transform.translation
+            points_target = transform_points(
+                points,
+                (t.x, t.y, t.z),
+                (q.x, q.y, q.z, q.w),
+            )
+            result = filter_points_to_arena(points_target, self.bounds)
+
+        header = Header()
+        header.stamp = msg.header.stamp
+        header.frame_id = self.target_frame
+        self.cloud_pub.publish(create_cloud_xyz32(header, result.points.tolist()))
+
+        self.last_result = result
+        self.last_cloud_time = self.get_clock().now()
+        self.last_error = ""
+
+    def _lookup_cloud_transform(self, msg: PointCloud2):
+        """Return the transform for a cloud, tolerating small future TF offsets."""
+        cloud_time = Time.from_msg(msg.header.stamp)
+        try:
+            return self.tf_buffer.lookup_transform(
+                self.target_frame,
+                msg.header.frame_id,
+                cloud_time,
+                timeout=Duration(seconds=0.0),
+            )
+        except ExtrapolationException as e:
+            if "future" not in str(e).lower():
+                self._log_tf_lookup_failure(msg, e)
+                return None
+
+            try:
+                latest_tf = self.tf_buffer.lookup_transform(
+                    self.target_frame,
+                    msg.header.frame_id,
+                    Time(),
+                    timeout=Duration(seconds=0.0),
+                )
+            except TransformException as latest_error:
+                self._log_tf_lookup_failure(msg, latest_error)
+                return None
+
+            self.get_logger().warning(
+                f"TF lookup {msg.header.frame_id} -> {self.target_frame} "
+                f"needed a future transform; using latest available transform: {e}",
+                throttle_duration_sec=5.0,
+            )
+            return latest_tf
+        except TransformException as e:
+            self._log_tf_lookup_failure(msg, e)
+            return None
+
+    def _log_tf_lookup_failure(
+        self, msg: PointCloud2, error: TransformException
+    ) -> None:
+        """Log and remember a throttled TF lookup failure."""
+        self.last_error = str(error)
+        self.get_logger().warning(
+            f"TF lookup {msg.header.frame_id} -> {self.target_frame} failed: {error}",
+            throttle_duration_sec=5.0,
+        )
+
+    def _publish_diagnostics(self) -> None:
+        """Publish filter state and rejection counts for evidence bags."""
+        status = DiagnosticStatus()
+        status.name = f"perception/arena_boundary_filter/{self.source_name}"
+        status.hardware_id = self.source_name
+
+        if self.last_result is None or self.last_cloud_time is None:
+            status.level = DiagnosticStatus.STALE
+            status.message = "No filtered cloud published yet"
+            age_s = float("inf")
+        else:
+            age_s = (self.get_clock().now() - self.last_cloud_time).nanoseconds / 1e9
+            if age_s > self.stale_timeout_s:
+                status.level = DiagnosticStatus.STALE
+                status.message = "No fresh boundary-filtered cloud"
+            elif self.last_error:
+                status.level = DiagnosticStatus.WARN
+                status.message = "TF lookup failure while filtering"
+            else:
+                status.level = DiagnosticStatus.OK
+                status.message = "Filtering wall/out-of-field points"
+
+        result = self.last_result or BoundaryFilterResult(
+            points=np.empty((0, 3), dtype=np.float32),
+            input_count=0,
+            kept_count=0,
+            rejected_count=0,
+        )
+        status.values = [
+            KeyValue(key="input_topic", value=self.input_topic),
+            KeyValue(key="output_topic", value=self.output_topic),
+            KeyValue(key="target_frame", value=self.target_frame),
+            KeyValue(key="input_count", value=str(result.input_count)),
+            KeyValue(key="kept_count", value=str(result.kept_count)),
+            KeyValue(key="rejected_count", value=str(result.rejected_count)),
+            KeyValue(key="reject_ratio", value=f"{result.reject_ratio:.3f}"),
+            KeyValue(key="last_cloud_age_s", value=f"{age_s:.3f}"),
+            KeyValue(key="legal_min_x", value=f"{self.bounds.legal_min_x:.3f}"),
+            KeyValue(key="legal_max_x", value=f"{self.bounds.legal_max_x:.3f}"),
+            KeyValue(key="legal_min_y", value=f"{self.bounds.legal_min_y:.3f}"),
+            KeyValue(key="legal_max_y", value=f"{self.bounds.legal_max_y:.3f}"),
+            KeyValue(
+                key="wall_exclusion_margin_m",
+                value=f"{self.bounds.wall_exclusion_margin_m:.3f}",
+            ),
+        ]
+        if self.last_error:
+            status.values.append(KeyValue(key="last_error", value=self.last_error))
+
+        array = DiagnosticArray()
+        array.header.stamp = self.get_clock().now().to_msg()
+        array.status.append(status)
+        self.diagnostic_pub.publish(array)
+
+
+def main(args=None):
+    """Run the arena boundary filter node."""
+    rclpy.init(args=args)
+    node = ArenaBoundaryFilterNode()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/src/lunabot_perception/lunabot_perception/crater_detection.py
+++ b/src/lunabot_perception/lunabot_perception/crater_detection.py
@@ -26,14 +26,61 @@ from rclpy.qos import (
     qos_profile_sensor_data,
 )
 from rclpy.time import Time
-from scipy.ndimage import binary_dilation
-from scipy.spatial.transform import Rotation
 from sensor_msgs.msg import PointCloud2
 from sensor_msgs_py.point_cloud2 import create_cloud_xyz32, read_points_numpy
 from std_msgs.msg import Header
 from tf2_ros import ExtrapolationException, TransformException
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
+
+
+def _rotation_matrix_from_quaternion(
+    x: float, y: float, z: float, w: float
+) -> np.ndarray:
+    """Return a 3x3 rotation matrix from a normalised or unnormalised quaternion."""
+    norm = np.sqrt((x * x) + (y * y) + (z * z) + (w * w))
+    if norm == 0.0:
+        raise ValueError("quaternion must be non-zero")
+    x /= norm
+    y /= norm
+    z /= norm
+    w /= norm
+    return np.array(
+        [
+            [
+                1.0 - 2.0 * (y * y + z * z),
+                2.0 * (x * y - z * w),
+                2.0 * (x * z + y * w),
+            ],
+            [
+                2.0 * (x * y + z * w),
+                1.0 - 2.0 * (x * x + z * z),
+                2.0 * (y * z - x * w),
+            ],
+            [
+                2.0 * (x * z - y * w),
+                2.0 * (y * z + x * w),
+                1.0 - 2.0 * (x * x + y * y),
+            ],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _binary_dilation(mask: np.ndarray, radius_cells: int) -> np.ndarray:
+    """Dilate a 2D boolean mask without adding a SciPy runtime dependency."""
+    if radius_cells <= 0 or not np.any(mask):
+        return mask
+
+    padded = np.pad(mask, radius_cells, mode="constant", constant_values=False)
+    dilated = np.zeros_like(mask, dtype=bool)
+    kernel_width = (2 * radius_cells) + 1
+    for row_offset in range(kernel_width):
+        for col_offset in range(kernel_width):
+            row_stop = row_offset + mask.shape[0]
+            col_stop = col_offset + mask.shape[1]
+            dilated |= padded[row_offset:row_stop, col_offset:col_stop]
+    return dilated
 
 
 class CraterDetectionNode(Node):
@@ -56,6 +103,10 @@ class CraterDetectionNode(Node):
         self.declare_parameter("ground_percentile", 80.0)
         self.declare_parameter("inflation_cells", 2)
         self.declare_parameter("accumulator_decay", 0.95)
+        self.declare_parameter(
+            "input_cloud_topic",
+            "/perception/arena_boundary/camera_front/points",
+        )
         # Fixed ground Z for competition arenas with known flat floor
         # Set to NaN to use automatic percentile-based estimation
         self.declare_parameter("fixed_ground_z", float("nan"))
@@ -72,6 +123,7 @@ class CraterDetectionNode(Node):
         self.ground_percentile = self.get_parameter("ground_percentile").value
         self.inflation_cells = self.get_parameter("inflation_cells").value
         self.decay = self.get_parameter("accumulator_decay").value
+        self.input_cloud_topic = self.get_parameter("input_cloud_topic").value
         self.fixed_ground_z = self.get_parameter("fixed_ground_z").value
 
         if self.resolution <= 0.0:
@@ -92,11 +144,7 @@ class CraterDetectionNode(Node):
         self._z_count = np.zeros((self.grid_h, self.grid_w), dtype=np.float64)
 
         # Pre-build dilation kernel for crater inflation
-        if self.inflation_cells > 0:
-            k = self.inflation_cells
-            self._inflate_kernel = np.ones((2 * k + 1, 2 * k + 1), dtype=bool)
-        else:
-            self._inflate_kernel = None
+        self._inflation_radius_cells = max(0, int(self.inflation_cells))
 
         # --- TF2 ---
         self.tf_buffer = Buffer()
@@ -105,7 +153,7 @@ class CraterDetectionNode(Node):
         # --- Subscriber ---
         self.create_subscription(
             PointCloud2,
-            "/camera_front/points",
+            self.input_cloud_topic,
             self._cloud_callback,
             qos_profile_sensor_data,
         )
@@ -132,7 +180,8 @@ class CraterDetectionNode(Node):
         self.get_logger().info(
             f"Crater detection: {self.grid_w}x{self.grid_h} grid "
             f"@ {self.resolution}m, depth_threshold={self.depth_threshold}m, "
-            f"decay={self.decay}, inflation={self.inflation_cells} cells"
+            f"decay={self.decay}, inflation={self.inflation_cells} cells, "
+            f"input={self.input_cloud_topic}"
         )
 
     def _cloud_callback(self, msg: PointCloud2):
@@ -152,7 +201,7 @@ class CraterDetectionNode(Node):
 
         q = tf.transform.rotation
         t = tf.transform.translation
-        rot = Rotation.from_quat([q.x, q.y, q.z, q.w]).as_matrix()
+        rot = _rotation_matrix_from_quaternion(q.x, q.y, q.z, q.w)
         trans = np.array([t.x, t.y, t.z])
         points_odom = (rot @ points.T).T + trans
 
@@ -216,8 +265,7 @@ class CraterDetectionNode(Node):
     ) -> None:
         """Log a throttled TF lookup failure for an incoming cloud."""
         self.get_logger().warning(
-            f"TF lookup {msg.header.frame_id} -> {self.target_frame} "
-            f"failed: {error}",
+            f"TF lookup {msg.header.frame_id} -> {self.target_frame} failed: {error}",
             throttle_duration_sec=5.0,
         )
 
@@ -241,8 +289,7 @@ class CraterDetectionNode(Node):
         crater_mask = observed & (elevation < (ground_z - self.depth_threshold))
 
         # Inflate using proper dilation (no wraparound)
-        if self._inflate_kernel is not None and np.any(crater_mask):
-            crater_mask = binary_dilation(crater_mask, structure=self._inflate_kernel)
+        crater_mask = _binary_dilation(crater_mask, self._inflation_radius_cells)
 
         # Build OccupancyGrid
         grid_msg = OccupancyGrid()

--- a/src/lunabot_perception/package.xml
+++ b/src/lunabot_perception/package.xml
@@ -11,10 +11,10 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>sensor_msgs_py</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf2_ros_py</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
-  <exec_depend>python3-scipy</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/src/lunabot_perception/setup.py
+++ b/src/lunabot_perception/setup.py
@@ -26,6 +26,7 @@ setup(
     },
     entry_points={
         "console_scripts": [
+            "arena_boundary_filter = lunabot_perception.arena_boundary_filter:main",
             "crater_detection = lunabot_perception.crater_detection:main",
         ],
     },

--- a/src/lunabot_perception/test/test_arena_boundary_filter.py
+++ b/src/lunabot_perception/test/test_arena_boundary_filter.py
@@ -1,0 +1,80 @@
+"""Unit tests for arena wall-exclusion filtering."""
+
+import numpy as np
+import pytest
+
+from lunabot_perception.arena_boundary_filter import (
+    ArenaBounds,
+    filter_points_to_arena,
+    transform_points,
+)
+
+
+def test_arena_bounds_reject_invalid_margin():
+    """The exclusion margin cannot remove the whole usable arena."""
+    with pytest.raises(ValueError, match="removes all legal arena height"):
+        ArenaBounds(
+            min_x=0.0, max_x=10.0, min_y=0.0, max_y=1.0, wall_exclusion_margin_m=0.5
+        )
+
+
+def test_filter_rejects_wall_band_and_outside_points():
+    """Only points in the legal interior pass through."""
+    bounds = ArenaBounds(
+        min_x=-1.0,
+        max_x=6.9,
+        min_y=-3.3,
+        max_y=1.1,
+        wall_exclusion_margin_m=0.35,
+    )
+    points = np.array(
+        [
+            [0.0, 0.0, 0.2],  # legal interior
+            [-0.9, 0.0, 0.2],  # west wall band
+            [6.8, 0.0, 0.2],  # east wall band
+            [2.0, -3.2, 0.2],  # south wall band
+            [2.0, 1.0, 0.2],  # north wall band
+            [9.0, 0.0, 0.2],  # outside arena
+            [np.nan, 0.0, 0.2],  # non-finite point
+        ],
+        dtype=np.float32,
+    )
+
+    result = filter_points_to_arena(points, bounds)
+
+    assert result.input_count == 6
+    assert result.kept_count == 1
+    assert result.rejected_count == 5
+    assert result.reject_ratio == pytest.approx(5.0 / 6.0)
+    np.testing.assert_allclose(result.points, [[0.0, 0.0, 0.2]])
+
+
+def test_filter_accepts_points_on_legal_boundary():
+    """The configured margin is inclusive for points exactly on the legal edge."""
+    bounds = ArenaBounds(
+        min_x=0.0, max_x=4.0, min_y=0.0, max_y=4.0, wall_exclusion_margin_m=0.5
+    )
+    points = np.array(
+        [
+            [0.5, 2.0, 0.0],
+            [3.5, 2.0, 0.0],
+            [2.0, 0.5, 0.0],
+            [2.0, 3.5, 0.0],
+        ],
+        dtype=np.float32,
+    )
+
+    result = filter_points_to_arena(points, bounds)
+
+    assert result.kept_count == 4
+
+
+def test_transform_points_applies_translation_and_yaw():
+    """Point transforms match the target-frame geometry used before filtering."""
+    points = np.array([[1.0, 0.0, 0.0]], dtype=np.float32)
+    # 90 degrees around z: (1, 0, 0) -> (0, 1, 0), then translate.
+    quaternion_xyzw = (0.0, 0.0, np.sqrt(0.5), np.sqrt(0.5))
+
+    transformed = transform_points(points, (2.0, -1.0, 0.25), quaternion_xyzw)
+
+    np.testing.assert_allclose(transformed, [[2.0, 0.0, 0.25]], atol=1e-6)

--- a/src/lunabot_perception/test/test_crater_detection.py
+++ b/src/lunabot_perception/test/test_crater_detection.py
@@ -16,11 +16,16 @@
 
 from unittest.mock import Mock
 
+import numpy as np
 from rclpy.time import Time
 from sensor_msgs.msg import PointCloud2
 from tf2_ros import ExtrapolationException, LookupException
 
-from lunabot_perception.crater_detection import CraterDetectionNode
+from lunabot_perception.crater_detection import (
+    CraterDetectionNode,
+    _binary_dilation,
+    _rotation_matrix_from_quaternion,
+)
 
 
 def _node_with_buffer(tf_buffer: Mock) -> CraterDetectionNode:
@@ -37,6 +42,29 @@ def _point_cloud() -> PointCloud2:
     msg.header.stamp.sec = 42
     msg.header.stamp.nanosec = 123
     return msg
+
+
+def test_rotation_matrix_from_quaternion_applies_yaw():
+    """Quaternion transforms do not depend on SciPy at runtime."""
+    rot = _rotation_matrix_from_quaternion(0.0, 0.0, 2**0.5 / 2.0, 2**0.5 / 2.0)
+
+    np.testing.assert_allclose(
+        rot @ np.array([1.0, 0.0, 0.0]), [0.0, 1.0, 0.0], atol=1e-6
+    )
+
+
+def test_binary_dilation_expands_without_wrapping_edges():
+    """Inflation expands into neighbours without wrapping across the grid."""
+    mask = np.zeros((3, 3), dtype=bool)
+    mask[0, 0] = True
+
+    dilated = _binary_dilation(mask, 1)
+
+    assert dilated.tolist() == [
+        [True, True, False],
+        [True, True, False],
+        [False, False, False],
+    ]
 
 
 def test_lookup_cloud_transform_uses_cloud_stamp_first():


### PR DESCRIPTION
## Summary
- add `arena_boundary_filter` to transform clouds into `odom`, reject wall-band/out-of-field returns, publish filtered clouds and diagnostics
- route Nav2 obstacle/voxel layers, collision monitor, crater detection, RViz and evidence profiles through `/perception/arena_boundary/...` topics
- make `enable_visual_slam` real so the default competition path avoids RTAB-Map mapping from raw RGB-D wall views
- remove the SciPy runtime dependency from crater detection while keeping crater inflation and quaternion transforms covered by tests

## Validation
- `ruff format --check` on touched Python files
- `ruff check src/lunabot_perception src/lunabot_navigation src/lunabot_bringup src/lunabot_localisation`
- `git diff --check`
- `python3 .github/scripts/check_interface_contracts.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ... pytest -q ...` focused suite: 87 passed
- `colcon test --base-paths src --packages-select lunabot_perception lunabot_navigation lunabot_localisation --event-handlers console_direct+`: perception 12 passed/1 skipped, navigation 35 passed/1 skipped, localisation 41 passed/1 skipped
- `colcon build --base-paths src --packages-select lunabot_perception lunabot_navigation lunabot_localisation lunabot_safety lunabot_bringup`: 5 packages finished
- live synthetic ROS smoke test: 5 input points, 1 kept, 4 rejected, diagnostic reject ratio 0.800

## Notes
- Full `colcon test` for `lunabot_bringup` cannot collect in this macOS/Conda ROS install because `lunabot_interfaces` is unavailable; attempting to rebuild `lunabot_interfaces` fails in generated C++ against local macOS SDK headers. The new navigation launch wiring is covered by a focused bringup test that does not need generated action modules.
