### PR TITLE
Add safety latch for power and physical E-stop input

### DIFF
--- a/.github/contracts/interface_contracts.json
+++ b/.github/contracts/interface_contracts.json
@@ -50,6 +50,13 @@
     {
       "name": "/safety/estop",
       "type": "std_msgs/msg/Bool",
+      "kind": "publisher",
+      "source": "src/lunabot_safety/lunabot_safety/physical_estop_input.py",
+      "phases": ["runtime", "hardware"]
+    },
+    {
+      "name": "/safety/estop",
+      "type": "std_msgs/msg/Bool",
       "kind": "subscription",
       "source": "src/lunabot_safety/lunabot_safety/estop_node.py",
       "phases": ["runtime", "hardware"]
@@ -65,6 +72,13 @@
     {
       "name": "/safety/reset_motion_inhibit",
       "type": "std_msgs/msg/Bool",
+      "kind": "subscription",
+      "source": "src/lunabot_safety/lunabot_safety/estop_node.py",
+      "phases": ["runtime", "hardware"]
+    },
+    {
+      "name": "/power/telemetry",
+      "type": "lunabot_interfaces/msg/PowerTelemetry",
       "kind": "subscription",
       "source": "src/lunabot_safety/lunabot_safety/estop_node.py",
       "phases": ["runtime", "hardware"]

--- a/docs/competition_inspection_packet.md
+++ b/docs/competition_inspection_packet.md
@@ -45,6 +45,11 @@ Inspection demo:
 The COTS power logger is an inspection item. `/power/telemetry` is the ROS view
 of the same power story, not a replacement for a physical logger.
 
+The software low-voltage policy is deliberately conservative: warning voltage
+appears as diagnostics WARN, critical voltage appears as diagnostics ERROR and
+latched `/safety/motion_inhibit`. Re-enable motion only after the voltage has
+recovered and `/safety/reset_motion_inhibit` has been published.
+
 Document the logger wiring once electrical integration is final. The logger
 needs to be visible or quickly readable by a judge, and its record needs to
 survive E-stop.

--- a/docs/hardware_week_runbook.md
+++ b/docs/hardware_week_runbook.md
@@ -186,6 +186,10 @@ Use `lipo_4s` if the rover is on a 4S pack. The default voltage is unavailable,
 so diagnostics will say power telemetry is missing until someone enters a real
 value.
 
+If the voltage reaches the critical threshold, the safety bridge latches
+`/safety/motion_inhibit`. Do not reset it until the pack has recovered or been
+replaced and `/power/telemetry` is no longer critical.
+
 The physical COTS power logger is still required for inspection. Treat
 `/power/telemetry` as the operator and evidence view of that power story, not as
 a substitute for the logger itself.

--- a/src/lunabot_bringup/README.md
+++ b/src/lunabot_bringup/README.md
@@ -237,6 +237,11 @@ The physical COTS power logger remains the inspection artefact. `/power/telemetr
 is the operator and evidence topic that should mirror the logger or bridge once
 electrical integration is final.
 
+When `/power/telemetry` reports `STATE_LOW_CRITICAL` or
+`low_voltage_critical: true`, `lunabot_safety/estop_node` latches
+`/safety/motion_inhibit`. Motion is allowed again only after the voltage has
+recovered and the operator publishes `/safety/reset_motion_inhibit`.
+
 ## Common failure modes
 
 - Launch starts successfully but one critical node crashes shortly after (dependency mismatch).

--- a/src/lunabot_safety/README.md
+++ b/src/lunabot_safety/README.md
@@ -4,11 +4,12 @@ Safety package for the E-stop to motion-inhibit bridge on the INNEX-1 rover.
 
 ## Current state
 
-One node lives here. The rest of the rover's safety behaviour is currently
+Two nodes live here. The rest of the rover's safety behaviour is currently
 distributed across other packages:
 
 | Safety function | Where it lives |
 |-----------------|----------------|
+| Physical E-stop input publisher | `lunabot_safety` (`physical_estop_input`) |
 | E-stop → motion inhibit bridge | `lunabot_safety` (`estop_node`) |
 | Velocity gating (zero cmd_vel on fault) | `lunabot_drivetrain` (`velocity_gate`) |
 | Drivetrain stall detection & E-stop recovery | `lunabot_drivetrain` (`drivetrain_bridge`) |
@@ -17,6 +18,46 @@ distributed across other packages:
 
 ## Nodes
 
+Start both safety nodes with:
+
+```bash
+ros2 launch lunabot_safety safety.launch.py
+```
+
+For a confirmed Jetson GPIO E-stop input:
+
+```bash
+ros2 launch lunabot_safety safety.launch.py \
+  estop_backend:=jetson_gpio \
+  estop_gpio_pin:=<pin> \
+  estop_active_high:=true
+```
+
+### `physical_estop_input`
+
+Publishes the physical E-stop state on `/safety/estop`. The default
+`backend:=parameter` mode is for bench and CI checks. Hardware runs should use
+`backend:=jetson_gpio` only after the actual pin, polarity, and wiring have
+been confirmed.
+
+| Direction | Topic | Type | QoS |
+|-----------|-------|------|-----|
+| Publish | `/safety/estop` | `std_msgs/Bool` | default (reliable, volatile) |
+
+Useful parameters:
+
+| Parameter | Default | Meaning |
+|-----------|---------|---------|
+| `backend` | `parameter` | `parameter` or `jetson_gpio` |
+| `gpio_pin` | `0` | Jetson GPIO pin number for hardware mode |
+| `gpio_numbering` | `BOARD` | `BOARD` or `BCM` numbering |
+| `active_high` | `true` | Whether a high input means E-stop active |
+| `simulated_estop_active` | `false` | Published state in parameter mode |
+| `release_debounce_samples` | `3` | Consecutive clear samples before release |
+| `fail_safe_on_error` | `true` | Publish active E-stop if GPIO cannot be read |
+
+E-stop assertion is immediate. Only release is debounced.
+
 ### `estop_node`
 
 Latches the hardware E-stop signal into a motion-inhibit topic. When
@@ -24,10 +65,15 @@ Latches the hardware E-stop signal into a motion-inhibit topic. When
 true after the E-stop input clears. Motion is only allowed again after an
 operator publishes a true message on `/safety/reset_motion_inhibit`.
 
+Critical low-voltage telemetry from `/power/telemetry` is treated the same way:
+it latches `/safety/motion_inhibit` until the voltage recovers and the operator
+explicitly resets motion inhibit.
+
 | Direction | Topic | Type | QoS |
 |-----------|-------|------|-----|
 | Subscribe | `/safety/estop` | `std_msgs/Bool` | default (reliable, volatile) |
 | Subscribe | `/safety/reset_motion_inhibit` | `std_msgs/Bool` | default (reliable, volatile) |
+| Subscribe | `/power/telemetry` | `lunabot_interfaces/msg/PowerTelemetry` | default (reliable, volatile) |
 | Publish | `/safety/motion_inhibit` | `std_msgs/Bool` | reliable, transient-local |
 
 Transient-local durability ensures that nodes joining after an E-stop event
@@ -41,7 +87,8 @@ physical E-stop should not make the rover move again by itself.
 ros2 topic pub --once /safety/reset_motion_inhibit std_msgs/msg/Bool "{data: true}"
 ```
 
-The node ignores reset requests while `/safety/estop` is still true.
+The node ignores reset requests while `/safety/estop` is still true or power
+telemetry is still critical.
 
 ## Safety topic convention
 

--- a/src/lunabot_safety/launch/safety.launch.py
+++ b/src/lunabot_safety/launch/safety.launch.py
@@ -1,0 +1,94 @@
+"""Launch safety input and inhibit bridge nodes."""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+
+def generate_launch_description():
+    """Generate the safety launch description."""
+    use_sim_time = LaunchConfiguration("use_sim_time")
+    estop_backend = LaunchConfiguration("estop_backend")
+    estop_gpio_pin = LaunchConfiguration("estop_gpio_pin")
+    estop_active_high = LaunchConfiguration("estop_active_high")
+    simulated_estop_active = LaunchConfiguration("simulated_estop_active")
+    release_debounce_samples = LaunchConfiguration("release_debounce_samples")
+    power_inhibit_enabled = LaunchConfiguration("power_inhibit_enabled")
+
+    physical_estop = Node(
+        package="lunabot_safety",
+        executable="physical_estop_input",
+        name="physical_estop_input",
+        output="screen",
+        parameters=[
+            {
+                "use_sim_time": ParameterValue(use_sim_time, value_type=bool),
+                "backend": estop_backend,
+                "gpio_pin": ParameterValue(estop_gpio_pin, value_type=int),
+                "active_high": ParameterValue(
+                    estop_active_high, value_type=bool
+                ),
+                "simulated_estop_active": ParameterValue(
+                    simulated_estop_active, value_type=bool
+                ),
+                "release_debounce_samples": ParameterValue(
+                    release_debounce_samples, value_type=int
+                ),
+            }
+        ],
+    )
+
+    estop_node = Node(
+        package="lunabot_safety",
+        executable="estop_node",
+        name="estop_node",
+        output="screen",
+        parameters=[
+            {
+                "use_sim_time": ParameterValue(use_sim_time, value_type=bool),
+                "power_inhibit_enabled": ParameterValue(
+                    power_inhibit_enabled, value_type=bool
+                ),
+            }
+        ],
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument("use_sim_time", default_value="false"),
+            DeclareLaunchArgument(
+                "estop_backend",
+                default_value="parameter",
+                description="E-stop source: parameter or jetson_gpio.",
+            ),
+            DeclareLaunchArgument(
+                "estop_gpio_pin",
+                default_value="0",
+                description="Jetson GPIO pin used when estop_backend is jetson_gpio.",
+            ),
+            DeclareLaunchArgument(
+                "estop_active_high",
+                default_value="true",
+                description="Whether a high GPIO input means E-stop active.",
+            ),
+            DeclareLaunchArgument(
+                "simulated_estop_active",
+                default_value="false",
+                description="Published E-stop state for parameter backend.",
+            ),
+            DeclareLaunchArgument(
+                "release_debounce_samples",
+                default_value="3",
+                description="Consecutive clear samples required before release.",
+            ),
+            DeclareLaunchArgument(
+                "power_inhibit_enabled",
+                default_value="true",
+                description="Latch motion inhibit on critical /power/telemetry.",
+            ),
+            physical_estop,
+            estop_node,
+        ]
+    )

--- a/src/lunabot_safety/lunabot_safety/estop_node.py
+++ b/src/lunabot_safety/lunabot_safety/estop_node.py
@@ -1,9 +1,11 @@
-"""E-stop node: latches /safety/estop into /safety/motion_inhibit."""
+"""E-stop node: latches safety inputs into /safety/motion_inhibit."""
 
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
 from std_msgs.msg import Bool
+
+from lunabot_interfaces.msg import PowerTelemetry
 
 # TRANSIENT_LOCAL so late subscribers (e.g. motor controllers) receive the current
 # inhibit state immediately on connect rather than waiting for the next e-stop event.
@@ -23,8 +25,15 @@ class EstopNode(Node):
         super().__init__("estop_node")
 
         self._estop_active = False
+        self._power_critical = False
         self._inhibited = False
         self._reset_required = False
+        self._active_reasons: set[str] = set()
+
+        self.declare_parameter("power_inhibit_enabled", True)
+        self._power_inhibit_enabled = bool(
+            self.get_parameter("power_inhibit_enabled").value
+        )
 
         self._motion_inhibit_pub = self.create_publisher(
             Bool,
@@ -46,6 +55,13 @@ class EstopNode(Node):
             10,
         )
 
+        self._power_sub = self.create_subscription(
+            PowerTelemetry,
+            "/power/telemetry",
+            self._power_callback,
+            10,
+        )
+
         # Publish initial state so subscribers joining before any e-stop event
         # receive a well-defined value.
         self._publish_inhibit()
@@ -57,6 +73,14 @@ class EstopNode(Node):
         out.data = self._inhibited
         self._motion_inhibit_pub.publish(out)
 
+    def _set_latched_reason(self, reason: str, active: bool) -> None:
+        """Track which safety source requires an operator reset."""
+        if active:
+            self._active_reasons.add(reason)
+            self._reset_required = True
+        else:
+            self._active_reasons.discard(reason)
+
     def _estop_callback(self, msg: Bool) -> None:
         """Handle incoming e-stop signal and latch motion inhibit until reset."""
         new_state = bool(msg.data)
@@ -67,16 +91,48 @@ class EstopNode(Node):
 
         self._estop_active = new_state
         if self._estop_active:
-            self._reset_required = True
+            self._set_latched_reason("estop", True)
             self._inhibited = True
             self.get_logger().warn(
                 "E-stop active; motion inhibited until reset"
             )
         else:
+            self._set_latched_reason("estop", False)
             if self._reset_required:
                 self.get_logger().info(
-                    "E-stop cleared; publish /safety/reset_motion_inhibit "
+                    "Safety input cleared; publish /safety/reset_motion_inhibit "
                     "before motion is allowed"
+                )
+            else:
+                self._inhibited = False
+
+        self._publish_inhibit()
+
+    def _power_callback(self, msg: PowerTelemetry) -> None:
+        """Latch motion inhibit while power telemetry is critical."""
+        if not self._power_inhibit_enabled:
+            return
+
+        new_state = bool(msg.low_voltage_critical) or (
+            msg.state == PowerTelemetry.STATE_LOW_CRITICAL
+        )
+        if new_state == self._power_critical:
+            self._publish_inhibit()
+            return
+
+        self._power_critical = new_state
+        if self._power_critical:
+            self._set_latched_reason("power", True)
+            self._inhibited = True
+            self.get_logger().warn(
+                "Power voltage critical; motion inhibited until reset"
+            )
+        else:
+            self._set_latched_reason("power", False)
+            if self._reset_required:
+                self.get_logger().info(
+                    "Power voltage recovered; publish "
+                    "/safety/reset_motion_inhibit before motion is allowed"
                 )
             else:
                 self._inhibited = False
@@ -88,9 +144,9 @@ class EstopNode(Node):
         if not msg.data:
             return
 
-        if self._estop_active:
+        if self._active_reasons:
             self.get_logger().warn(
-                "Motion-inhibit reset ignored while E-stop is active"
+                "Motion-inhibit reset ignored while a safety input is active"
             )
             self._publish_inhibit()
             return

--- a/src/lunabot_safety/lunabot_safety/physical_estop_input.py
+++ b/src/lunabot_safety/lunabot_safety/physical_estop_input.py
@@ -1,0 +1,134 @@
+"""Publish the physical E-stop input on /safety/estop."""
+
+from __future__ import annotations
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import Bool
+
+
+def interpret_estop_input(raw_value: bool, *, active_high: bool) -> bool:
+    """Return whether the E-stop is active for one raw input sample."""
+    value = bool(raw_value)
+    return value if active_high else not value
+
+
+class PhysicalEstopInput(Node):
+    """Publish a debounced physical or configured E-stop input."""
+
+    def __init__(self) -> None:
+        super().__init__("physical_estop_input")
+        self.declare_parameter("backend", "parameter")
+        self.declare_parameter("gpio_pin", 0)
+        self.declare_parameter("gpio_numbering", "BOARD")
+        self.declare_parameter("active_high", True)
+        self.declare_parameter("simulated_estop_active", False)
+        self.declare_parameter("publish_hz", 20.0)
+        self.declare_parameter("release_debounce_samples", 3)
+        self.declare_parameter("fail_safe_on_error", True)
+
+        self._backend = str(self.get_parameter("backend").value)
+        self._active_high = bool(self.get_parameter("active_high").value)
+        self._fail_safe_on_error = bool(
+            self.get_parameter("fail_safe_on_error").value
+        )
+        publish_hz = float(self.get_parameter("publish_hz").value)
+        if publish_hz <= 0.0:
+            raise ValueError("publish_hz must be positive")
+        self._release_debounce_samples = int(
+            self.get_parameter("release_debounce_samples").value
+        )
+        if self._release_debounce_samples <= 0:
+            raise ValueError("release_debounce_samples must be positive")
+
+        self._publisher = self.create_publisher(Bool, "/safety/estop", 10)
+        self._gpio = None
+        self._gpio_pin = int(self.get_parameter("gpio_pin").value)
+        self._published_estop_active: bool | None = None
+        self._release_sample_count = 0
+        if self._backend == "jetson_gpio":
+            self._setup_gpio()
+        elif self._backend != "parameter":
+            raise ValueError("backend must be 'parameter' or 'jetson_gpio'")
+
+        self.create_timer(1.0 / publish_hz, self._publish)
+        self.get_logger().info(
+            f"physical_estop_input publishing /safety/estop via {self._backend}"
+        )
+
+    def _setup_gpio(self) -> None:
+        """Initialise Jetson.GPIO for the configured input pin."""
+        try:
+            import Jetson.GPIO as GPIO  # type: ignore[import-not-found]
+        except Exception as exc:
+            if self._fail_safe_on_error:
+                self.get_logger().error(
+                    f"Jetson.GPIO unavailable; publishing E-stop active: {exc}"
+                )
+                return
+            raise
+
+        numbering = str(self.get_parameter("gpio_numbering").value).upper()
+        mode = GPIO.BOARD if numbering == "BOARD" else GPIO.BCM
+        GPIO.setmode(mode)
+        GPIO.setup(self._gpio_pin, GPIO.IN)
+        self._gpio = GPIO
+
+    def _read_estop_active(self) -> bool:
+        """Read the configured E-stop source."""
+        if self._backend == "parameter":
+            return bool(self.get_parameter("simulated_estop_active").value)
+
+        if self._gpio is None:
+            return self._fail_safe_on_error
+
+        raw_value = bool(self._gpio.input(self._gpio_pin))
+        return interpret_estop_input(raw_value, active_high=self._active_high)
+
+    def _debounced_estop_active(self, sampled_active: bool) -> bool:
+        """Apply immediate assertion and debounced release."""
+        if self._published_estop_active is None:
+            self._published_estop_active = sampled_active
+            self._release_sample_count = 0
+            return sampled_active
+
+        if sampled_active:
+            self._published_estop_active = True
+            self._release_sample_count = 0
+            return True
+
+        if not self._published_estop_active:
+            self._release_sample_count = 0
+            return False
+
+        self._release_sample_count += 1
+        if self._release_sample_count >= self._release_debounce_samples:
+            self._published_estop_active = False
+            self._release_sample_count = 0
+
+        return self._published_estop_active
+
+    def _publish(self) -> None:
+        msg = Bool()
+        msg.data = self._debounced_estop_active(self._read_estop_active())
+        self._publisher.publish(msg)
+
+    def destroy_node(self):
+        """Clean up GPIO resources before shutdown."""
+        if self._gpio is not None:
+            self._gpio.cleanup(self._gpio_pin)
+        super().destroy_node()
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = PhysicalEstopInput()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lunabot_safety/package.xml
+++ b/src/lunabot_safety/package.xml
@@ -8,6 +8,9 @@
   <license>MIT</license>
 
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>lunabot_interfaces</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/src/lunabot_safety/setup.py
+++ b/src/lunabot_safety/setup.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 from setuptools import find_packages, setup
 
 package_name = "lunabot_safety"
+package_root = Path(__file__).resolve().parent
 
 setup(
     name=package_name,
@@ -12,6 +15,13 @@ setup(
             ["resource/" + package_name],
         ),
         ("share/" + package_name, ["package.xml"]),
+        (
+            "share/" + package_name + "/launch",
+            [
+                str(path.relative_to(package_root))
+                for path in package_root.joinpath("launch").glob("*.launch.py")
+            ],
+        ),
     ],
     install_requires=["setuptools"],
     zip_safe=True,
@@ -27,6 +37,7 @@ setup(
     entry_points={
         "console_scripts": [
             "estop_node = lunabot_safety.estop_node:main",
+            "physical_estop_input = lunabot_safety.physical_estop_input:main",
         ],
     },
 )

--- a/src/lunabot_safety/test/test_estop_node.py
+++ b/src/lunabot_safety/test/test_estop_node.py
@@ -1,6 +1,7 @@
 from std_msgs.msg import Bool
 
 from lunabot_safety.estop_node import EstopNode
+from lunabot_interfaces.msg import PowerTelemetry
 
 
 class FakePublisher:
@@ -32,8 +33,11 @@ def _bool(value):
 def _node():
     node = object.__new__(EstopNode)
     node._estop_active = False
+    node._power_critical = False
     node._inhibited = False
     node._reset_required = False
+    node._active_reasons = set()
+    node._power_inhibit_enabled = True
     node._motion_inhibit_pub = FakePublisher()
     logger = FakeLogger()
     node.get_logger = lambda: logger
@@ -94,4 +98,89 @@ def test_false_reset_message_is_ignored():
 
     node._reset_callback(_bool(False))
 
+    assert node._motion_inhibit_pub.messages == []
+
+
+def _power_msg(*, critical=False):
+    msg = PowerTelemetry()
+    msg.state = (
+        PowerTelemetry.STATE_LOW_CRITICAL
+        if critical
+        else PowerTelemetry.STATE_OK
+    )
+    msg.low_voltage_critical = critical
+    return msg
+
+
+def test_critical_power_latches_motion_inhibit():
+    node = _node()
+
+    node._power_callback(_power_msg(critical=True))
+
+    assert node._power_critical is True
+    assert node._reset_required is True
+    assert node._inhibited is True
+    assert node._motion_inhibit_pub.messages == [True]
+
+
+def test_power_recovery_keeps_motion_inhibit_until_reset():
+    node = _node()
+
+    node._power_callback(_power_msg(critical=True))
+    node._power_callback(_power_msg(critical=False))
+
+    assert node._power_critical is False
+    assert node._reset_required is True
+    assert node._inhibited is True
+    assert node._motion_inhibit_pub.messages == [True, True]
+
+
+def test_reset_while_power_is_critical_is_ignored():
+    node = _node()
+
+    node._power_callback(_power_msg(critical=True))
+    node._reset_callback(_bool(True))
+
+    assert node._power_critical is True
+    assert node._reset_required is True
+    assert node._inhibited is True
+    assert node._motion_inhibit_pub.messages == [True, True]
+
+
+def test_reset_after_power_recovery_allows_motion():
+    node = _node()
+
+    node._power_callback(_power_msg(critical=True))
+    node._power_callback(_power_msg(critical=False))
+    node._reset_callback(_bool(True))
+
+    assert node._power_critical is False
+    assert node._reset_required is False
+    assert node._inhibited is False
+    assert node._motion_inhibit_pub.messages == [True, True, False]
+
+
+def test_estop_and_power_both_clear_before_reset_allows_motion():
+    node = _node()
+
+    node._estop_callback(_bool(True))
+    node._power_callback(_power_msg(critical=True))
+    node._estop_callback(_bool(False))
+    node._reset_callback(_bool(True))
+    node._power_callback(_power_msg(critical=False))
+    node._reset_callback(_bool(True))
+
+    assert node._reset_required is False
+    assert node._inhibited is False
+    assert node._motion_inhibit_pub.messages[-1] is False
+
+
+def test_power_inhibit_can_be_disabled():
+    node = _node()
+    node._power_inhibit_enabled = False
+
+    node._power_callback(_power_msg(critical=True))
+
+    assert node._power_critical is False
+    assert node._reset_required is False
     assert node._motion_inhibit_pub.messages == []

--- a/src/lunabot_safety/test/test_physical_estop_input.py
+++ b/src/lunabot_safety/test/test_physical_estop_input.py
@@ -1,0 +1,55 @@
+"""Unit tests for physical E-stop input helpers."""
+
+from lunabot_safety.physical_estop_input import (
+    PhysicalEstopInput,
+    interpret_estop_input,
+)
+
+
+def test_active_high_input_reports_true_when_raw_high():
+    assert interpret_estop_input(True, active_high=True) is True
+
+
+def test_active_high_input_reports_false_when_raw_low():
+    assert interpret_estop_input(False, active_high=True) is False
+
+
+def test_active_low_input_reports_true_when_raw_low():
+    assert interpret_estop_input(False, active_high=False) is True
+
+
+def test_active_low_input_reports_false_when_raw_high():
+    assert interpret_estop_input(True, active_high=False) is False
+
+
+def _node(debounce_samples=3):
+    node = object.__new__(PhysicalEstopInput)
+    node._published_estop_active = None
+    node._release_sample_count = 0
+    node._release_debounce_samples = debounce_samples
+    return node
+
+
+def test_estop_assertion_is_immediate():
+    node = _node()
+
+    assert node._debounced_estop_active(True) is True
+
+
+def test_estop_release_is_debounced():
+    node = _node(debounce_samples=3)
+
+    assert node._debounced_estop_active(True) is True
+    assert node._debounced_estop_active(False) is True
+    assert node._debounced_estop_active(False) is True
+    assert node._debounced_estop_active(False) is False
+
+
+def test_estop_reassertion_resets_release_debounce():
+    node = _node(debounce_samples=2)
+
+    assert node._debounced_estop_active(True) is True
+    assert node._debounced_estop_active(False) is True
+    assert node._debounced_estop_active(True) is True
+    assert node._debounced_estop_active(False) is True
+    assert node._debounced_estop_active(False) is False


### PR DESCRIPTION
## Summary

- Add a `physical_estop_input` node and `lunabot_safety` launch file so the physical E-stop has a defined `/safety/estop` publisher boundary.
- Extend `estop_node` so critical `/power/telemetry` latches `/safety/motion_inhibit` until voltage recovers and an operator resets motion inhibit.
- Update the interface contract and runbook/inspection docs for the low-voltage safety policy.

## Linear

- INX-1: battery telemetry contract and low-voltage policy
- INX-4: physical E-stop input publisher and recovery checks
- Supports INX-25 contract sweep by updating `.github/contracts/interface_contracts.json`

## Verification

- Local: `ruff check src/lunabot_safety/lunabot_safety src/lunabot_safety/test src/lunabot_safety/launch`
- Local: `python3 .github/scripts/check_interface_contracts.py`
- Local: `git diff --check`
- Jetson temp checkout: `colcon test --packages-select lunabot_safety --event-handlers console_direct+ --pytest-args -q` -> 17 passed, 1 skipped
- Jetson temp checkout: `python3 .github/scripts/check_interface_contracts.py`

## Notes

This does not claim final hardware validation. The GPIO pin, polarity and wiring still need to be confirmed on the rover before `estop_backend:=jetson_gpio` is used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds safety enhancements for power management and physical E-stop functionality on the rover:

### New Components
- **Physical E-stop input node**: Publishes debounced E-stop state from GPIO pins with configurable polarity and simulation support
- **Safety launch file**: Configures and starts the physical E-stop and safety nodes with parameters for GPIO pins, simulation, and low-voltage behavior

### Enhanced Safety Logic
- **Low-voltage critical protection**: The E-stop safety node now monitors battery telemetry and automatically latches motion inhibit when voltage drops to a critical threshold
- **Persistent inhibit**: Once motion is inhibited due to low voltage, it remains latched until the voltage recovers AND the operator explicitly resets motion via `/safety/reset_motion_inhibit`

### Documentation Updates
Updated runbooks and documentation across:
- Competition inspection packet with low-voltage safety policy
- Hardware week runbook describing the latching behavior
- Safety package READMEs explaining E-stop and low-voltage behavior
- Interface contracts documenting the new E-stop publisher and power telemetry subscription

### Verification
- Local checks and interface contract validation passed
- Jetson temperature tests: 17 passed, 1 skipped
- Note: Hardware validation deferred—GPIO pin, polarity, and wiring require confirmation on the actual rover before using E-stop functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->