### PR TITLE
Docs/hardware datasheets

### DIFF
--- a/docs/hardware/bld-510b-bldc-controller.md
+++ b/docs/hardware/bld-510b-bldc-controller.md
@@ -1,0 +1,193 @@
+# BLD-510B BLDC Motor Driver — Datasheet
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Manufacturer** | STEPPERONLINE |
+| **Model** | BLD-510B |
+| **Role on Rover** | Brushless DC motor driver — excavation motor (57BLR50) |
+| **Power Domain** | 🔴 Motive (22.2 V from WUPP fuse block slot 5, 10 A blade fuse) |
+| **Qty on Rover** | 1 |
+
+---
+
+## Electrical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| **Supported input voltages** | 12 / 24 / 36 / 48 V DC |
+| **INNEX-1 supply** | **22.2 V motive rail** (≈24 V nominal — slightly below 24 V rated) |
+| Continuous output current @ 24 V | **8.3 A** |
+| Continuous output current @ 12 V | 10 A |
+| Peak current | **15 A** |
+| Rated power @ 24 V | 200 W |
+| PWM chopper frequency | 20 kHz |
+| Operating temperature | 0 – 45 °C |
+| Dimensions | 118 × 75.5 × 34 mm |
+| Cooling | Passive heatsink (active airflow recommended in enclosure) |
+
+> **22.2 V vs 24 V:** The INNEX-1 motive rail at 22.2 V is slightly below the 24 V nominal
+> rating. The driver operates correctly at this voltage; output power is marginally lower but
+> the 57BLR50 motor is within limits. The motive rail at full charge is ~25.2 V (6S LiPo),
+> which is also within the 24 V continuous range. Battery protect cutoff will reduce voltage
+> during discharge — monitor motor performance at low battery.
+
+---
+
+## Physical Dimensions
+
+- 118 × 75.5 × 34 mm
+- Passive heatsink — ensure airflow inside chassis enclosure during sustained excavation runs
+
+---
+
+## Terminal Reference
+
+### Power Input
+
+| Terminal | Description |
+|----------|-------------|
+| V+ | 22.2 V motive rail (from WUPP slot 5, 10 A fuse) |
+| GND | Motive domain ground |
+
+### Motor Phase & Hall Outputs
+
+| Terminal | Description |
+|----------|-------------|
+| MA | Motor Phase A |
+| MB | Motor Phase B |
+| MC | Motor Phase C |
+| GND | Motor GND (common) |
+| HA | Hall sensor A input |
+| HB | Hall sensor B input |
+| HC | Hall sensor C input |
+| +5V | Hall sensor power supply (5 V) |
+
+> Connect MA/MB/MC to the 57BLR50 phase wires (Orange/Green/Brown = Phase U/V/W — verify
+> with 57blr50-excavation-motor.md). If rotation is wrong, swap any two phase wires.
+> Connect HA/HB/HC to the Hall sensor outputs (Yellow/White/Blue = Hall A/B/C).
+
+### Control Signal Terminal (8-pin)
+
+| Pin | Name | Description |
+|-----|------|-------------|
+| 1 | GND | Signal ground — connect to Teensy GND |
+| 2 | F/R | Direction: open/high = CW (facing shaft); connect to GND = CCW |
+| 3 | EN | Enable: V2.0 — connect to GND = run, open = stop |
+| 4 | BK | Brake: connect to GND = fast brake stop; open = run |
+| 5 | SV | Speed reference: 0–5 V analogue OR 1–2 kHz PWM (5 V amplitude) |
+| 6 | PG | Speed pulse output (open-collector) — needs 3–10 kΩ pull-up to 5 V |
+| 7 | ALM | Alarm output (open-collector, active LOW) — needs 3–10 kΩ pull-up to 5 V |
+| 8 | +5V | 5 V supply output (do not use to power Teensy — use Jetson USB) |
+
+---
+
+## INNEX-1 Control Wiring (Teensy 4.1)
+
+| BLD-510B Pin | Signal | Teensy 4.1 Pin | Notes |
+|-------------|--------|----------------|-------|
+| GND | Signal GND | GND | Shared logic ground |
+| SV | Speed PWM | **Pin 6** | 1–2 kHz PWM, 3.3 V amplitude (see note) |
+| EN | Enable | **Pin 13** | HIGH = stop (V2.0 logic), LOW = run |
+| F/R | Direction | **Pin 14** | LOW = CCW, HIGH/open = CW |
+| BK | Brake | **TBD** | LOW = brake; use GPIO output |
+| PG | Speed feedback | **Pin 15** | Open-collector — add 4.7 kΩ pull-up to 3.3 V |
+| ALM | Alarm | **Pin 16** | Open-collector — add 4.7 kΩ pull-up to 3.3 V |
+
+> **SV PWM amplitude:** The SV pin accepts 0–5 V. Teensy 4.1 outputs 3.3 V PWM. This gives
+> approximately 66% of rated speed at full duty cycle. Adjust R-SL potentiometer on driver to
+> scale accordingly, or set maximum speed via internal jumpers to match the 57BLR50 target RPM.
+> See `teensy-4.1-microcontroller.md` for confirmed pin assignments.
+
+---
+
+## Speed Control — PWM via SV Pin
+
+The Teensy sends a **1–2 kHz PWM signal** to the SV pin:
+- Duty cycle 0% → motor speed 0 (stops below 0.3 V equivalent)
+- Duty cycle 100% → motor speed proportional to V_HIGH (3.3 V from Teensy)
+- Motor speed scales linearly with duty cycle
+
+> To use the full speed range with 3.3 V logic, set the built-in R-SL potentiometer to 100%
+> (maximum, clockwise). The maximum motor speed is then set by the internal jumpers.
+
+---
+
+## Maximum Speed Jumpers (Internal — Set Before Assembly)
+
+Internal jumpers 1–4 select max speed based on motor pole pairs. The **57BLR50** motor pole pair
+count must be confirmed from the motor datasheet — see `57blr50-excavation-motor.md`.
+
+Default factory setting: **7000 RPM** for 1 pole pair, **3500 RPM** for 2 pole pairs (jumper 1=1, 2=0, 3=0, 4=0).
+
+> Set the maximum speed jumpers before installing the driver in the chassis. Disassemble the
+> housing to access the jumpers. Confirm motor pole pairs from the 57BLR50 datasheet.
+
+---
+
+## EN / F/R Logic (Version-Dependent)
+
+> ⚠️ Two firmware versions exist: **V2.0** and **V2.4** with opposite EN logic.
+
+| Version | EN connected to GND | EN open |
+|---------|-------------------|---------|
+| **V2.0** | Motor **runs** | Motor **stops** |
+| **V2.4** | Motor **stops** | Motor **runs** |
+
+**Verify version label on driver before writing Teensy firmware.** Default assumption in
+INNEX-1 code should be V2.0 (connect EN to GND = run). If behaviour is reversed, invert EN logic.
+
+---
+
+## Protection Functions
+
+| Protection | Behaviour |
+|-----------|-----------|
+| Over-current | Driver stops; red LED on |
+| Over-voltage | Driver stops; red LED on |
+| Under-voltage | Driver stops; red LED on |
+| Over-temperature | Driver stops; red LED on |
+| Hall signal fault | Driver stops; red LED on |
+| Stall | Driver stops |
+
+To clear an alarm: disconnect EN from GND (stop command) or cycle power.
+The ALM output goes LOW during any alarm — Teensy should monitor this pin.
+
+---
+
+## On-Board Indicators
+
+| Indicator | Colour | Meaning |
+|-----------|--------|---------|
+| P/A — Green | Green | Motor running (always on when operating) |
+| P/A — Red | Red | Alarm / fault (always on during fault) |
+
+---
+
+## Key Rules & Gotchas
+
+- **PG and ALM are open-collector** — must have external pull-up resistors (3–10 kΩ to 5 V
+  or 4.7 kΩ to 3.3 V for Teensy inputs). Without pull-ups, pins float and give false readings.
+- **Check EN firmware version before first power-on** — wrong EN polarity causes motor to
+  run immediately at power-up, before the Teensy asserts control.
+- **Never change F/R direction while motor is running** — always bring motor to stop first
+  (EN stop command), then change F/R, then restart. Changing direction mid-run can damage driver.
+- **BK (brake) for fast stop only** — braking places electrical stress on the system.
+  Use natural stop (EN) for routine stops; reserve BK for emergency use.
+- **Fuse:** 10 A blade fuse in WUPP slot 5. At 22.2 V the driver draws up to 8.3 A continuous;
+  a 10 A fuse provides protection without nuisance tripping.
+- **Heatsink ventilation** — mount with heatsink fins vertical if possible; ensure chassis
+  enclosure has airflow around the driver during sustained operation.
+- **Hall sensor +5V** — use the driver's own +5V terminal to power Hall sensors. Do not share
+  this with other logic supplies.
+- **Power-up sequence** — apply 22.2 V only after Teensy has asserted EN = stop (open).
+  Prevents motor running before software is ready.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-24 | eniomecaj | Initial datasheet — sourced from BLD-510B User Manual V1 (STEPPERONLINE, 2024) |

--- a/docs/hardware/cytron-mdd10a.md
+++ b/docs/hardware/cytron-mdd10a.md
@@ -1,0 +1,149 @@
+# Cytron MDD10A — Dual Channel DC Motor Driver Datasheet
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Manufacturer** | Cytron Technologies |
+| **Model** | MDD10A (RB-Cyt-153, Rev2.0) |
+| **Role on Rover** | Dual-channel PWM motor driver — linear actuators |
+| **Power Domain** | 🔴 Motive (see per-unit detail below) |
+| **Qty on Rover** | 2 |
+
+| Unit | Power Input | Controls |
+|------|-------------|----------|
+| **Cytron MDD10A #1** | 22.2 V directly from WUPP fuse block (slot 3) | 50mm TRU Components actuators ×2 |
+| **Cytron MDD10A #2** | 12 V from DollaTek buck converter (fuse block slot 4 → buck → Cytron) | 250mm DCHOUSE actuators ×2 |
+
+---
+
+## Electrical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| **Motor supply voltage (VPWR)** | **5 – 30 V** (Rev2.0) |
+| **Cytron #1 supply** | **22.2 V** ✅ (50mm actuators rated 24 V) |
+| **Cytron #2 supply** | **12 V** ✅ (250mm actuators rated 12 V, via DollaTek buck) |
+| Continuous output current (per channel) | **10 A** |
+| Peak output current (per channel, ≤10 s) | **30 A** |
+| Logic input high (PWM, DIR) | 3.0 – 5.5 V |
+| Logic input low | 0 – 0.5 V |
+| Max PWM frequency | **20 kHz** |
+| Dimensions | 84.5 × 62 mm |
+
+> **Logic compatibility:** 3.0 V minimum for logic HIGH — Teensy 4.1 (3.3 V logic) is directly
+> compatible. No level shifter required.
+
+---
+
+## Control Interface (Sign-Magnitude PWM)
+
+INNEX-1 uses **sign-magnitude PWM** mode: one PWM signal sets speed, one DIR signal sets direction.
+
+| PWM | DIR | Motor Output | Effect |
+|-----|-----|--------------|--------|
+| LOW | X | A = Low, B = Low | Stop (coast) |
+| HIGH | LOW | A = High, B = Low | Forward |
+| HIGH | HIGH | A = Low, B = High | Reverse |
+
+> **Locked-antiphase alternative:** Connect PWM pin to 3.3 V and feed the DIR pin with a PWM
+> signal. 50% duty = stop, <50% = one direction, >50% = other. INNEX-1 does NOT use this mode.
+
+---
+
+## Pin Connectors
+
+### Control Header (5-pin, 2510 connector)
+
+| Pin | Name | Description |
+|-----|------|-------------|
+| 1 | GND | Logic ground — connect to Teensy GND |
+| 2 | PWM2 | Speed control, Motor 2 (TTL PWM, not RC PWM) |
+| 3 | DIR2 | Direction, Motor 2 (HIGH = reverse) |
+| 4 | PWM1 | Speed control, Motor 1 |
+| 5 | DIR1 | Direction, Motor 1 |
+
+### Power Terminal Block (6-position screw terminal)
+
+| Position | Name | Description |
+|----------|------|-------------|
+| 1 | M1B | Motor 1 Output B |
+| 2 | M1A | Motor 1 Output A |
+| 3 | POWER + | Motor supply positive (from fuse block / buck converter) |
+| 4 | POWER − | Motor supply negative (GND) |
+| 5 | M2A | Motor 2 Output A |
+| 6 | M2B | Motor 2 Output B |
+
+---
+
+## INNEX-1 Wiring
+
+### Cytron MDD10A #1 — 50mm Actuators (22.2 V)
+
+| Cytron Terminal | INNEX-1 Connection |
+|----------------|--------------------|
+| POWER + | WUPP fuse block slot 3 (15 A blade fuse) |
+| POWER − | Motive domain GND bus |
+| M1A / M1B | TRU Components 50mm Actuator #1 (Brown +, Blue −) |
+| M2A / M2B | TRU Components 50mm Actuator #2 (Brown +, Blue −) |
+| GND (header) | Teensy GND |
+| PWM1 | Teensy pin **2** |
+| DIR1 | Teensy pin **9** |
+| PWM2 | Teensy pin **3** |
+| DIR2 | Teensy pin **10** |
+
+### Cytron MDD10A #2 — 250mm Actuators (12 V via DollaTek buck)
+
+| Cytron Terminal | INNEX-1 Connection |
+|----------------|--------------------|
+| POWER + | DollaTek buck output + (set to 12 V) |
+| POWER − | DollaTek buck output − (GND) |
+| M1A / M1B | DCHOUSE 250mm Actuator #3 (Red +, Black −) |
+| M2A / M2B | DCHOUSE 250mm Actuator #4 (Red +, Black −) |
+| GND (header) | Teensy GND |
+| PWM1 | Teensy pin **4** |
+| DIR1 | Teensy pin **11** |
+| PWM2 | Teensy pin **5** |
+| DIR2 | Teensy pin **12** |
+
+---
+
+## On-board LEDs
+
+| LED | Colour | Meaning |
+|-----|--------|---------|
+| Power | Green | Board is powered |
+| M1A | Red | Current flowing from M1A → M1B (motor 1 CW) |
+| M1B | Red | Current flowing from M1B → M1A (motor 1 CCW) |
+| M2A | Red | Current flowing from M2A → M2B (motor 2 CW) |
+| M2B | Red | Current flowing from M2B → M2A (motor 2 CCW) |
+
+The direction LEDs are useful for confirming correct actuator polarity during bench testing.
+
+---
+
+## Key Rules & Gotchas
+
+- **10A continuous, 30A peak** — the 50mm actuators draw up to 1.6 A each (well within limit).
+  The 250mm actuators draw up to 3 A each; combined max is 6 A — within the 10 A rating.
+- **22.2 V is within the 30 V max for Cytron #1** ✅ — 50mm actuators rated 24 V, so the
+  motor voltage slightly exceeds actuator rating; keep duty cycles ≤ 100% and monitor heat.
+  Consider capping PWM to ~90% to approximate 20 V if required.
+- **Cytron #2 must be fed from the DollaTek buck only** — do not connect directly to the 22.2 V
+  motive rail; 250mm actuators are rated 12 V and will be damaged.
+- **Not for RC PWM** — the PWM input accepts TTL-level digital PWM from the Teensy, not the
+  1–2 ms RC servo signal type.
+- **Use battery (motive LiPo), not bench power supply** — regenerative current from actuators
+  can trip the overcurrent protection on a switching supply. Always test with the motive LiPo.
+- **Test buttons on board** — each motor channel has a physical test button (M1A, M1B, M2A, M2B)
+  for bench verification without microcontroller. Useful for polarity checks before software.
+- **Logic ground must be shared** — connect the GND pin on the control header to Teensy GND.
+  A floating logic ground will cause erratic behaviour.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-24 | eniomecaj | Initial datasheet — sourced from MDD10A User Manual V2.0 (Cytron Technologies, June 2017) |

--- a/docs/hardware/dchouse-linear-actuator-250mm.md
+++ b/docs/hardware/dchouse-linear-actuator-250mm.md
@@ -8,25 +8,15 @@
 | **Part Number (MPN)** | L11TGF1000N250-T-1 |
 | **ASIN** | B07S3VWKTB |
 | **Role on Rover** | Linear actuation — deployment / adjustment mechanism |
-| **Power Domain** | 🔴 Motive (via Cytron MDD10A — see voltage warning below) |
+| **Power Domain** | 🔴 Motive → DollaTek 12V buck converter → Cytron MDD10A #2 → actuators |
 | **Qty on Rover** | 2 |
 | **Price** | £35.99 (pair) |
 | **Supplier** | Amazon (DCHOUSE GLOBAL-UK) |
 | **Rating** | 4.3/5 — #1 Best Seller, Linear Motion Actuators |
 
----
-
-## ⚠️ Voltage Warning
-
-> **This actuator is rated 12V DC. The INNEX-1 motive rail is 22.2V nominal.**
->
-> The Cytron MDD10A uses PWM switching — average voltage to the actuator depends on duty cycle.
-> To stay within the actuator's 12V rating, **cap PWM duty cycle at approximately 55%**
-> (55% × 22.2V ≈ 12.2V average). Running at 100% duty cycle from the 22.2V rail will over-voltage
-> the actuator and risk burning out the motor winding.
->
-> Software must enforce a duty cycle cap on all Cytron channels driving these actuators.
-> See software-team-notes.md.
+> **Voltage note:** This actuator is rated 12V DC. The motive rail is 22.2V. A DollaTek 300W
+> buck converter steps the motive rail down to 12V before Cytron MDD10A #2 — no duty cycle
+> capping required. See dollatek-buck-converter-12v.md.
 
 ---
 
@@ -70,8 +60,8 @@ This actuator has **2 wires only** — no encoder.
 
 | Wire Colour | Function | INNEX-1 Connection |
 |-------------|----------|-------------------|
-| **Red** | Motor + (extend) | Cytron MDD10A M1A (or M2A) |
-| **Black** | Motor − (retract) | Cytron MDD10A M1B (or M2B) |
+| **Red** | Motor + (extend) | Cytron MDD10A #2 M1A (or M2A) |
+| **Black** | Motor − (retract) | Cytron MDD10A #2 M1B (or M2B) |
 
 > **Direction:** Red to M1A / Black to M1B = actuator extends. Swap wires to reverse direction.
 > If movement is wrong, swap at the Cytron terminals — do not invert in software first.
@@ -82,28 +72,28 @@ This actuator has **2 wires only** — no encoder.
 
 | Parameter | Value |
 |-----------|-------|
-| Controller | Cytron MDD10A (dual channel) |
+| Controller | Cytron MDD10A #2 (dual channel) |
+| Supply to Cytron | 12 V from DollaTek buck converter (not direct motive rail) |
 | Actuators per controller | 2 (one per channel) |
 | Control type | **Open-loop — timed PWM commands, no position feedback** |
-| Teensy PWM pins | Actuators 1 & 2: Pins 2, 3 / Actuators 3 & 4: Pins 4, 5 |
-| Teensy DIR pins | Actuators 1 & 2: Pins 9, 10 / Actuators 3 & 4: Pins 11, 12 |
-| **Max PWM duty cycle** | **~55%** to keep average voltage at 12V from 22.2V rail |
-| Fuse (motive fuse block) | **15 A blade** per Cytron MDD10A slot |
+| Teensy PWM pins | Pins 4, 5 (Actuators 3 & 4) |
+| Teensy DIR pins | Pins 11, 12 (Actuators 3 & 4) |
+| Fuse (motive fuse block) | **15 A blade** — Cytron #2 slot (fuses the buck converter input) |
 
 ---
 
 ## Key Rules & Gotchas
 
-- **12V rated on a 22.2V rail — duty cycle must be capped at ~55% in software.** This is a
-  critical constraint. Over-voltage will burn the actuator motor winding over time.
+- **Powered via 12V buck — no duty cycle restriction needed.** Cytron MDD10A #2 runs at 12V
+  from the buck output; full PWM range is available.
 - **20% duty cycle** — maximum 1 minute on, 4 minutes off. Do not run continuously.
 - **IP54** — dust and splash resistant but not fully sealed. Adequate for regolith environment
   provided the actuator is not directly submerged.
-- **No encoder** — open-loop timed control only. Position cannot be verified; use timed commands
-  with known extension rates (~10mm/s at rated load under correct voltage).
-- **Inner limit switch is non-adjustable** — full stroke is always 250mm. No mid-stroke stopping
-  via hardware; software must time out before end of travel if partial extension is needed.
-- **Holds position when unpowered** — no need for active braking or holding current.
+- **No encoder** — open-loop timed control only. Use timed commands with known extension rate
+  (~10mm/s at rated load).
+- **Inner limit switch is non-adjustable** — full stroke is 250mm. Software must time out before
+  end of travel if partial extension is needed.
+- **Holds position when unpowered** — no active braking or holding current required.
 
 ---
 
@@ -112,3 +102,4 @@ This actuator has **2 wires only** — no encoder.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-24 | eniomecaj | Initial datasheet — sourced from Amazon product page (ASIN B07S3VWKTB, DCHOUSE GLOBAL-UK) |
+| 2026-05-24 | eniomecaj | Removed PWM duty cycle warning — DollaTek 12V buck converter added before Cytron MDD10A #2 |

--- a/docs/hardware/dchouse-linear-actuator-250mm.md
+++ b/docs/hardware/dchouse-linear-actuator-250mm.md
@@ -1,0 +1,114 @@
+# DCHOUSE L11TGF1000N250 — Linear Actuator 250mm Datasheet
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Manufacturer** | DCHOUSE |
+| **Part Number (MPN)** | L11TGF1000N250-T-1 |
+| **ASIN** | B07S3VWKTB |
+| **Role on Rover** | Linear actuation — deployment / adjustment mechanism |
+| **Power Domain** | 🔴 Motive (via Cytron MDD10A — see voltage warning below) |
+| **Qty on Rover** | 2 |
+| **Price** | £35.99 (pair) |
+| **Supplier** | Amazon (DCHOUSE GLOBAL-UK) |
+| **Rating** | 4.3/5 — #1 Best Seller, Linear Motion Actuators |
+
+---
+
+## ⚠️ Voltage Warning
+
+> **This actuator is rated 12V DC. The INNEX-1 motive rail is 22.2V nominal.**
+>
+> The Cytron MDD10A uses PWM switching — average voltage to the actuator depends on duty cycle.
+> To stay within the actuator's 12V rating, **cap PWM duty cycle at approximately 55%**
+> (55% × 22.2V ≈ 12.2V average). Running at 100% duty cycle from the 22.2V rail will over-voltage
+> the actuator and risk burning out the motor winding.
+>
+> Software must enforce a duty cycle cap on all Cytron channels driving these actuators.
+> See software-team-notes.md.
+
+---
+
+## Electrical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| **Rated input voltage** | **12 V DC** |
+| No-load current | **0.8 A** |
+| Max load current | **3 A** |
+| Max push load | 1000 N (100 kg / 225 lb) |
+| Max pull load | 1000 N (100 kg / 225 lb) |
+| Travel speed (under load) | 10 mm/s |
+| **Duty cycle** | **20% — must not run continuously** |
+| Protection class | IP54 |
+| Operating temperature | −26 °C to +65 °C |
+| Protections built-in | Overcurrent, overload, overvoltage, short circuit, end-of-travel |
+
+---
+
+## Mechanical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Stroke length | **250 mm (10 inch)** |
+| Retracted length | 370 mm |
+| Extended length | 620 mm |
+| Body material | Aluminium alloy |
+| Shaft material | Alloy steel with metal gears |
+| Limit switch | Inner — pre-installed, non-adjustable |
+| Colour | Silver grey |
+
+> The inner limit switch automatically stops the actuator at both ends of travel.
+> The actuator holds position when unpowered.
+
+---
+
+## Wire Colours & INNEX-1 Connections
+
+This actuator has **2 wires only** — no encoder.
+
+| Wire Colour | Function | INNEX-1 Connection |
+|-------------|----------|-------------------|
+| **Red** | Motor + (extend) | Cytron MDD10A M1A (or M2A) |
+| **Black** | Motor − (retract) | Cytron MDD10A M1B (or M2B) |
+
+> **Direction:** Red to M1A / Black to M1B = actuator extends. Swap wires to reverse direction.
+> If movement is wrong, swap at the Cytron terminals — do not invert in software first.
+
+---
+
+## Motor Controller Interface
+
+| Parameter | Value |
+|-----------|-------|
+| Controller | Cytron MDD10A (dual channel) |
+| Actuators per controller | 2 (one per channel) |
+| Control type | **Open-loop — timed PWM commands, no position feedback** |
+| Teensy PWM pins | Actuators 1 & 2: Pins 2, 3 / Actuators 3 & 4: Pins 4, 5 |
+| Teensy DIR pins | Actuators 1 & 2: Pins 9, 10 / Actuators 3 & 4: Pins 11, 12 |
+| **Max PWM duty cycle** | **~55%** to keep average voltage at 12V from 22.2V rail |
+| Fuse (motive fuse block) | **15 A blade** per Cytron MDD10A slot |
+
+---
+
+## Key Rules & Gotchas
+
+- **12V rated on a 22.2V rail — duty cycle must be capped at ~55% in software.** This is a
+  critical constraint. Over-voltage will burn the actuator motor winding over time.
+- **20% duty cycle** — maximum 1 minute on, 4 minutes off. Do not run continuously.
+- **IP54** — dust and splash resistant but not fully sealed. Adequate for regolith environment
+  provided the actuator is not directly submerged.
+- **No encoder** — open-loop timed control only. Position cannot be verified; use timed commands
+  with known extension rates (~10mm/s at rated load under correct voltage).
+- **Inner limit switch is non-adjustable** — full stroke is always 250mm. No mid-stroke stopping
+  via hardware; software must time out before end of travel if partial extension is needed.
+- **Holds position when unpowered** — no need for active braking or holding current.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-24 | eniomecaj | Initial datasheet — sourced from Amazon product page (ASIN B07S3VWKTB, DCHOUSE GLOBAL-UK) |

--- a/docs/hardware/dollatek-buck-converter-12v.md
+++ b/docs/hardware/dollatek-buck-converter-12v.md
@@ -1,0 +1,89 @@
+# DollaTek 300W CC CV Buck Converter — Datasheet
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Manufacturer** | DollaTek |
+| **ASIN** | B07DJ47HGZ |
+| **Role on Rover** | Step-down 22.2 V motive rail → 12 V for Cytron MDD10A #2 (250mm actuators) |
+| **Power Domain** | 🔴 Motive (input) → regulated 12 V output to Cytron MDD10A #2 |
+| **Qty on Rover** | 1 |
+| **Price** | £5.99 |
+| **Supplier** | Amazon (DollaTek) |
+
+---
+
+## Electrical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Input voltage | **DC 7 – 32 V** |
+| Output voltage | **DC 0.8 – 28 V** (continuously adjustable via potentiometer) |
+| **INNEX-1 output set to** | **12 V DC** |
+| Rated output current (advertised) | 12 A MAX |
+| **Real output current limit** | **~8 A** (XL4016E chip rated 8 A — see note) |
+| Constant current range | 0.2 – 12 A (adjustable) |
+| Maximum output power | ~300 W |
+| Conversion efficiency | Up to ~95% |
+| Output ripple | ~50 mV (24 V in, 12 V out, 5 A load) |
+| Dropout voltage | 1 V |
+| No-load current | ~20 mA typical |
+| Load regulation | ±1% (CV mode) |
+| Voltage regulation | ±1% |
+| Operating temperature | −40 °C to +85 °C (industrial grade) |
+| Dimensions | 65 × 47 × 23.5 mm |
+| Reverse polarity protection | **No** |
+| Output backflow protection | **No** |
+
+> **⚠️ Real current limit is ~8 A, not 12 A.** The XL4016E driver chip is rated 8 A maximum.
+> Reviews confirm practical limit of ~7.7 A. INNEX-1 max draw through this converter is
+> 2 × 3 A = 6 A (both 250mm actuators at full load) — within safe limits. Do not exceed 7 A.
+> Add a heatsink or small fan if sustained loads above 5 A are expected.
+
+---
+
+## INNEX-1 Wiring
+
+| Connection | Detail |
+|------------|--------|
+| Input + | Motive rail 22.2 V (from fuse block) |
+| Input − | Motive GND |
+| Output + | Cytron MDD10A #2 VPWR |
+| Output − | Cytron MDD10A #2 GND |
+| Output voltage | Set to **12 V** via CV potentiometer (close to input port, turn clockwise to increase) |
+| Current limit | Set to **≥ 6 A** via CC potentiometer (close to output port) — leave at max unless current limiting is intentionally required |
+
+> Set output voltage before connecting load. Use a multimeter on the output terminals to confirm
+> 12 V before plugging in the Cytron.
+
+---
+
+## Potentiometer Adjustment
+
+| Potentiometer | Location | Function | Direction |
+|---------------|----------|----------|-----------|
+| CV (voltage) | Close to **input** port | Sets output voltage | Clockwise = increase |
+| CC (current) | Close to **output** port | Sets current limit | Clockwise = increase |
+
+---
+
+## Key Rules & Gotchas
+
+- **No reverse polarity protection** — wiring polarity must be correct. Reversed input will
+  likely damage the module.
+- **Real current limit ~8 A** — do not load above 7 A sustained. INNEX-1 max is 6 A (well within limit).
+- **Set voltage before connecting load** — verify 12 V output with multimeter first.
+- **Heatsink recommended** — at sustained loads above 5 A, the power transistor can exceed
+  65 °C. Add a small heatsink or 40 mm fan for reliability during competition runs.
+- **No output backflow protection** — do not connect to a supply with higher output voltage on
+  the load side; this will damage the module.
+- **Not waterproof** — PCB mount only; house inside the chassis enclosure.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-24 | eniomecaj | Initial datasheet — sourced from Amazon product page (ASIN B07DJ47HGZ, DollaTek) |

--- a/docs/hardware/gl-a1300-router.md
+++ b/docs/hardware/gl-a1300-router.md
@@ -1,0 +1,120 @@
+# GL.iNet GL-A1300 (Slate Plus) Router — Datasheet
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Manufacturer** | GL Technologies (Hong Kong) Limited |
+| **Model** | GL-A1300 (Slate Plus) |
+| **Role on Rover** | On-board LAN hub — connects OS1 LiDAR and Jetson; Wi-Fi link to ground station |
+| **Power Domain** | 🔵 Compute — BD-02 5V rail (USB Type-C, 5V/3A) |
+| **Qty on Rover** | 1 |
+
+---
+
+## Hardware Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| **CPU** | Qualcomm IPQ4018, Quad-Core @ 717 MHz |
+| **Memory** | DDR3L 256 MB |
+| **Storage** | NOR Flash 4 MB + NAND Flash 128 MB |
+| **Ethernet ports** | 1 × WAN + 2 × LAN (all 10/100/1000 Mbps Gigabit) |
+| **Wi-Fi** | 802.11 a/b/g/n @ 2.4 GHz (400 Mbps) + 802.11 ac @ 5 GHz (867 Mbps) |
+| **USB** | 1 × USB 3.0 Type-A |
+| **Power input** | USB Type-C, **5 V / 3 A** (15 W max) |
+| **Power consumption** | < 6.5 W typical |
+| **Dimensions** | 118 × 84 × 33 mm |
+| **Weight** | 181 g |
+| **OS** | OpenWrt |
+| **Operating temperature** | 0 – 40 °C |
+
+---
+
+## INNEX-1 Power Supply
+
+| Parameter | Value |
+|-----------|-------|
+| Supply source | BD-02 5V rail (compute domain) |
+| Connection | USB Type-C cable from BD-02 WAGO output → router power port |
+| Current draw | ~1.3 A @ 5 V (< 6.5 W) |
+
+> Power is provided directly from the BD-02 WAGO 2-in-6-out block — no USB hub or splitter.
+> The router is one of the 6 direct outputs from BD-02.
+
+---
+
+## INNEX-1 Network Topology
+
+```
+Ground Station (Wi-Fi 2.4 GHz)
+          │
+    GL-A1300 Router (Wi-Fi AP)
+          │
+    ┌─────┴──────┐
+    │ LAN port 1 │ LAN port 2 │
+    │            │
+  OS1 LiDAR   Jetson Orin Nano Super
+  (static IP)  (static IP)
+```
+
+| Port | Device | Connection | IP |
+|------|--------|------------|----|
+| **LAN 1** | Ouster OS1-128 LiDAR | GbE Ethernet | Static (configured in OS1 sensor web UI) |
+| **LAN 2** | Jetson Orin Nano Super (J15) | GbE Ethernet | Static (configured in Ubuntu) |
+| **WAN** | Not used | — | — |
+| **Wi-Fi 2.4 GHz** | Ground station laptop/tablet | SSID set on router | DHCP or static |
+
+> **2.4 GHz only for INNEX-1.** The ground station connects on 2.4 GHz — do not change to
+> 5 GHz. 2.4 GHz provides better range and wall penetration for the competition arena.
+
+---
+
+## Network Configuration (INNEX-1 Setup)
+
+### Router LAN Subnet
+Set LAN subnet to e.g. `192.168.8.0/24` (GL.iNet default). Assign static IPs:
+
+| Device | Recommended Static IP | Notes |
+|--------|-----------------------|-------|
+| Router LAN gateway | 192.168.8.1 | GL.iNet default |
+| OS1-128 LiDAR | 192.168.8.50 | Configured via OS1 sensor web UI |
+| Jetson Orin Nano | 192.168.8.100 | Configured in Ubuntu netplan/nmcli |
+| Ground station | 192.168.8.200 | DHCP reservation or static |
+
+> Static IPs prevent DHCP lookup delays during startup. The OS1 LiDAR requires a static IP to
+> be reliably discovered by `ouster-ros`. See `ouster-os1-128-lidar.md` for OS1 config details.
+
+### Wi-Fi SSID
+Set a unique SSID (e.g. `INNEX-1-GCS`) with a strong password. Use 2.4 GHz band, channel
+auto-select or fixed to a clear channel at the competition venue.
+
+---
+
+## Key Rules & Gotchas
+
+- **Boot time ~30–60 s** — router must be given time to fully boot before the Jetson or OS1
+  attempts network connections. Include router boot in the startup sequence.
+- **OS1 LiDAR also has ~60 s boot delay** — total time from power-on to first point cloud data
+  is at least 60 s even after the router is ready.
+- **5 V/3 A required** — BD-02 must supply at least 3 A on the router output. Verify WAGO wire
+  gauge and BD-02 converter rating support this.
+- **Jetson Ethernet is the only LAN device feeding ROS** — the Jetson uses the router as its
+  default gateway and LAN switch. All ROS topics traverse the router.
+- **WAN port left disconnected** — no internet connection in the rover. The WAN port can be
+  left empty. Do not plug LiDAR or Jetson into the WAN port by mistake.
+- **OpenWrt admin UI** — accessible at 192.168.8.1 from any LAN or Wi-Fi connected device.
+  Use this to configure static IPs, SSID, and DHCP. Change default admin password before
+  competition.
+- **Reset button** — press >3 s (< 8 s) to restore network settings; press ≥ 8 s to full factory
+  reset. Do not accidentally hold reset during competition.
+- **USB 3.0 port** — available for future use (e.g. USB storage or USB modem). Not used in
+  current INNEX-1 design.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-24 | eniomecaj | Initial datasheet — sourced from GL-A1300 Datasheet ver.20230602 (GL Technologies HK) |

--- a/docs/hardware/jetson-orin-nano-super.md
+++ b/docs/hardware/jetson-orin-nano-super.md
@@ -1,0 +1,138 @@
+# NVIDIA Jetson Orin Nano Super Developer Kit — Datasheet
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Manufacturer** | NVIDIA |
+| **Product** | Jetson Orin Nano Super Developer Kit |
+| **Carrier Board Spec** | SP-11324-001 v1.3 (December 2024) |
+| **Role on Rover** | High-level autonomy — navigation, perception, mission management |
+| **Power Domain** | 🔵 Compute (12 V from BD-01 → DC jack, 9–20 V range) |
+| **Qty on Rover** | 1 |
+| **Price** | £280.60 |
+| **Supplier** | RS Components |
+
+---
+
+## Module Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Processor | NVIDIA Orin (ARM Cortex-A78AE) |
+| AI Performance | 40 TOPS |
+| Memory | 8 GB 128-bit LPDDR5 (up to 68 GB/s) |
+| Storage | Micro SD card (UHS-1) |
+| Networking | 10/100/1000 BASE-T Ethernet |
+| OS | Linux (JetPack SDK) |
+| Developer Kit weight | 0.175 kg |
+
+---
+
+## Electrical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| **DC jack input voltage** | **9 – 20 V DC** |
+| **INNEX-1 supply** | **12 V from BD-01** (within range ✅) |
+| Max input current (at 19 V) | 4.2 A (~80 W max) |
+| Typical power (compute load) | 7 – 25 W depending on performance mode |
+| Module supply (internal) | 5 V only — carrier board always supplies VDD_IN at 5V regardless of module type |
+| Main 5V rail capacity | 7.8 A max |
+| Main 3.3V rail capacity | 5.4 A max |
+
+> **Important:** The developer kit carrier board has MODULE_ID pull-up removed. VDD_IN is always
+> 5V regardless of module. Custom carrier boards can support 5V/19V — the dev kit does not.
+> This does not affect INNEX-1 operation since we use the dev kit as-is.
+
+---
+
+## Carrier Board Dimensions
+
+| Parameter | Value |
+|-----------|-------|
+| Carrier board (PCB) | 100 × 79 mm |
+| Full developer kit | 103 × 90.5 × 34.77 mm |
+
+---
+
+## Connectors & INNEX-1 Usage
+
+| Connector | Spec | INNEX-1 Use |
+|-----------|------|-------------|
+| DC Jack (J16) | 9–20V input | 12V from BD-01 compute rail |
+| GbE RJ45 (J15) | Gigabit Ethernet | GL-A1300 router (→ OS1 LiDAR + telemetry) |
+| USB 3.2 Type A ×4 (J6, J7) | 5V, 0.5A max per port | OAK-D Pro ×2, Teensy 4.1 ×1, spare ×1 |
+| USB Type C (J5) | Recovery mode | Not used in operation |
+| CSI Camera ×2 (J20, J21) | 22-pin flex, 2.5 Gbps | **Not used** (cameras via USB) |
+| 40-pin expansion (J12) | 3.3V/5V GPIO, SPI, I2C, UART | Available — not currently allocated |
+| M.2 Key E (J10) | PCIe Gen3 x1, USB 2.0 | Available for future use |
+| Fan (J13) | 5V, 0.15A | Cooling fan if required |
+
+### USB Power Budget (per port)
+
+| Port | Max Current | INNEX-1 Device |
+|------|-------------|----------------|
+| USB 3.2 Type A #1 | 0.5 A @ 5V | OAK-D Pro Camera #1 |
+| USB 3.2 Type A #2 | 0.5 A @ 5V | OAK-D Pro Camera #2 |
+| USB 3.2 Type A #3 | 0.5 A @ 5V | Teensy 4.1 (serial comms + 5V power) |
+| USB 3.2 Type A #4 | 0.5 A @ 5V | Spare |
+
+> **USB current limit:** Each Type A port is limited to 0.5A from the Jetson USB hub. The
+> OAK-D Pro cameras may occasionally request more. Monitor for USB power warnings during
+> testing; if instability occurs, consider an externally powered USB hub.
+
+---
+
+## Connectivity Architecture (INNEX-1)
+
+```
+BD-01 (12V) ─────────────────────── DC Jack (J16)
+                                           │
+                              Jetson Orin Nano Super
+                                           │
+              ┌────────────────────────────┼───────────────────┐
+              │                            │                   │
+         GbE (J15)                USB Type A ×3          USB Type A ×1
+              │                    │       │                   │
+        GL-A1300 Router      Teensy 4.1  OAK-D Pro ×2      Spare
+              │
+        OS1 LiDAR (via router LAN)
+```
+
+---
+
+## Software Role
+
+The Jetson runs the **high-level autonomy stack only**:
+- ROS 2 (Humble) on Ubuntu
+- Navigation, localisation, mission management
+- Perception (OAK-D Pro depth/RGB via `depthai-ros`)
+- LiDAR (`ouster-ros`)
+- Commands sent to Teensy 4.1 over USB serial (`/dev/ttyACM0` or similar)
+- Telemetry streamed to ground station via GL-A1300 router
+
+> **The Jetson does not talk directly to any motor controller.** All motor I/O goes through
+> the Teensy 4.1. See software-team-notes.md and teensy-4.1-microcontroller.md.
+
+---
+
+## Key Rules & Gotchas
+
+- **Always power up Jetson and Teensy before applying 22.2V to Sabertooth** — floating signal
+  lines on Sabertooth power-on can be interpreted as drive commands.
+- **DC jack accepts 9–20V** — BD-01 at 12V is correct. Do not exceed 20V.
+- **USB Type A ports limited to 0.5A each** — verify cameras operate stably at this limit.
+- **60s LiDAR boot delay** — startup sequence must wait before expecting OS1 point cloud data.
+- **ESD sensitive** — always ground yourself before handling the carrier board or module.
+- **Do not hot-plug** peripherals while powered — shut down first before plugging/unplugging
+  cameras, M.2 cards, or expansion headers.
+- **Micro SD is primary storage** — use a fast UHS-1 card; slow cards cause JetPack performance issues.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-24 | eniomecaj | Initial datasheet — sourced from SP-11324-001 v1.3 carrier board spec (Dec 2024) |

--- a/docs/hardware/sabertooth-2x32.md
+++ b/docs/hardware/sabertooth-2x32.md
@@ -1,0 +1,177 @@
+# Sabertooth 2×32 Motor Driver — Datasheet
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Manufacturer** | Dimension Engineering |
+| **Model** | Sabertooth 2×32 |
+| **Role on Rover** | Dual-channel brushed DC motor driver — drive train |
+| **Power Domain** | 🔴 Motive (22.2 V input from WUPP fuse block, no individual blade fuse) |
+| **Qty on Rover** | 2 |
+| **INNEX-1 Assignment** | #1 = Left drivetrain (FL + RL motors); #2 = Right drivetrain (FR + RR motors) |
+
+---
+
+## Electrical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| **Input voltage (B+ to B−)** | **6.0 – 33.6 V** |
+| **INNEX-1 supply** | **22.2 V motive rail** ✅ (within range) |
+| Continuous output current (per channel) | **32 A** |
+| Peak output current (per channel) | **64 A** |
+| **INNEX-1 software current limit** | **≤ 10 A / channel** (⚠️ see safety note below) |
+| Output voltage (M1, M2) | ±95% of input voltage |
+| 5V logic output | 5 V @ 1 A max |
+| Power outputs (P1, P2) | Open collector, 8 A sink max each |
+| Signal input voltage (S1, S2, A1, A2) | 0 – 5 V (3.3 V logic compatible — no level shifter needed) |
+| Switching frequency | 30 kHz (silent — no motor whine) |
+| Operating temperature | −20 °C to +70 °C (derates above 40 °C ambient) |
+
+> **Current derating:** At 40 °C ambient the full 32 A/channel is available. At 70 °C ambient
+> continuous rating drops to 10 A/channel. INNEX-1 software limits to ≤10 A/channel regardless.
+
+---
+
+## ⚠️ Safety: Software Current Limit — REQUIRED for INNEX-1
+
+The motive domain trunk fuse is **40 A ANL** (protecting the entire motive rail). There is
+**no blade fuse between the fuse block and the Sabertooth** — the Sabertooth's own 64 A peak
+capability would allow cable damage before the ANL fuse trips.
+
+**The Teensy 4.1 firmware MUST configure the Sabertooth current limit to ≤ 10 A per channel**
+before commanding any motion. This is enforced via the DEScribe PC software or packet serial
+commands. Without this limit, the motor wiring may be at risk.
+
+See `software-team-notes.md` and `fuses.md` for the full fuse rationale.
+
+---
+
+## Physical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Dimensions | 70 × 90 × 26 mm (2.75 × 3.5 × 1.0 in) |
+| Weight | 125 g (4.5 oz) |
+| Recommended motor wire | 10–12 AWG |
+| Recommended battery wire | 10 AWG (INNEX-1 uses 10 AWG ✅) |
+
+---
+
+## Terminal Wiring Reference
+
+| Terminal | Description | Voltage | Current |
+|----------|-------------|---------|---------|
+| **B+** | Power input positive | 6 – 33.6 V | 64 A peak |
+| **B−** | Power input negative | 0 V (GND) | 64 A peak |
+| **M1A / M1B** | Motor 1 output | 0 – 33.6 V | 32 A / 64 A peak |
+| **M2A / M2B** | Motor 2 output | 0 – 33.6 V | 32 A / 64 A peak |
+| **0V** | Logic ground (tied internally to B−) | 0 V | 2 A max |
+| **5V** | Regulated 5 V output | 5 V | 1 A max |
+| **S1** | Serial RX (main signal input) | 0 – 5 V | 1 mA |
+| **S2** | Serial TX (main signal input / indicator output) | 0 – 5 V | 1 mA in / 20 mA out |
+| **A1** | Auxiliary input 1 | 0 – 5 V | 1 mA |
+| **A2** | Auxiliary input 2 / indicator output | 0 – 5 V | 1 mA in / 20 mA out |
+| **P1 / P2** | Power outputs (open collector sink) | 0 – 33.6 V | 8 A each |
+
+---
+
+## INNEX-1 Wiring
+
+| Sabertooth Terminal | INNEX-1 Connection |
+|--------------------|--------------------|
+| B+ | WUPP fuse block (motive rail 22.2 V) |
+| B− | Motive domain GND bus |
+| M1A / M1B | Drive motor 1 (e.g. Front-Left or Front-Right) |
+| M2A / M2B | Drive motor 2 (e.g. Rear-Left or Rear-Right) |
+| S1 | Teensy 4.1 TX (UART) |
+| S2 | Teensy 4.1 RX (optional — needed for telemetry/readback) |
+| 0V | Common GND with Teensy / logic domain |
+
+**Teensy UART pin assignments (from `teensy-4.1-microcontroller.md`):**
+- Sabertooth #1: Teensy pins 0 (TX1) and 1 (RX1) — Left drivetrain
+- Sabertooth #2: Teensy pins 7 (TX2) and 8 (RX2) — Right drivetrain
+
+---
+
+## Serial Control Mode
+
+The Sabertooth is controlled by the Teensy 4.1 over **TTL UART (plain text or packet serial)**.
+
+### DIP Switch Settings for Serial Mode
+
+| DIP Switch | Position | Function |
+|------------|----------|----------|
+| 1 | — | Baud rate (see below) |
+| 2 | — | Baud rate (see below) |
+| 3 | OFF | Battery protect mode (LiPo auto-detect) |
+| **4** | **ON** | **Packet / plain text serial mode** |
+| **5** | **ON** | **Packet serial address 128** |
+| **6** | **ON** | **Emergency stops disabled** (A1/A2 not used as E-stop) |
+
+> DIP 6 ON = emergency stops disabled. INNEX-1 uses software-only stop via Teensy. If hardware
+> E-stop is later needed, wire A1 → 5V (M1 enable) and A2 → 5V (M2 enable), then set DIP 6 OFF.
+
+### Baud Rate (DIP 1 & 2, switch 4 ON)
+
+| DIP 1 | DIP 2 | Baud Rate |
+|-------|-------|-----------|
+| OFF | OFF | 2400 |
+| ON | OFF | 9600 ✅ (default, recommended) |
+| OFF | ON | 19200 |
+| ON | ON | 38400 |
+
+**Use 9600 baud (DIP1 ON, DIP2 OFF) for INNEX-1.**
+
+### Plain Text Serial Commands (key examples)
+
+```
+M1: 2047\r\n       → Motor 1 full forward
+M2: -2047\r\n      → Motor 2 full reverse
+M1: 0\r\n          → Motor 1 stop
+M1: getc\r\n       → Read motor 1 current (tenths of amp)
+M1: getb\r\n       → Read battery voltage (tenths of volt)
+M1:shutdown\r\n    → Hard brake motor 1
+M1:startup\r\n     → Resume normal operation
+```
+
+Command range: −2047 to +2047. Positive = forward, negative = reverse.
+
+---
+
+## Motor Connection Direction
+
+| Wire to M1A | Wire to M1B | Effect |
+|-------------|-------------|--------|
+| Motor + (Red) | Motor − (Black) | Forward when positive command |
+| Motor − (Black) | Motor + (Red) | Reverse when positive command |
+
+> If drive direction is wrong, swap M1A/M1B at the Sabertooth terminal. Do not invert
+> in software first — establish physical forward in wiring, then calibrate software.
+
+---
+
+## Key Rules & Gotchas
+
+- **Power up sequence:** Always power Jetson + Teensy **before** applying 22.2 V to the motive rail.
+  Floating signal lines on Sabertooth power-on can be interpreted as drive commands.
+- **Software current limit ≤ 10 A/channel is MANDATORY** — no hardware fuse protects the branch.
+- **22.2 V is within the 33.6 V max** — 6S LiPo fully charged ~25.2 V is also within spec ✅
+- **Battery protect mode (DIP 3 OFF):** Sabertooth will auto-detect 6S LiPo (6 cells) and stop motors
+  when voltage is depleted. Verify cell count is detected correctly at startup (Status LED blink pattern).
+- **3.3 V logic compatible:** Teensy 4.1 is 3.3 V — no level shifter required on S1/S2.
+- **0V must be shared with Teensy GND** for serial communication — connect logic grounds.
+- **Regenerative braking:** Returns energy to battery during braking — do not use with non-rechargeable
+  batteries. 6S LiPo is correct for this.
+- **Do not exceed 10 AWG on battery leads** — Sabertooth terminal max is 10 AWG.
+- **DEScribe software** (Windows) used to set current limits, configure modes, update firmware.
+  Connect via Micro USB. No battery/motors needed for configuration.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-24 | eniomecaj | Initial datasheet — sourced from Sabertooth 2×32 User Manual (Dimension Engineering) |

--- a/docs/hardware/tru-components-linear-actuator-50mm.md
+++ b/docs/hardware/tru-components-linear-actuator-50mm.md
@@ -1,0 +1,109 @@
+# TRU Components TC-13492780 — Linear Actuator 50mm Datasheet
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Manufacturer** | TRU Components (Conrad Electronic SE) |
+| **Part Number (MPN)** | TC-13492780 |
+| **Datasheet Item No.** | 3373195 |
+| **EAN** | 4064161472003 |
+| **Order Code** | 18-2816 |
+| **Role on Rover** | Linear actuation — deployment / adjustment mechanism |
+| **Power Domain** | 🔴 Motive (24 V from motive rail via Cytron MDD10A) |
+| **Qty on Rover** | 2 |
+| **Price** | £67.75 (pair) |
+| **Supplier** | TRU Components |
+| **Compliance** | RoHS |
+
+---
+
+## Electrical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Input voltage | **24 V DC** |
+| No-load speed | 16 ± 10% mm/s |
+| Rated current | **1.6 A** |
+| Rated load capacity | **500 N** |
+| Duty cycle | **10% — 2 min on / 18 min off** |
+| Hall effect sensor | **Yes** (included, unused on INNEX-1) |
+| Protection class | IP65 |
+| Operating temperature | −20 °C to +60 °C |
+
+> **Duty cycle is critical:** Maximum 2 minutes continuous operation followed by 18 minutes off.
+> Exceeding this will overheat the motor winding. Mission profiles must enforce timed actuation
+> with adequate rest between moves.
+
+---
+
+## Mechanical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Stroke length | **50 mm** |
+| Minimum installation length | 155 ± 3 mm |
+| Cable length | 900 ± 20 mm |
+| Limit switch | Inner (built-in, both ends of travel) |
+| Thrust | 500 N rated |
+
+> The inner limit switch cuts motor current at both ends of travel — the actuator will stop
+> automatically at full extend and full retract without needing software end-stop detection.
+
+---
+
+## Wire Colours & INNEX-1 Connections
+
+The actuator ships with **6 wires**. INNEX-1 uses only the 2 motor power wires — the encoder
+is not connected as the Cytron MDD10A runs open-loop.
+
+| Wire Colour | Function | INNEX-1 Connection |
+|-------------|----------|-------------------|
+| **Brown** | Motor + | Cytron MDD10A M1A (or M2A) |
+| **Blue** | Motor − | Cytron MDD10A M1B (or M2B) |
+| Red | Encoder +5V | **Not connected** |
+| Black | Encoder GND | **Not connected** |
+| Yellow | Encoder CH-A | **Not connected** |
+| White | Encoder CH-B | **Not connected** |
+
+> **Direction reversal:** If the actuator extends when it should retract, swap Brown and Blue at
+> the Cytron M1A/M1B terminals. Do not invert direction in software first.
+
+> **Unused encoder wires:** Tape or heat-shrink the Red, Black, Yellow, and White wires
+> individually to prevent shorts. Do not leave bare ends loose near the motive rail.
+
+---
+
+## Motor Controller Interface
+
+| Parameter | Value |
+|-----------|-------|
+| Controller | Cytron MDD10A (dual channel) |
+| Actuators per controller | 2 (one per channel) |
+| Control type | **Open-loop — timed PWM commands, no position feedback** |
+| Teensy PWM pins | Actuators 1 & 2: Pins 2, 3 / Actuators 3 & 4: Pins 4, 5 |
+| Teensy DIR pins | Actuators 1 & 2: Pins 9, 10 / Actuators 3 & 4: Pins 11, 12 |
+| Fuse (motive fuse block) | **15 A blade** per Cytron MDD10A slot |
+
+> Both actuators on a single Cytron channel share a 15 A fuse. Peak draw per actuator is 1.6 A
+> so two actuators = 3.2 A combined — well within the 15 A fuse and 10 A Cytron channel rating.
+
+---
+
+## Key Rules & Gotchas
+
+- **2 min on / 18 min off** — strictly enforced duty cycle. Do not run continuously.
+- **IP65 rated** — sealed against dust and water jets; suitable for regolith environment.
+- **Built-in limit switches** cut power at end of travel — no software end-stops needed, but
+  software should still time out commands to avoid stalling against the limit switch repeatedly.
+- **Never connect 24 V directly to the Teensy** — all 24 V switching goes through the Cytron MDD10A.
+- **Encoder unused** — open-loop control only. If position feedback is needed in future, the
+  encoder wires (Red/Black/Yellow/White) are available but currently disconnected.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-24 | eniomecaj | Initial datasheet — sourced from TRU Components datasheet (item 3373195) and INNEX-1 wiring notes |

--- a/docs/hardware/wupp-fuse-block-pdb.md
+++ b/docs/hardware/wupp-fuse-block-pdb.md
@@ -1,0 +1,98 @@
+# WUPP 12-Circuit Fuse Block — Datasheet
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Manufacturer** | WUPP |
+| **ASIN** | B07GBST5NX |
+| **Role on Rover** | Power Distribution Board — branch fusing for motive domain devices |
+| **Power Domain** | 🔴 Motive (22.2 V input from 40A ANL fuse) |
+| **Qty on Rover** | 1 |
+| **Price** | £27.51 |
+| **Supplier** | Amazon (KRS STORE LTD) |
+| **Rating** | 4.7/5 (4,106 ratings) |
+
+---
+
+## Electrical Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Input voltage | **DC 12 – 24 V** (compatible with 22.2 V motive rail) |
+| Total block capacity | **100 A** |
+| Max current per slot | **30 A** |
+| Number of circuits | **12** (standard blade fuse, ATO/ATC) |
+| Negative bus | **Yes** — integrated ground bus bar |
+| LED fault indicator | **Yes** — red LED per circuit lights when fuse is blown |
+| Connector type | Screw terminal |
+| Mounting type | Chassis mount |
+| Terminal material | Nickel-plated copper |
+| Cover material | PBT (flame resistant, heat resistant, waterproof) |
+| Cover type | Damp-proof removable cover |
+
+---
+
+## Included Fuse Kit
+
+| Rating | Qty |
+|--------|-----|
+| 5 A | 6 |
+| 10 A | 6 |
+| 15 A | 6 |
+| 20 A | 6 |
+
+**All fuses required for INNEX-1 are in the included kit — no additional orders needed.**
+
+---
+
+## INNEX-1 Slot Assignments
+
+For full fuse rationale see **fuses.md**.
+
+| Slot | Device | Fuse Fitted |
+|------|--------|-------------|
+| 1 | Sabertooth 2×32 #1 (Left: FL + RL) | None — 40A ANL is domain protection |
+| 2 | Sabertooth 2×32 #2 (Right: FR + RR) | None — 40A ANL is domain protection |
+| 3 | Cytron MDD10A #1 (50mm Actuators 1 & 2) | **15 A** |
+| 4 | Cytron MDD10A #2 input (→ DollaTek 12V buck → 250mm Actuators 3 & 4) | **15 A** |
+| 5 | BLD-510B (Excavation BLDC) | **10 A** |
+| 6–12 | Spare | — |
+
+> **Why no fuse on Sabertooth slots:** The 40A ANL inline fuse between the battery and fuse block
+> is the domain protection for the motive rail. The Sabertooth 2×32 draws up to 26A peak
+> (2 motors × 13A) — no standard blade fuse in the included kit is appropriate without
+> nuisance tripping. See fuses.md for full reasoning.
+
+---
+
+## Physical & Wiring Notes
+
+- **Input:** Single feed from motive domain — connect after the 40A ANL inline fuse
+- **Negative bus:** Connect all device GNDs to the negative bus bar for a clean star topology
+- **LED indicators:** One red LED per slot — useful for fault diagnosis during testing and
+  competition. A blown fuse causes the corresponding LED to illuminate
+- **Cover:** Damp-proof cover should be fitted during operation to protect against regolith dust
+- **Chassis mount:** Secure inside chassis enclosure with M-series bolts; keep accessible for
+  fuse replacement during competition
+
+---
+
+## Key Rules & Gotchas
+
+- **100A block total, 30A max per slot** — motive domain ANL is 40A so total block load is
+  already capped well below the 100A block rating
+- **Standard blade fuses only (ATO/ATC)** — do not fit mini or micro blade fuses; they will
+  not make contact with the terminals correctly
+- **LED on = blown fuse** — not a power indicator. If LED is on, check and replace the fuse
+  before re-energising that branch
+- **Damp-proof, not waterproof** — rated for damp environments, not submersion. Suitable for
+  enclosed chassis with potential dust ingress but do not expose to water directly
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-24 | eniomecaj | Initial datasheet — sourced from Amazon product page (ASIN B07GBST5NX, WUPP) |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds hardware datasheets and documentation for INNEX-1 rover components. Introduces nine new documentation pages covering:

- **Motor Drivers**: STEPPERONLINE BLD-510B BLDC controller, Sabertooth 2×32, and Cytron MDD10A dual-channel DC motor driver
- **Power Systems**: DollaTek 300W buck converter and WUPP 12-Circuit Fuse Block power distribution
- **Actuators**: DCHOUSE 250mm and TRU Components 50mm linear actuators
- **Computing & Networking**: NVIDIA Jetson Orin Nano Super and GL.iNet GL-A1300 router

Each datasheet includes electrical specifications, wiring diagrams, INNEX-1 integration details, operational constraints, and revision history entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->