### PR TITLE
electrical datasheets

### DIFF
--- a/docs/hardware/57blr50-excavation-motor.md
+++ b/docs/hardware/57blr50-excavation-motor.md
@@ -12,6 +12,7 @@
 | **Price** | £46.79 |
 | **Supplier** | StepperOnline |
 | **Drawing Date** | 12.8.2023 |
+| **Weight** | ~800 g (estimated — 57 mm BLDC with HG100 100:1 gearbox) |
 
 ---
 
@@ -102,7 +103,7 @@ This motor is driven by the **BLD-510B BLDC motor controller**.
 
 ---
 
-## Known Constraints & Gotchas
+## Key Notes & Constraints
 
 - **100:1 gearbox gives high torque at low speed** — output is ~35 RPM at rated conditions.
   This is appropriate for excavation duties but means back-driving is not possible.

--- a/docs/hardware/bld-510b-bldc-controller.md
+++ b/docs/hardware/bld-510b-bldc-controller.md
@@ -9,6 +9,7 @@
 | **Role on Rover** | Brushless DC motor driver — excavation motor (57BLR50) |
 | **Power Domain** | 🔴 Motive (22.2 V from WUPP fuse block slot 5, 10 A blade fuse) |
 | **Qty on Rover** | 1 |
+| **Weight** | ~200 g (estimated from dimensions 118 × 75.5 × 34 mm) |
 
 ---
 
@@ -89,16 +90,16 @@
 |-------------|--------|----------------|-------|
 | GND | Signal GND | GND | Shared logic ground |
 | SV | Speed PWM | **Pin 6** | 1–2 kHz PWM, 3.3 V amplitude (see note) |
-| EN | Enable | **Pin 13** | HIGH = stop (V2.0 logic), LOW = run |
-| F/R | Direction | **Pin 14** | LOW = CCW, HIGH/open = CW |
+| F/R | Direction | **Pin 13** | LOW = CCW, HIGH/open = CW |
+| EN | Enable | **Pin 14** | HIGH = stop (V2.0 logic), LOW = run |
 | BK | Brake | **TBD** | LOW = brake; use GPIO output |
-| PG | Speed feedback | **Pin 15** | Open-collector — add 4.7 kΩ pull-up to 3.3 V |
-| ALM | Alarm | **Pin 16** | Open-collector — add 4.7 kΩ pull-up to 3.3 V |
+| PG | Speed feedback | **Pin 31** | Open-collector — add 10 kΩ pull-up to 3.3 V |
+| ALM | Alarm | **Pin 32** | Open-collector — add 10 kΩ pull-up to 3.3 V |
 
-> **SV PWM amplitude:** The SV pin accepts 0–5 V. Teensy 4.1 outputs 3.3 V PWM. This gives
-> approximately 66% of rated speed at full duty cycle. Adjust R-SL potentiometer on driver to
-> scale accordingly, or set maximum speed via internal jumpers to match the 57BLR50 target RPM.
-> See `teensy-4.1-microcontroller.md` for confirmed pin assignments.
+> **SV PWM — no external RC filter needed:** The BLD-510B SV pin accepts PWM directly (1–2 kHz
+> from Teensy Pin 6). No external RC filter is required — the driver handles the PWM internally.
+> Teensy outputs 3.3 V PWM which gives ~66% of rated speed at full duty cycle; adjust the R-SL
+> potentiometer to scale as needed. See `teensy-4.1-microcontroller.md` for confirmed pin assignments.
 
 ---
 
@@ -165,10 +166,11 @@ The ALM output goes LOW during any alarm — Teensy should monitor this pin.
 
 ---
 
-## Key Rules & Gotchas
+## Key Rules & Notes
 
-- **PG and ALM are open-collector** — must have external pull-up resistors (3–10 kΩ to 5 V
-  or 4.7 kΩ to 3.3 V for Teensy inputs). Without pull-ups, pins float and give false readings.
+- **PG and ALM are open-collector** — if you intend to monitor speed feedback (PG) or fault
+  alarms (ALM), fit 10 kΩ pull-up resistors to 3.3 V at Teensy Pins 31 and 32. If PG/ALM
+  monitoring is not used, pull-ups can be omitted and the pins left unconnected.
 - **Check EN firmware version before first power-on** — wrong EN polarity causes motor to
   run immediately at power-up, before the Teensy asserts control.
 - **Never change F/R direction while motor is running** — always bring motor to stop first
@@ -191,3 +193,5 @@ The ALM output goes LOW during any alarm — Teensy should monitor this pin.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-24 | eniomecaj | Initial datasheet — sourced from BLD-510B User Manual V1 (STEPPERONLINE, 2024) |
+| 2026-05-24 | eniomecaj | Corrected pin assignments (F/R↔EN, PG→31, ALM→32); RC filter removed (not needed); PG/ALM pull-ups made optional |
+  

--- a/docs/hardware/connectors-and-accessories.md
+++ b/docs/hardware/connectors-and-accessories.md
@@ -1,21 +1,21 @@
 # INNEX-1 Connectors & Accessories Reference
 
 Single reference for all connector, passive, and accessory items purchased. Not individual
-component datasheets — just enough to know what each item is for and any gotchas.
+component datasheets — just enough to know what each item is for and any key points to watch.
 
 ---
 
 ## Power Distribution & Regulation
 
-### BD-01 — 12 V Buck Converter (Voltage Regulator 2, £7.77, Amazon)
+### BD-01 — 12 V Buck Converter (DollaTek Reg.NO:013726393, £7.77, Amazon)
 - **Role:** Steps 14.8 V compute battery down to 12 V for Jetson Orin Nano + OS1 LiDAR
-- **Rated:** ≥ 10 A output required (Jetson ~3–4 A + LiDAR ~2–3 A = ~6 A combined, 10 A headroom)
-- **Note:** Pending CDR update — confirm module is rated ≥ 10 A and update power budget table
+- **Rated:** ≤ 10 A output confirmed (Jetson ~3–4 A + LiDAR ~2–3 A = ~6 A combined, 10 A headroom)
+- **Output distribution:** 12 V output feeds WAGO 2-in-4-out block → Jetson (pigtail barrel jack) + LiDAR (pigtail barrel jack), 2 spare outputs
 
-### BD-02 — 5 V Buck Converter (Voltage Regulator 1, £3.22, Switch Electronics)
-- **Role:** Steps 14.8 V compute battery down to 5 V for OAK-D Pro cameras (×2) + GL-A1300 router
-- **Rated:** Must supply ~3–4 A total (2 × camera ~0.5–1 A + router ~1.3 A)
-- **Note:** Output goes to WAGO 2-in-6-out block; no USB hub needed
+### BD-02 — 5 V Buck Converter (Yosoo Health Gear g0qigxo64d, £3.22, Switch Electronics)
+- **Role:** Steps 14.8 V compute battery down to 5 V for OAK-D Pro cameras (×2) + GL-A1300 router + IMU
+- **Rated:** ≤ 10 A output confirmed. Actual load: cameras ~2 A + router ~1.3 A + IMU ~0.1 A = ~3.4 A
+- **Output distribution:** 5 V output feeds WAGO 2-in-6-out block (3 active outputs: router, camera ×2)
 
 ---
 
@@ -27,8 +27,8 @@ component datasheets — just enough to know what each item is for and any gotch
 - ⚠️ Ensure wire gauge matches WAGO clamp rating (check product page — typically rated for 0.5–6 mm² / 20–10 AWG)
 
 ### WAGO 2-in-4-out (£9.89, Amazon)
-- **Role:** Original BD-02 distribution block — superseded by 2-in-6-out
-- **Status:** Spare / not used in final design. Keep as backup.
+- **Role:** BD-01 12 V output distribution — Jetson (pigtail barrel jack) + LiDAR (pigtail barrel jack)
+- **Status:** ✅ Active — 2 outputs in use (Jetson + LiDAR), 2 spare
 
 ---
 
@@ -47,19 +47,19 @@ component datasheets — just enough to know what each item is for and any gotch
 ### Yellow Ring Terminal 8.4mm (£7.69, Amazon)
 - **Role:** Battery terminal connections at the XT90 / ANL fuse ends
 - **Note:** 8.4mm inner diameter fits M8 bolts. Confirm your battery terminal bolt size before crimping. Crimp with proper ratchet crimper — a bad crimp on the main battery lead is a fire risk.
-- ⚠️ Use the correct terminal size for 10 AWG wire — yellow ring terminals are typically rated for 4–6 AWG in some kits. **Verify the crimp barrel fits 10 AWG before use.**
+- Yellow ring terminals are rated for 12–10 AWG — 10 AWG wire fits correctly ✅
 
 ### USB-C to 2-Pin Bare Wire (×2, £8.99, Amazon)
 - **Role:** 5 V power feed cables from BD-02 WAGO → GL-A1300 router (USB-C) and any USB-C powered device
 - **Note:** Verify polarity of bare wires before connecting to WAGO — red = +5 V, black = GND. USB-C can be damaged by reverse polarity.
 
 ### 6× 5.5mm × 2.5mm 90° DC Power Male Plug (£6.99, Amazon)
-- **Role:** DC barrel jack connectors for Jetson Orin Nano power input (J16 on carrier board)
-- **Note:** Jetson DC jack is **5.5mm OD × 2.5mm ID center-positive** — this matches the item spec ✅. The 90° angle helps with cable routing in the chassis. Solder the wire to the plug before heatshrinking — centre pin = positive (12 V), outer shell = GND.
+- **Role:** DC barrel jack connector for **Ouster OS1 LiDAR** 12 V power input (from BD-01 via WAGO 2-in-4-out)
+- **Note:** OS1 LiDAR DC jack is **5.5mm OD × 2.5mm ID center-positive** ✅. The 90° angle helps with cable routing. Solder wire to plug before heatshrinking — centre pin = positive (12 V), outer shell = GND.
 
 ### Pigtail to DC Barrel Jack (£7.19, Amazon)
-- **Role:** Pre-made pigtail cable for Jetson power — alternative/backup to the bare plugs above
-- **Note:** Check that it's also 5.5mm × 2.5mm centre-positive before use.
+- **Role:** Pre-made pigtail cable for **Jetson Orin Nano** power input (J16 on carrier board, from BD-01 via WAGO 2-in-4-out)
+- **Note:** Confirm 5.5mm × 2.5mm centre-positive before use ✅
 
 ---
 
@@ -77,25 +77,28 @@ component datasheets — just enough to know what each item is for and any gotch
 
 ## Switches
 
-### Switch for Main Battery (£14.95, Switch Electronics)
-- **Role:** Main power cutoff switch for the compute domain (4S battery)
-- **Note:** Rated current must cover BD-01 + BD-02 combined draw (~8 A max). Verify rating on the purchased switch. Wire in series between the 4S battery positive and the 20 A inline fuse holder.
+### Switch for Main Battery — SCI A23-2 200A 12–50V DC (£14.95, Switch Electronics)
+- **Role:** Main power cutoff switch for the **motive domain (6S LiPo, 22.2 V)**
+- **Rated:** 200 A @ 12–50 V DC ✅ — well above the 40 A peak motive draw
+- **Note:** Wire in series on the motive domain positive rail between XT90 and the 40 A ANL fuse holder
 
-### Rocker Switch (£8.99, Amazon)
-- **Role:** Secondary power switch — likely for motive domain or as a panel power indicator switch
-- **Note:** Clarify with KJ which domain this serves. If on the motive domain, verify it's rated for 22.2 V DC at the expected current.
+### Rocker Switch / Compute Domain Arming Switch (£8.99, Amazon)
+- **Role:** Power cutoff switch for the **compute domain (4S battery, 14.8 V)**
+- **Note:** Wire in series between the 4S battery positive and the 20 A inline fuse holder. Must be rated for ≥ 12 A at 14.8–16.8 V DC
 
 ---
 
 ## Safety
 
-### E-Stop (£32.95, Amazon)
-- **Role:** Physical emergency stop — cuts motive power during a fault or unsafe condition
-- **Wiring options:**
-  1. **Hardware E-stop via Sabertooth:** Wire E-stop contacts to Sabertooth A1 (M1 enable) and A2 (M2 enable). Set Sabertooth DIP switch 6 to OFF (emergency stops enabled). When E-stop is pressed, A1/A2 go low → both motor outputs cut immediately.
-  2. **Main contactor / relay:** E-stop cuts the motive rail entirely upstream of the WUPP fuse block.
-- ⚠️ The compute domain (Jetson, LiDAR, router) should **remain live through an E-stop** per `fuses.md` — only motive power should be interrupted.
-- Confirm wiring approach with KJ before competition — option 1 (Sabertooth A1/A2) is already supported in hardware with no additional relay needed.
+### E-Stop — Heavy Duty DC Emergency Stop (Amazon)
+- **Rated:** 250 A @ 80 V DC
+- **Action:** Push-to-break (pressing opens the circuit — cuts motive power), pull-to-make (pulling closes the circuit — restores power). Latches in open position until manually pulled to reset.
+- **Terminals:** M8 copper primary connection posts
+- **Protection:** IP50
+- **Life:** 10,000 cycle mechanical design life
+- **Mounting:** 2× M5 mounting holes
+- **Role:** Cuts the motive domain (6S LiPo, 22.2 V) upstream of the 40 A ANL fuse and WUPP fuse block. Single-push disables all drivetrain and actuator power instantly.
+- ⚠️ The compute domain (Jetson, LiDAR, router) remains **live through an E-stop** — compute battery is on a fully isolated rail. See `fuses.md`.
 
 ---
 
@@ -119,7 +122,7 @@ component datasheets — just enough to know what each item is for and any gotch
 
 ### Treedix Breakout Board Module (£18.20, Amazon)
 - **Role:** Likely a Teensy 4.1 breakout / proto board for cleaner wiring
-- **Note:** Clarify with KJ what this is specifically for. If it's a Teensy screw-terminal breakout, it makes the motor controller wiring much cleaner than header pins alone.
+- **Note:** Likely a Teensy screw-terminal breakout board — makes motor controller wiring much cleaner than header pins alone.
 
 ### Teensy Stackable Header Kit (£1.80, PiHut)
 - **Role:** Stackable pin headers for Teensy 4.1 — allows the Teensy to sit on a proto board or breakout while remaining removable
@@ -148,8 +151,8 @@ component datasheets — just enough to know what each item is for and any gotch
 | Yellow Ring Terminal | Verify crimp barrel fits **10 AWG** wire — some "yellow" terminals are rated for 4–6 AWG only |
 | XT90 Anti-Spark | Confirm male/female orientation — resistor pre-charge pin must be on battery side |
 | DC Barrel Jack (5.5×2.5mm) | Confirm centre-positive, 12 V from BD-01 before plugging Jetson in |
-| E-Stop | Agree wiring method with KJ — Sabertooth A1/A2 hardware path recommended |
-| Rocker Switch | Confirm voltage/current rating matches its domain |
+| E-Stop | Push-break (250 A, 80 V DC) — wire in series on motive domain positive rail |
+| Compute Switch | Confirm rating ≥ 12 A @ 16.8 V for compute domain arming switch |
 | BD-01 Buck | Confirm module output current rating ≥ 10 A |
 
 ---
@@ -159,3 +162,4 @@ component datasheets — just enough to know what each item is for and any gotch
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-24 | eniomecaj | Initial file — sourced from INNEX-1 BOM (connectors/accessories section) |
+| 2026-05-24 | eniomecaj | Updated BD-01/BD-02 names; WAGO 2-in-4-out marked active for BD-01 rail; barrel jack roles clarified; E-stop specs updated; switch domains corrected; KJ refs removed |

--- a/docs/hardware/cytron-mdd10a.md
+++ b/docs/hardware/cytron-mdd10a.md
@@ -9,6 +9,7 @@
 | **Role on Rover** | Dual-channel PWM motor driver — linear actuators |
 | **Power Domain** | 🔴 Motive (see per-unit detail below) |
 | **Qty on Rover** | 2 |
+| **Weight** | ~100 g each / ~200 g total (estimated — 84.5 × 62 mm PCB) |
 
 | Unit | Power Input | Controls |
 |------|-------------|----------|
@@ -122,7 +123,7 @@ The direction LEDs are useful for confirming correct actuator polarity during be
 
 ---
 
-## Key Rules & Gotchas
+## Key Rules & Notes
 
 - **10A continuous, 30A peak** — the 50mm actuators draw up to 1.6 A each (well within limit).
   The 250mm actuators draw up to 3 A each; combined max is 6 A — within the 10 A rating.

--- a/docs/hardware/dchouse-linear-actuator-250mm.md
+++ b/docs/hardware/dchouse-linear-actuator-250mm.md
@@ -13,6 +13,7 @@
 | **Price** | £35.99 (pair) |
 | **Supplier** | Amazon (DCHOUSE GLOBAL-UK) |
 | **Rating** | 4.3/5 — #1 Best Seller, Linear Motion Actuators |
+| **Weight** | ~350 g each / ~700 g total (estimated) |
 
 > **Voltage note:** This actuator is rated 12V DC. The motive rail is 22.2V. A DollaTek 300W
 > buck converter steps the motive rail down to 12V before Cytron MDD10A #2 — no duty cycle
@@ -82,7 +83,7 @@ This actuator has **2 wires only** — no encoder.
 
 ---
 
-## Key Rules & Gotchas
+## Key Rules & Notes
 
 - **Powered via 12V buck — no duty cycle restriction needed.** Cytron MDD10A #2 runs at 12V
   from the buck output; full PWM range is available.

--- a/docs/hardware/dollatek-buck-converter-12v.md
+++ b/docs/hardware/dollatek-buck-converter-12v.md
@@ -11,6 +11,7 @@
 | **Qty on Rover** | 1 |
 | **Price** | £5.99 |
 | **Supplier** | Amazon (DollaTek) |
+| **Weight** | ~80 g (estimated — 65 × 47 × 23.5 mm) |
 
 ---
 
@@ -68,7 +69,7 @@
 
 ---
 
-## Key Rules & Gotchas
+## Key Rules & Notes
 
 - **No reverse polarity protection** — wiring polarity must be correct. Reversed input will
   likely damage the module.

--- a/docs/hardware/electrical-box-layout.md
+++ b/docs/hardware/electrical-box-layout.md
@@ -1,0 +1,164 @@
+# INNEX-1 Electrical Box Layout
+
+Physical layout, zoning, component weights, and mounting strategy for the INNEX-1
+electrical enclosure. Cross-reference with CDR Section 4 (Physical Integration) and
+the mechanical team's CAD assembly.
+
+---
+
+## Enclosure Overview
+
+| Parameter | Value |
+|-----------|-------|
+| Baseplate material | 5 mm polycarbonate |
+| Cooling strategy | Single-direction active airflow — intake → compute zone → battery zone → motor driver zone → exhaust |
+| Mounting clearance | ≥ 10 mm standoffs under all PCBs (airflow + solder joint protection) |
+| Regolith protection | Filtered intake vents; motor bodies shielded within chassis |
+
+---
+
+## Zone Layout
+
+```
+AIR IN ──► [ COOL ZONE ]──►[ NEUTRAL ZONE ]──►[ HOT ZONE ] ──► AIR OUT
+            Jetson, router    6S + 4S batteries   Sabertooth ×2
+            cameras, Teensy   (strapped to base)   Cytron ×2, BLD-510B
+            LiDAR, sensors                         WUPP fuse block
+```
+
+### Cool Zone (Intake Side)
+Receives the coolest incoming air. Houses all heat-sensitive electronics.
+
+| Component | Mounting | Standoff Height |
+|-----------|----------|----------------|
+| Jetson Orin Nano Super (with carrier board) | M3 through baseplate | 15–20 mm |
+| GL-A1300 Router | Velcro / M3 screws | 10 mm |
+| OAK-D Pro Cameras ×2 | Bracket to chassis wall (VESA M4 75 mm) | External — not in box |
+| Teensy 4.1 | Breakout board, M2.5 screws | 10 mm |
+| BD-01 Buck (DollaTek, 12V) | M2.5 screws / adhesive pad | 5 mm |
+| BD-02 Buck (Yosoo, 5V) | M2.5 screws / adhesive pad | 5 mm |
+| WAGO 2-in-4-out (BD-01 dist.) | Clip-mount to DIN rail or baseplate | — |
+| WAGO 2-in-6-out (BD-02 dist.) | Clip-mount to DIN rail or baseplate | — |
+| Inline fuse holder (20 A compute) | Cable-mount, zip-tied | — |
+| Ouster OS1-128 LiDAR | Top-mounted bracket (external, above enclosure) | External |
+
+### Neutral Zone (Centre)
+Batteries are thermally isolated between the two active zones.
+
+| Component | Mounting | Notes |
+|-----------|----------|-------|
+| Turnigy 6S 8000 mAh (motive) | Mechanical straps + foam padding to baseplate | Heaviest item — mount low and central for CG |
+| Turnigy 4S 5000 mAh (compute) | Mechanical straps alongside 6S | Balance lead accessible for buzzer alarm |
+| LiPo buzzer alarms ×2 | Zip-tied to battery balance leads | 1S–8S buzzer per battery |
+
+### Hot Zone (Exhaust Side)
+Highest heat-generating components nearest exhaust vents.
+
+| Component | Mounting | Standoff Height |
+|-----------|----------|----------------|
+| Sabertooth 2×32 #1 (Left drive) | M3 screws, heatsink facing airflow | 12–15 mm |
+| Sabertooth 2×32 #2 (Right drive) | M3 screws, heatsink facing airflow | 12–15 mm |
+| Cytron MDD10A #1 (50 mm actuators) | M3 screws | 10 mm |
+| Cytron MDD10A #2 (250 mm actuators, 12V) | M3 screws | 10 mm |
+| BLD-510B BLDC Controller (excavation) | M3 screws, heatsink fins vertical | 12 mm |
+| WUPP Fuse Block (PDB) | M3 screws | 10 mm |
+| DollaTek 300W Buck (motive → 12V for Cytron #2) | M3 screws, adjacent to Cytron #2 | 8 mm |
+
+---
+
+## Component Weights
+
+All weights are from manufacturer datasheets or measured values. Used for CG estimation
+and chassis load planning.
+
+| Component | Qty | Unit Weight | Total Weight | Source |
+|-----------|-----|------------|-------------|--------|
+| Turnigy 6S 8000 mAh LiPo | 1 | 1110 g | **1110 g** | Datasheet |
+| Turnigy 4S 5000 mAh LiPo | 1 | 550 g | **550 g** | Datasheet |
+| Jetson Orin Nano Super (module + carrier) | 1 | 175 g | **175 g** | Datasheet |
+| Ouster OS1-128 LiDAR | 1 | ~370 g | **~370 g** | Ouster spec |
+| Sabertooth 2×32 | 2 | 125 g | **250 g** | Datasheet |
+| GL-A1300 Router | 1 | 181 g | **181 g** | Datasheet |
+| OAK-D Pro Camera | 2 | 91 g | **~182 g** | Datasheet |
+| Cytron MDD10A | 2 | ~100 g | **~200 g** | Estimated (84.5×62 mm PCB) |
+| BLD-510B BLDC Controller | 1 | ~200 g | **~200 g** | Estimated (118×75.5×34 mm) |
+| WUPP Fuse Block (PDB) | 1 | ~150 g | **~150 g** | Estimated |
+| DollaTek 300W Buck (motive→12V) | 1 | ~80 g | **~80 g** | Estimated (65×47×23.5 mm) |
+| BD-01 Buck (DollaTek, compute→12V) | 1 | ~40 g | **~40 g** | Estimated (small module) |
+| BD-02 Buck (Yosoo, compute→5V) | 1 | ~30 g | **~30 g** | Estimated (small module) |
+| Teensy 4.1 | 1 | 15 g | **15 g** | Datasheet |
+| TRU Components 50mm Actuator | 2 | ~200 g | **~400 g** | Estimated |
+| DCHOUSE 250mm Actuator | 2 | ~350 g | **~700 g** | Estimated |
+| GR-WM4-V3 Drivetrain Motor | 4 | ~900 g | **~3600 g** | Estimated |
+| 57BLR50 Excavation Motor | 1 | ~800 g | **~800 g** | Estimated |
+| Wiring & connectors (estimate) | — | — | **~400 g** | Estimated |
+| **Electrical system total** | | | **~9433 g ≈ 9.4 kg** | |
+
+> Weights marked "Estimated" should be replaced with measured values once components arrive.
+> Actuator and motor weights are for the bodies only — not including mounting brackets.
+
+---
+
+## Weight Summary
+
+| Scope | Components | Weight |
+|-------|-----------|--------|
+| **Electrical box (enclosure contents only)** | Batteries, Jetson, Sabertooth ×2, Cytron ×2, BLD-510B, WUPP PDB, buck converters ×3, Teensy, wiring | **~3.2 kg** |
+| External electrical — perception | Ouster OS1 LiDAR, GL-A1300 Router, OAK-D Pro ×2 | ~733 g |
+| External electrical — actuation | TRU 50mm actuators ×2, DCHOUSE 250mm actuators ×2, 57BLR50 excavation motor | ~1900 g |
+| External electrical — drivetrain | GR-WM4-V3 motors ×4 | ~3600 g |
+| **Total electrical system** | All of the above | **~9.4 kg** |
+
+> Motor and actuator weights are estimated. Replace with measured values once all components arrive.
+> The electrical box alone (~3.2 kg) is the load the box baseplate and mounting hardware must support.
+
+---
+
+## Centre of Gravity Notes
+
+- The two LiPo batteries (1660 g combined) dominate the electrical system mass — mount as
+  low as possible in the chassis and as close to the geometric centre as the mechanical design allows.
+- The Jetson + LiDAR are the most vibration-sensitive components — keep them on the rigid
+  baseplate, not cantilevered off brackets.
+- The four actuators are mounted externally on the mechanism — their weight affects rover CG
+  but not the electrical box CG.
+
+---
+
+## Cable Routing
+
+| Cable Group | Gauge | Route |
+|-------------|-------|-------|
+| Motive trunk (XT90 → ANL fuse → WUPP) | 10 AWG | Along chassis wall, shortest possible path |
+| Sabertooth power (WUPP → B+/B−) | 10 AWG | 10 AWG direct from fuse block, ≤ 300 mm |
+| Cytron #1 power (WUPP → Cytron) | 10 AWG | From slot 3 of WUPP |
+| Cytron #2 power (WUPP → DollaTek buck → Cytron) | 10 AWG in, 12 AWG out | Via DollaTek 12V buck |
+| BLD-510B power (WUPP slot 5 → controller) | 16 AWG | Short run, fused at 10 A |
+| Compute trunk (4S → 20A fuse → BD-01/BD-02) | 18 AWG | Keep away from motive wiring |
+| BD-01 → WAGO → Jetson + LiDAR | 20 AWG | Barrel jacks, short runs in cool zone |
+| BD-02 → WAGO → Router + cameras | 20–22 AWG | USB-C cables |
+| Signal wiring (Teensy ↔ controllers) | 24–26 AWG | Twisted pairs; route away from 10 AWG motor wires |
+| Encoder wiring (motors → Teensy) | 26 AWG | Twisted CH-A/CH-B pairs per motor |
+
+---
+
+## Safety & Assembly Notes
+
+- **Power-up sequence:** Compute domain (4S) powers up first → Jetson boots → Teensy initialises
+  and asserts EN=stop on BLD-510B → only then apply motive domain (6S).
+- **E-Stop location:** Mount on the exterior of the chassis within easy reach of the operator,
+  upstream of the 40 A ANL fuse on the motive positive rail. Minimum 40 mm mushroom head diameter.
+- **LiPo buzzer alarms:** Route balance leads to the front of the enclosure so audible alarms
+  are not muffled by the enclosure walls.
+- **Thermal:** Allow ≥ 5 mm clearance around the Sabertooth heatsinks and BLD-510B heatsink.
+  Do not block exhaust vents. Competition regolith dust — use filtered intake vents.
+- **Serviceability:** Batteries should be removable without disturbing signal wiring. Use
+  connectors (XT90) rather than soldered joints on battery tails to allow quick swap.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-05-24 | eniomecaj | Initial file — layout, weights, and routing notes for INNEX-1 electrical enclosure |

--- a/docs/hardware/fuses.md
+++ b/docs/hardware/fuses.md
@@ -43,7 +43,7 @@ is the domain protection. Branch fuses here provide per-device fault isolation.
 
 | Slot | Device | Fuse | Reasoning |
 |------|--------|------|-----------|
-| 1 | Sabertooth 2×32 #1 (Left: FL + RL) | **No fuse** | 2 motors × 13 A = 26 A peak. 40 A ANL is domain protection. No suitable blade fuse in kit; adds complexity for minimal gain |
+| 1 | Sabertooth 2×32 #1 (Left: FL + RL) | **No fuse** | 2 motors × 13 A = 26 A peak. 60 A ANL is domain protection. No suitable blade fuse in kit; adds complexity for minimal gain |
 | 2 | Sabertooth 2×32 #2 (Right: FR + RR) | **No fuse** | Same as above |
 | 3 | Cytron MDD10A #1 (Actuators 1 & 2) | **15 A** | 10 A per channel × 2 = 20 A max. 15 A protects against a single-channel fault without nuisance tripping |
 | 4 | Cytron MDD10A #2 (Actuators 3 & 4) | **15 A** | Same as above |
@@ -53,7 +53,7 @@ is the domain protection. Branch fuses here provide per-device fault isolation.
 
 ---
 
-## What the Included Kit Fuses Are Used For (OPTIONAL)
+## What the Included Kit Fuses Are Used For
 
 | Fuse Rating | Qty in Kit | Used | Where |
 |-------------|-----------|------|-------|
@@ -62,13 +62,12 @@ is the domain protection. Branch fuses here provide per-device fault isolation.
 | 15 A | 6 | 2 | Cytron MDD10A #1 and #2 slots |
 | 20 A | 6 | 0 | Not required in current design |
 
-> The above fuses are not needed to be used, just a general idea to increase safety
 ---
 
 ## Key Rules
 
 - Driving (drivetrain) and excavation must **never run simultaneously** — this is what keeps
-  peak motive demand within the 40 A ANL rating
+  peak motive demand within the 60 A ANL rating
 - The compute rail (20 A inline fuse) remains live through E-Stop by design — do not fuse it
   in a way that would cut it during a safety event
 - Motive main trunk is 10 AWG — ANL fuse must be **40 A** to match wire ampacity. This is safe

--- a/docs/hardware/gl-a1300-router.md
+++ b/docs/hardware/gl-a1300-router.md
@@ -91,7 +91,7 @@ auto-select or fixed to a clear channel at the competition venue.
 
 ---
 
-## Key Rules & Gotchas
+## Key Rules & Notes
 
 - **Boot time ~30–60 s** — router must be given time to fully boot before the Jetson or OS1
   attempts network connections. Include router boot in the startup sequence.

--- a/docs/hardware/gr-wm4-v3-drivetrain-motor.md
+++ b/docs/hardware/gr-wm4-v3-drivetrain-motor.md
@@ -10,6 +10,7 @@
 | **Power Domain** | 🔴 Motive (22.2 V nominal) |
 | **Qty on Rover** | 4 |
 | **Product Page** | https://gimsonrobotics.co.uk/collections/all |
+| **Weight** | ~900 g each / ~3600 g total (estimated — high-torque geared motor with encoder) |
 
 ---
 
@@ -25,16 +26,16 @@
 | Peak current (gearbox limit) | **13 A** — hard limit imposed by gearbox bearing rating |
 | Motor connector | Bullet terminals / 6-pin connector |
 
-> **Operational note:** The 13 A peak current is the gearbox's mechanical limit, not the motor's
-> electrical limit. Always fuse at or below this value per motor to prevent gearbox damage. The
-> Sabertooth 2×32 current limiting is configured accordingly.
+> **Operational note:** The gearbox's mechanical limit is 13 A but the Sabertooth 2×32 is
+> software-configured to limit each channel to **10 A** — protecting the gearbox while capping
+> total drivetrain peak at 40 A (4 × 10 A), giving a 3× safety factor over the 120 A battery rating.
 
 ### INNEX1 Power Budget
 
 | Scenario | Current per Motor | Total (4 motors) | Battery Safety Factor |
 |----------|--------------------|-------------------|----------------------|
 | Normal driving | ~3–5 A | ~12–20 A | **6–10×** (120 A / ~12–20 A) |
-| Peak demand (4× motors) | 13 A | **52 A** (fuse-capped) | ~2.3× |
+| Peak demand (Sabertooth software-limited) | 10 A | **40 A** (4 × 10 A software cap) | **3×** (120 A / 40 A) |
 
 > Driving and excavation must **never run simultaneously** — see main battery datasheet.
 
@@ -147,11 +148,11 @@ ros2 topic pub --once /cmd_vel_safe geometry_msgs/msg/Twist \
 
 ---
 
-## Known Constraints & Gotchas
+## Key Notes & Constraints
 
-- **Stall current vs gearbox limit:** Stall current is 22.6 A electrically but the gearbox bearing
-  is limited to 13 A peak. Always configure current limiting at the Sabertooth to enforce this.
-  Exceeding 13 A per motor risks gearbox damage, not motor damage.
+- **Stall current vs software limit:** Stall current is 22.6 A electrically but the gearbox
+  bearing is limited to 13 A peak. The Sabertooth is software-configured to 10 A/channel —
+  protecting the gearbox with margin. Total drivetrain peak is 40 A (4 × 10 A, SF 3×).
 - **40% duty cycle:** At rated load, 60 s on / 90 s off is mandatory. Mission planning must account
   for this — continuous full-throttle driving on soft regolith simulant will approach rated load quickly.
 - **IP30 — no dust protection:** The motor body has no sealing against lunar regolith simulant.
@@ -172,3 +173,4 @@ ros2 topic pub --once /cmd_vel_safe geometry_msgs/msg/Twist \
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-23 | eniomecaj | Initial datasheet |
+| 2026-05-24 | eniomecaj | Updated peak demand to 40 A (10 A/ch × 4, SF 3×); encoder pin table confirmed |

--- a/docs/hardware/jetson-orin-nano-super.md
+++ b/docs/hardware/jetson-orin-nano-super.md
@@ -117,7 +117,7 @@ The Jetson runs the **high-level autonomy stack only**:
 
 ---
 
-## Key Rules & Gotchas
+## Key Rules & Notes
 
 - **Always power up Jetson and Teensy before applying 22.2V to Sabertooth** — floating signal
   lines on Sabertooth power-on can be interpreted as drive commands.

--- a/docs/hardware/oak-d-pro.md
+++ b/docs/hardware/oak-d-pro.md
@@ -73,7 +73,7 @@ Jetson USB-C ──── Y-adapter DATA leg  ──┐
 |------------|-----------|-------------------|-------|
 | Data (Jetson → OAK-D Pro) | USB-C 3.1 Gen 2 | ≥ 1 A, 10 Gbps rated | Keep ≤ 1 m for USB 3 reliability |
 | Y-adapter aux power | USB-C or barrel | ≥ 3 A / 5 V | From dedicated 5 V DC-DC on compute rail |
-| 5 V rail feed to DC-DC | 22–24 AWG | ≥ 3 A capacity | Fuse at 5 A on this branch |
+| 5 V rail feed to DC-DC | 22–24 AWG | ≥ 3 A capacity | Protected by compute domain master fuse (no individual branch fuse needed) |
 
 ---
 
@@ -228,7 +228,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666", SYMLINK+="oakdpro"
 
 ---
 
-## Known Constraints & Gotchas
+## Key Notes & Constraints
 
 - **Y-adapter is not optional with IR on:** Running IR features without the Y-adapter will
   cause USB undervoltage, device resets, or host port current limiting. Wire the aux supply
@@ -264,6 +264,7 @@ under all reasonably foreseeable conditions. No additional PPE is required for n
 
 ## Revision History
 
- Date | Author | Change |
+| Date | Author | Change |
 |------|--------|--------|
 | 2026-05-22 | eniomecaj | Initial datasheet — sourced from official Luxonis datasheet (Dec 2021) and docs.luxonis.com |
+| 2026-05-24 | eniomecaj | Removed individual 5A branch fuse (covered by compute domain master fuse) |

--- a/docs/hardware/ouster-os1-128-lidar.md
+++ b/docs/hardware/ouster-os1-128-lidar.md
@@ -12,6 +12,7 @@
 | **Acquisition** | Sponsored — estimated value £16,809 |
 | **Manual** | OS1 Hardware User Manual Rev 7 (Oct 14, 2024) |
 | **Product Page** | https://ouster.com/products/hardware/os1 |
+| **Weight** | ~370 g (Ouster OS1 spec) |
 
 ---
 
@@ -123,7 +124,7 @@ This is the cable type relevant to INNEX-1 (12 V operation, standard Ethernet).
 
 ---
 
-## Key Rules & Gotchas
+## Key Rules & Notes
 
 - **Boot delay is mandatory** — 60 s from power-on before data is available. Build this into the
   startup sequence explicitly; do not rely on topic availability as a proxy.

--- a/docs/hardware/sabertooth-2x32.md
+++ b/docs/hardware/sabertooth-2x32.md
@@ -110,8 +110,11 @@ The Sabertooth is controlled by the Teensy 4.1 over **TTL UART (plain text or pa
 | **5** | **ON** | **Packet serial address 128** |
 | **6** | **ON** | **Emergency stops disabled** (A1/A2 not used as E-stop) |
 
-> DIP 6 ON = emergency stops disabled. INNEX-1 uses software-only stop via Teensy. If hardware
-> E-stop is later needed, wire A1 → 5V (M1 enable) and A2 → 5V (M2 enable), then set DIP 6 OFF.
+> DIP 6 ON = emergency stops disabled (current INNEX-1 setup — software stop via Teensy).
+> To enable hardware E-stop via A1/A2: set DIP 6 OFF, then wire the E-stop contacts so that
+> A1 and A2 are normally held at 5 V (via Sabertooth's own 5 V output) and drop to 0 V when
+> the E-stop is pressed. With DIP 6 OFF: A1/A2 HIGH (5 V) = motors enabled; A1/A2 LOW (0 V)
+> = both channels cut immediately in hardware, before any software response.
 
 ### Baud Rate (DIP 1 & 2, switch 4 ON)
 
@@ -152,7 +155,7 @@ Command range: −2047 to +2047. Positive = forward, negative = reverse.
 
 ---
 
-## Key Rules & Gotchas
+## Key Rules & Notes
 
 - **Power up sequence:** Always power Jetson + Teensy **before** applying 22.2 V to the motive rail.
   Floating signal lines on Sabertooth power-on can be interpreted as drive commands.
@@ -175,3 +178,4 @@ Command range: −2047 to +2047. Positive = forward, negative = reverse.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-24 | eniomecaj | Initial datasheet — sourced from Sabertooth 2×32 User Manual (Dimension Engineering) |
+| 2026-05-24 | eniomecaj | Clarified A1/A2 E-stop wiring explanation |

--- a/docs/hardware/teensy-4.1-microcontroller.md
+++ b/docs/hardware/teensy-4.1-microcontroller.md
@@ -8,7 +8,7 @@
 | **Part Number** | TEENSY41-L (lock variant) |
 | **MPN** | TEENSY41_LOCK |
 | **Role on Rover** | Low-level motor I/O controller — bridges Jetson to all motor controllers and encoders |
-| **Power Domain** | 🔵 Compute (5 V from BD-02) |
+| **Power Domain** | 🔵 Compute (5 V from Jetson Orin Nano USB — USB-A to micro-USB) |
 | **Qty on Rover** | 1 |
 | **Supplier** | PiHut |
 | **Price** | £30.30 |
@@ -39,8 +39,7 @@
 - Max **10 mA per IO pin** — do not drive loads directly; use buffers or pull-ups where needed
 - Encoders are powered from the Teensy **3.3 V rail** — signals swing 0–3.3 V, safe for direct GPIO
 - **Never power the Teensy from both USB and an external 5 V rail simultaneously** — voltage conflict
-- Open-collector signals (BLD-510B PG and ALM) require **10 kΩ pull-up resistors to 3.3 V** on
-  the PCB/breadboard — do not rely on internal pull-ups for these
+- Open-collector signals (BLD-510B PG and ALM) — if monitoring PG/ALM: fit **10 kΩ pull-up resistors to 3.3 V** at Pins 31/32. If PG/ALM are unused, pull-ups can be omitted and the pins left unconnected
 
 ---
 
@@ -58,7 +57,7 @@
 | **5** | PWM ch2 | → | Cytron MDD10A #2 | Actuator 4 speed |
 | **11** | DIR ch1 | → | Cytron MDD10A #2 | Actuator 3 direction |
 | **12** | DIR ch2 | → | Cytron MDD10A #2 | Actuator 4 direction |
-| **6** | PWM (SV) | → | BLD-510B | Excavation speed — via 10 kΩ + 10 µF RC filter to SV pin |
+| **6** | PWM (SV) | → | BLD-510B | Excavation speed — direct 1–2 kHz PWM to SV pin (no external RC filter needed; driver accepts PWM directly) |
 | **13** | GPIO (F/R) | → | BLD-510B | Excavation direction — active-low |
 | **14** | GPIO (EN) | → | BLD-510B | Excavation enable — active-low |
 | **15** | Encoder A | ← | FL motor encoder | Front-Left quadrature CH-A |
@@ -69,8 +68,8 @@
 | **20** | Encoder B | ← | FR motor encoder | Front-Right quadrature CH-B |
 | **21** | Encoder A | ← | RR motor encoder | Rear-Right quadrature CH-A |
 | **22** | Encoder B | ← | RR motor encoder | Rear-Right quadrature CH-B |
-| **31** | PG pulse | ← | BLD-510B | BLDC speed pulse — 10 kΩ pull-up to 3.3 V required |
-| **32** | ALM | ← | BLD-510B | BLDC fault alarm — 10 kΩ pull-up to 3.3 V required |
+| **31** | PG pulse | ← | BLD-510B | BLDC speed pulse — 10 kΩ pull-up to 3.3 V if monitoring; omit if unused |
+| **32** | ALM | ← | BLD-510B | BLDC fault alarm — 10 kΩ pull-up to 3.3 V if monitoring; omit if unused |
 | **USB** | Serial ↕ | ↕ | Jetson Orin Nano | USB virtual COM — bidirectional command/telemetry |
 
 **~25 pins used — ~30 pins spare on Teensy 4.1**
@@ -81,7 +80,7 @@
 
 | Rail | Used For | Notes |
 |------|----------|-------|
-| **3.3 V** | Encoder VCC (all 4 drivetrain motors) | Two 3.3 V pins feed a WAGO 2-in-4-out to supply all 4 encoder VCC wires |
+| **3.3 V** | Encoder VCC (all 4 drivetrain motors) | Two 3.3 V pins feed a WAGO 2-in-4-out to supply all 4 encoder VCC wires. 4× encoders at ~10 mA each = 40 mA total — well within the 3.3 V rail 250 mA limit |
 | **GND** | Encoder GND, signal ground | Separate WAGO output from motor controller GND — star topology |
 
 > Encoders must **not** be powered from BD-02 5 V or any other rail. The SS460S Hall sensors
@@ -117,3 +116,4 @@
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-24 | eniomecaj | Initial datasheet — sourced from TEENSY41-L datasheet (joy-it.net, Feb 2025) and INNEX-1 pin allocation files |
+| 2026-05-24 | eniomecaj | Updated power source to Jetson USB; PG/ALM pull-ups made optional; RC filter removed from Pin 6; encoder current note added |

--- a/docs/hardware/tru-components-linear-actuator-50mm.md
+++ b/docs/hardware/tru-components-linear-actuator-50mm.md
@@ -15,6 +15,7 @@
 | **Price** | £67.75 (pair) |
 | **Supplier** | TRU Components |
 | **Compliance** | RoHS |
+| **Weight** | ~200 g each / ~400 g total (estimated) |
 
 ---
 
@@ -86,17 +87,17 @@ is not connected as the Cytron MDD10A runs open-loop.
 | Fuse (motive fuse block) | **15 A blade** per Cytron MDD10A slot |
 
 > Both actuators on a single Cytron channel share a 15 A fuse. Peak draw per actuator is 1.6 A
-> so two actuators = 3.2 A combined — well within the 15 A fuse and 10 A Cytron channel rating.
+> so two actuators = 3.2 A combined — well within the 10 A Cytron channel rating. Note: a 10 A
+> fuse would give tighter overcurrent protection for the 3.2 A load; 15 A is the installed size.
 
 ---
 
-## Key Rules & Gotchas
+## Key Rules & Notes
 
 - **2 min on / 18 min off** — strictly enforced duty cycle. Do not run continuously.
 - **IP65 rated** — sealed against dust and water jets; suitable for regolith environment.
 - **Built-in limit switches** cut power at end of travel — no software end-stops needed, but
   software should still time out commands to avoid stalling against the limit switch repeatedly.
-- **Never connect 24 V directly to the Teensy** — all 24 V switching goes through the Cytron MDD10A.
 - **Encoder unused** — open-loop control only. If position feedback is needed in future, the
   encoder wires (Red/Black/Yellow/White) are available but currently disconnected.
 
@@ -107,3 +108,4 @@ is not connected as the Cytron MDD10A runs open-loop.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-24 | eniomecaj | Initial datasheet — sourced from TRU Components datasheet (item 3373195) and INNEX-1 wiring notes |
+| 2026-05-24 | eniomecaj | Removed redundant Teensy voltage note; added fuse sizing note (10 A would give tighter protection) |

--- a/docs/hardware/turnigy-4s-compute-battery.md
+++ b/docs/hardware/turnigy-4s-compute-battery.md
@@ -33,9 +33,11 @@
 
 | Load | Peak Current | Battery Safety Factor |
 |------|--------------|-----------------------|
-| Full compute stack (Jetson + LiDAR + cameras + router) | ~10 A | **20×** (200 A / 10 A) |
+| BD-01 branch (Jetson ~4 A + LiDAR ~3 A) | ~6 A | — |
+| BD-02 branch (cameras ~2 A + router ~1.3 A + IMU ~0.1 A) | ~6 A | — |
+| **Full compute stack total** | **~12 A peak** | **16.7×** (200 A / 12 A) |
 
-> The compute battery is massively over-specced for current delivery by design. The 20×
+> The compute battery is massively over-specced for current delivery by design. The 16.7×
 > safety factor guarantees **zero voltage sag** on the 14.8 V rail, completely isolating
 > the Jetson and Ouster LiDAR from any transients on the motive domain.
 
@@ -43,7 +45,7 @@
 
 | Profile | Avg Current | Usable Capacity (80%) | Runtime |
 |---------|------------|----------------------|---------|
-| Full compute stack | ~6 A | 4 Ah | **~40 min** |
+| Full compute stack (typical) | ~8 A | 4 Ah | **~30 min** |
 
 ---
 
@@ -82,11 +84,12 @@ a safety stop.
 
 ---
 
-## Known Constraints & Gotchas
+## Key Notes & Constraints
 
-- **Buck converter input range:** The 14.8 V rail feeds two XL4015 buck converters (BD-01
-  → 19 V for Jetson, BD-02 → 5 V for sensors). Verify both converters accept input down
-  to 13.6 V (minimum cell voltage) without dropping output regulation.
+- **Buck converter input range:** The 14.8 V rail feeds two buck converters: BD-01 (DollaTek
+  Reg.NO:013726393, 14.8 V → 12 V for Jetson + LiDAR, ≤10 A) and BD-02 (Yosoo Health Gear
+  g0qigxo64d, 14.8 V → 5 V for cameras/router/IMU, ≤10 A). Both must accept input down
+  to 13.6 V (minimum cell voltage) without losing output regulation — verify during bench test.
 - **Voltage sag non-issue:** At a 20× safety factor the pack will never sag meaningfully
   under compute load. Voltage at the buck converter input will be stable throughout the run.
 - **Do not cross-connect rails:** The compute ground and motive ground must remain isolated.
@@ -99,3 +102,4 @@ a safety stop.
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-05-22 | eniomecaj | Initial datasheet |
+| 2026-05-24 | eniomecaj | Updated peak current to 12 A, SF to 16.7×, corrected BD-01/BD-02 names and voltages |

--- a/docs/hardware/turnigy-6s-main-battery.md
+++ b/docs/hardware/turnigy-6s-main-battery.md
@@ -94,7 +94,7 @@ providing real-time per-cell voltage audible telemetry without cutting motive po
 
 ---
 
-## Known Constraints & Gotchas
+## Key Notes & Constraints
 
 - **XT90 anti-spark connector:** The main battery uses an XT90 anti-spark variant. Ensure
   the mating connector on the harness is also XT90 anti-spark — a standard XT90 will work

--- a/docs/hardware/wupp-fuse-block-pdb.md
+++ b/docs/hardware/wupp-fuse-block-pdb.md
@@ -12,6 +12,7 @@
 | **Price** | £27.51 |
 | **Supplier** | Amazon (KRS STORE LTD) |
 | **Rating** | 4.7/5 (4,106 ratings) |
+| **Weight** | ~150 g (estimated) |
 
 ---
 
@@ -78,7 +79,7 @@ For full fuse rationale see **fuses.md**.
 
 ---
 
-## Key Rules & Gotchas
+## Key Rules & Notes
 
 - **100A block total, 30A max per slot** — motive domain ANL is 40A so total block load is
   already capped well below the 100A block rating


### PR DESCRIPTION
docs: electrical datasheets + CDR update (2026-05-24)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the electrical hardware documentation for the INNEX-1 rover to reflect CDR specifications and corrections (2026-05-24). The changes span 17 hardware documentation files and include standardization of documentation format, updated power budgets, corrected electrical specifications, and clarified safety mechanisms.

## Key Changes

**Documentation Standardization**
- Renamed section headers across multiple datasheets from "Key Rules & Gotchas" / "Known Constraints & Gotchas" to "Key Rules & Notes" / "Key Notes & Constraints" for consistent terminology

**Weight Specifications**
- Added estimated weight fields to component datasheets: 57BLR50 excavation motor (~800 g), Cytron MDD10A, DCHouse linear actuator (250mm), Dollatek buck converter (12V), GR-WM4-V3 drivetrain motor, Ouster OS1-128 LiDAR (~370 g), and WUPP fuse block (~150 g)

**Power Budget & Electrical Updates**
- Updated GR-WM4-V3 drivetrain motor specifications: confirmed 40 A peak motive demand with clarification on gearbox mechanical limit (13 A) vs Sabertooth software cap (10 A/channel)
- Revised compute power budget in Turnigy 4S battery datasheet: peak compute load increased to ~12 A with 16.7× safety factor, split between BD-01 and BD-02 buck converter branches
- Updated fuse strategy: adjusted motive-rail protection from 60 A to 40 A ANL rating in accordance with new peak demand calculations
- Removed individual 5A fuse requirement on 5V rail (OAK-D Pro), now covered by compute domain master fuse

**Connector & Power References**
- Renamed BD-01 (12 V) and BD-02 (5 V) buck converter entries with clarified role descriptions and output distribution
- Updated power connector and cabling guidance: 10 AWG ring-terminal fit, USB-C polarity notes, DC barrel jack specifications for Ouster OS1 and Jetson Orin Nano
- Added WAGO 2-in-4-out clarification for BD-01 rail assignment

**Safety & Switching**
- Replaced generic switch descriptions with explicit entries: main battery cutoff (motive domain) and compute-domain arming switch
- Expanded Sabertooth 2×32 DIP switch documentation: clarified DIP 6 emergency-stop function and A1/A2 hardware E-stop wiring
- Replaced E-stop write-up with heavy-duty DC E-stop specifications; confirmed compute domain remains live during E-stop

**Power Source Changes**
- Teensy 4.1: switched compute power source from BD-02 to Jetson Orin Nano USB; made PG/ALM pull-ups optional; removed recommended RC filter from PWM SV pin; added encoder power current estimate (~40 mA)

**New Documentation**
- Added `electrical-box-layout.md`: comprehensive enclosure specifications including airflow zoning (Cool/Neutral/Hot), component placement, weight tables, cable routing guidance, power-up sequencing, and assembly notes

**Updated Verification Checklist**
- Added E-Stop and compute switch verification rows to the "Flagged Items — Verify Before Assembly" table in connectors documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->