### PR TITLE
Add Teensy motor IO bridge foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ src/
 ├── lunabot_safety/          # E-stop to motion-inhibit bridge
 ├── lunabot_simulation/      # Gazebo Fortress worlds and ros_gz bridges
 └── lunabot_teleop/          # Manual control
+firmware/
+└── teensy_motor_io/          # Host-testable Teensy 4.1 motor IO core
 ```
 
 ## Interface contracts in CI

--- a/docs/active_runtime_paths.md
+++ b/docs/active_runtime_paths.md
@@ -70,9 +70,20 @@ Use this for first-motion and bench drivetrain checks:
 ros2 launch lunabot_drivetrain drivetrain_bench.launch.py max_throttle:=0.2
 ```
 
+The launch defaults to the direct Jetson-to-Sabertooth bench path. To exercise
+the newer Teensy USB path, select it explicitly:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py \
+  bridge_backend:=teensy \
+  serial_port:=/dev/teensy_motor_io \
+  max_throttle:=0.2
+```
+
 `drivetrain_bench.launch.py` starts:
 
-- `lunabot_drivetrain/drivetrain_bridge`
+- `lunabot_drivetrain/drivetrain_bridge` or
+  `lunabot_drivetrain/teensy_drivetrain_bridge`
 - `lunabot_drivetrain/velocity_gate`
 - optional joystick teleop through `twist_mux`
 
@@ -84,7 +95,7 @@ The command path is:
   -> /cmd_vel_safe
   -> velocity_gate
   -> /cmd_vel_gated
-  -> drivetrain_bridge
+  -> selected drivetrain bridge
 ```
 
 Keep the velocity gate in this path for hardware work. Do not command the

--- a/docs/agent_logs/teensy_motor_io_scratch_log.md
+++ b/docs/agent_logs/teensy_motor_io_scratch_log.md
@@ -1,0 +1,100 @@
+# Teensy Motor IO Scratch Log
+
+This log records decisions, tradeoffs, checks, and follow-up questions from the
+agent-led Teensy motor IO implementation work. It is intentionally plain and
+chronological so future reviewers can see what was assumed rather than having to
+dig through chat.
+
+## 2026-05-24 — Kickoff
+
+- Branch created: `feature/teensy-motor-io`.
+- Goal: build the Teensy-based low-level motor IO path as far as possible before
+  the Teensy hardware is available, with desktop tests, simulation/fake serial,
+  Jetson validation, docs, and Linear tracking.
+- Local repo was clean and up to date with `origin/main` before branching.
+- SSH to the Jetson via Tailscale works non-interactively:
+  `ssh innex1-desktop ...` returned hostname `innex1-desktop`.
+- Local tools present: `gh`, `tailscale`, `ssh`, `arduino-cli`, `cmake`, `g++`,
+  Python 3.14.
+- Jetson tools observed: `git`, `colcon`; `ros2` was not printed by the quick
+  probe, so the Jetson ROS environment may require sourcing before use.
+- Linear project found: `INNEX1 Rover` (`INX`).
+- Existing related Linear issues found:
+  - `INX-5` — Teensy encoder acquisition and wheel odometry path.
+  - `INX-65` — next hardware integration plan.
+  - `INX-69` — Jetson OS1/localisation timing handoff.
+
+### Initial Direction
+
+- Use a small custom binary protocol over USB CDC serial between Jetson and
+  Teensy, with explicit framing and checksums.
+- Keep firmware logic hardware-independent where possible, with a thin Arduino
+  adapter later. This lets us test safety, packet parsing, command expiry,
+  drive/excavation mutual exclusion, and telemetry without the Teensy.
+- Treat the Teensy as the final authority before any hardware moves. ROS can
+  request motion; the Teensy must still deny motion on stale heartbeat, E-stop,
+  inhibit, ALM, invalid packet, unsafe mode, or missing startup configuration.
+
+### Open Risks
+
+- Need to confirm exact Sabertooth 2x32 packet/plain-text commands for current
+  limit and ramping before implementing hardware-write behaviour. If the current
+  limit is configured via DEScribe only, firmware must at least verify and expose
+  a clear preflight state.
+- Need to settle E-stop interpretation against UK Lunabotics RuleBook 2026 v1.0:
+  current docs say compute stays live through E-stop, but rulebook wording says
+  the E-stop disconnects batteries from all controllers and isolates active
+  subsystems. This is a design/inspection question, not just software.
+- Current repo drivetrain code still assumes Jetson-to-Sabertooth UART. The new
+  Teensy architecture should avoid breaking existing bench workflows until the
+  Teensy path is ready.
+
+## 2026-05-24 — First Implementation Slice
+
+- Created Linear subtickets `INX-71` through `INX-76` under `INX-70`.
+- Added a host-testable firmware core under `firmware/teensy_motor_io`:
+  COBS framing, CRC-16/CCITT-FALSE, protocol decode/encode tests, and a
+  fail-closed safety state machine.
+- Added Jetson-side Teensy protocol and serial client modules inside
+  `lunabot_drivetrain`, plus a fake Teensy pseudo-terminal endpoint for tests.
+- Added `teensy_drivetrain_bridge` while keeping the old `drivetrain_bridge`
+  as the default direct Sabertooth bench path. The launch file now uses
+  `bridge_backend:=sabertooth|teensy`.
+- Trade-off: kept the ROS-side bridge in `lunabot_drivetrain` rather than
+  creating a new ROS package. This preserves the existing `/cmd_vel_gated`,
+  `/drivetrain/status`, `/drivetrain/telemetry`, `/odom_wheels`, and
+  `/joint_states_wheels` contracts.
+- Tightened safety merge logic so Teensy telemetry can assert E-stop/inhibit
+  but cannot clear the ROS E-stop or latched motion-inhibit state.
+- Sabertooth research update: field firmware should use modern Packet Serial
+  with CRC. Plain Text Serial is bench/debug only. Current limiting and ramping
+  should be configured in DEScribe first; runtime current-target commands are a
+  later improvement, not the first safety line.
+- Local validation run:
+  - `cmake --build build/teensy_motor_io && ctest --test-dir build/teensy_motor_io --output-on-failure` passed.
+  - `PYTHONPATH=src/lunabot_drivetrain uv run --with pytest python -m pytest src/lunabot_drivetrain/test/test_teensy_protocol.py src/lunabot_drivetrain/test/test_teensy_serial.py -q` passed.
+  - Full local `test_sabertooth_serial.py` still needs a ROS environment because
+    this macOS Python does not provide `rclpy`; run that on the Jetson.
+
+## 2026-05-24 — Jetson Validation
+
+- Jetson repo had unrelated OAK-D bringup changes in the main worktree. Stashed
+  them before branch work with a `codex-pre-teensy-motor-io-*` stash entry.
+- Fast-forwarded Jetson `main`, created `feature/teensy-motor-io`, and copied
+  only this branch's changed files into that worktree.
+- Jetson validation passed:
+  - `cmake -S firmware/teensy_motor_io -B build/teensy_motor_io && cmake --build build/teensy_motor_io && ctest --test-dir build/teensy_motor_io --output-on-failure`
+  - `PYTHONPATH=src/lunabot_drivetrain python3 -m pytest src/lunabot_drivetrain/test/test_teensy_protocol.py src/lunabot_drivetrain/test/test_teensy_serial.py -q`
+  - `colcon build --symlink-install --packages-select lunabot_interfaces lunabot_drivetrain`
+  - `colcon test --packages-select lunabot_drivetrain --event-handlers console_direct+`
+- `colcon test` result on Jetson: `46 passed, 2 warnings`. The warnings are
+  existing pytest/flake8 selectable-groups deprecation warnings, not failures.
+- Fake Teensy ROS smoke test passed after fixing the PTY fake to use raw mode
+  and adding a Teensy startup grace period:
+  - one `teensy_drivetrain_bridge` node running against the fake PTY;
+  - `/drivetrain/status.state` reported `1` (`READY`);
+  - `/drivetrain/telemetry.controller_online` reported `[True, True]`.
+- Debug note: earlier smoke attempts left stale bridge child processes because
+  `ros2 run` spawns the real executable underneath the wrapper. Killed those and
+  reran the smoke test using the installed executable directly so cleanup owned
+  the actual bridge process.

--- a/docs/hardware/software-team-notes.md
+++ b/docs/hardware/software-team-notes.md
@@ -85,19 +85,23 @@ Two controllers used — skid-steer topology:
 | SW5 | ON | Address 128 |
 | SW6 | ON | No E-Stop |
 
-### Software Configuration at Startup
-```cpp
-// Must be called once at startup before any motion commands
-setSaberRamping(20);         // Hardware ramping — smooth accel/decel on all stop commands
-// ⚠️ REQUIRED: set per-channel current limit to 10 A max
-// Enforces gearbox bearing limit (13 A) and keeps motive draw within 40 A ANL fuse / 10 AWG wiring rating
-// setCurrentLimit(10);     // Replace with actual Sabertooth packetised serial command for current limit
-```
+### Software Configuration Before Startup
 
-- Protocol: packetised serial, 9600 baud, address 128
+Configure both Sabertooths in DEScribe before powered motion:
+
+- Packet Serial with CRC for the field firmware.
+- Serial timeout enabled as a backstop for broken wiring or dead firmware.
+- Conservative ramping for first-motion tests.
+- Per-channel soft current limit set to **≤ 10 A**.
+
+The Teensy firmware should refuse drivetrain motion until this configuration has
+been confirmed in preflight. Runtime packet commands for current targets can be
+added later, but they are not the first safety line.
+
+- Protocol: Packet Serial with CRC, 9600 baud, address 128
 - TX only — Teensy talks, Sabertooth listens (no RX needed)
 - ROS 2 package: `lunabot_drivetrain`
-- Command topic: `/cmd_vel_safe` (`geometry_msgs/msg/Twist`)
+- Command topic into hardware bridge: `/cmd_vel_gated` (`geometry_msgs/msg/Twist`)
 
 ---
 
@@ -116,16 +120,9 @@ setSaberRamping(20);         // Hardware ramping — smooth accel/decel on all s
 ## BLD-510B — BLDC Excavation Motor Controller
 
 ### Speed Control (SV pin)
-The SV pin accepts 0–5 V analog. Drive it with **PWM from Teensy Pin 6 through a 10 kΩ + 10 µF
-RC low-pass filter** to convert PWM to a smooth analog voltage.
-
-```
-Teensy Pin 6 (PWM) ── 10kΩ ──┬── BLD-510B SV pin
-                              │
-                             10µF
-                              │
-                             GND
-```
+The current Teensy handoff uses **direct PWM from Teensy Pin 6 to the BLD-510B
+SV pin**. Do not add the old Arduino RC-filter circuit unless electrical
+reverses this decision after bench testing.
 
 ### Control Signal Logic
 - EN (Pin 14), F/R (Pin 13), BK — all **active-low**
@@ -143,7 +140,7 @@ be fitted on the PCB/breadboard at Pins 31 and 32.
 > The startup sequence in the mission manager should monitor ALM continuously. Any fault must
 > trigger an immediate safe shutdown of the excavation system.
 
-### RC Filter Note (Arduino conflict — not applicable to Teensy)
+### Power Note (Arduino conflict — not applicable to Teensy)
 The previous test setup used an Arduino powered from both USB and the driver's +5 V simultaneously,
 which caused a voltage conflict and triggered the red alarm LED. On the Teensy/Jetson setup this
 conflict does not apply, but **never power the Teensy from both USB and an external 5 V rail simultaneously**.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -7,6 +7,7 @@
 | `lunabot_interfaces` | ament_cmake (ROSIDL) | All shared ROS contracts — actions, msgs, srvs. Edit here for new interfaces. |
 | `lunabot_bringup` | ament_python | Top-level launch, mission execution, preflight system, dry-run harness, manual power telemetry |
 | `lunabot_control` | ament_python | `material_action_server`, `material_action_client` — material movement |
+| `lunabot_drivetrain` | ament_python | Direct Sabertooth bridge, Teensy USB drivetrain bridge, fake Teensy endpoint, and velocity gate |
 | `lunabot_excavation` | ament_python | `excavation_action_server`, `excavation_controller`, sim proxy, telemetry mock |
 | `lunabot_localisation` | ament_python | `start_zone_localiser`, `stereo_camera_info_publisher`, `tag_pose_publisher` |
 | `lunabot_navigation` | ament_python | Nav2 params, behavior trees — does NOT contain navigation nodes themselves |
@@ -19,6 +20,10 @@
 ## External (vendored)
 - `src/external/leo_common-ros2` — Leo Rover base packages
 - `src/external/leo_simulator-ros2` — Leo Rover sim packages
+
+## Firmware
+- `firmware/teensy_motor_io` — host-testable Teensy 4.1 motor IO protocol and
+  safety core.
 
 ## Key files per package
 

--- a/docs/teensy_motor_io.md
+++ b/docs/teensy_motor_io.md
@@ -1,0 +1,137 @@
+# Teensy Motor IO Path
+
+This page describes the software boundary for the Teensy 4.1 motor IO work.
+It is the current plan from the updated electrical CDR: the Jetson stays in ROS
+2, while the Teensy owns low-level motor IO, encoder counting, and immediate
+hardware interlocks.
+
+## Runtime Shape
+
+```text
+/cmd_vel_safe
+  -> velocity_gate
+  -> /cmd_vel_gated
+  -> teensy_drivetrain_bridge
+  -> USB CDC serial
+  -> Teensy 4.1
+  -> Sabertooth 2x32, encoders, and later mechanism IO
+```
+
+The old direct Sabertooth path is still available for bench work:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py \
+  bridge_backend:=sabertooth \
+  serial_port:=/dev/ttyTHS1 \
+  max_throttle:=0.2
+```
+
+The Teensy path is selected explicitly:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py \
+  bridge_backend:=teensy \
+  serial_port:=/dev/teensy_motor_io \
+  max_throttle:=0.2
+```
+
+The Teensy backend defaults to `teensy_baud_rate:=115200`. The direct
+Sabertooth backend keeps `baud_rate:=9600`.
+
+Prefer a udev symlink such as `/dev/teensy_motor_io` on the Jetson rather than
+hard-coding `/dev/ttyACM0`, because USB enumeration can move after reconnects.
+
+## Protocol
+
+The Jetson and Teensy use a versioned binary protocol over USB CDC serial:
+
+- COBS framing with a zero delimiter.
+- CRC-16/CCITT-FALSE over the decoded payload.
+- Protocol version byte at the start of every frame.
+- Fixed message IDs for heartbeat, drive command, control flags, reset faults,
+  status, drivetrain telemetry, and fault events.
+
+The host-side codec lives in:
+
+- `src/lunabot_drivetrain/lunabot_drivetrain/teensy_protocol.py`
+- `src/lunabot_drivetrain/lunabot_drivetrain/teensy_serial.py`
+
+The firmware-side codec and safety core live in:
+
+- `firmware/teensy_motor_io/include/teensy_motor_io/`
+- `firmware/teensy_motor_io/src/`
+
+## Sabertooth Mode
+
+For the Teensy-to-Sabertooth link, use modern Packet Serial with CRC for the
+fielded firmware. Plain Text Serial is useful for bench debugging, but it should
+not be the competition control path. Legacy Simplified Serial remains available
+only through the old direct Jetson bench bridge.
+
+Set Sabertooth ramping and per-channel current limits in DEScribe before the
+first powered motion test. Treat runtime packet commands for `T1`/`T2` current
+targets as later polish, not the first safety line. The software must publish a
+clear fault or preflight failure until electrical confirms the configured
+current limit.
+
+Use the Sabertooth serial timeout as a backstop. The Teensy host-command
+watchdog should stop outputs first; the Sabertooth timeout should catch a broken
+wire or dead Teensy.
+
+## Safety Invariants
+
+The Teensy firmware must fail closed:
+
+- malformed COBS frames or bad CRCs are ignored;
+- stale Jetson heartbeat disables outputs;
+- stale `/cmd_vel_gated` disables outputs;
+- E-stop and `/safety/motion_inhibit` disable outputs;
+- Sabertooth current-limit/ramping configuration must be confirmed before
+  drivetrain motion is allowed;
+- driver faults, overcurrent, BLD-510B ALM, or invalid command ranges disable
+  the affected output and publish a fault;
+- clearing the physical E-stop must not resume motion by itself.
+
+The ROS bridge also preserves the existing safety contract. Incoming Teensy
+telemetry can assert E-stop or inhibit, but it must not clear the ROS E-stop or
+motion-inhibit state. The combined state is what appears on
+`/drivetrain/status` and `/drivetrain/telemetry`.
+
+## Testing Without Hardware
+
+Run the firmware core tests:
+
+```bash
+cmake -S firmware/teensy_motor_io -B build/teensy_motor_io
+cmake --build build/teensy_motor_io
+ctest --test-dir build/teensy_motor_io --output-on-failure
+```
+
+Run the Python protocol tests locally:
+
+```bash
+PYTHONPATH=src/lunabot_drivetrain \
+  uv run --with pytest python -m pytest \
+  src/lunabot_drivetrain/test/test_teensy_protocol.py \
+  src/lunabot_drivetrain/test/test_teensy_serial.py -q
+```
+
+The fake Teensy endpoint prints a pseudo-terminal path that can be passed to the
+bridge:
+
+```bash
+PYTHONPATH=src/lunabot_drivetrain \
+  python3 -m lunabot_drivetrain.fake_teensy
+```
+
+Then launch the bridge against that PTY in another terminal.
+
+## Open Electrical Items
+
+- Confirm the exact Sabertooth DEScribe profile and export it with the project
+  docs: Packet Serial with CRC, serial timeout, ramping, and `<=10 A`
+  per-channel soft current limit.
+- Finalise and label the Teensy pin map once the harness is built.
+- Resolve the UK Lunabotics 2026 v1.0 E-stop wording with electrical and/or the
+  organisers. Current repo notes say compute remains live; the rulebook wording
+  says E-stop isolates batteries from active subsystems.

--- a/firmware/teensy_motor_io/CMakeLists.txt
+++ b/firmware/teensy_motor_io/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.16)
+project(teensy_motor_io LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_library(teensy_motor_io_core
+  src/protocol.cpp
+  src/safety_state.cpp
+)
+target_include_directories(teensy_motor_io_core PUBLIC include)
+
+enable_testing()
+
+add_executable(test_protocol tests/test_protocol.cpp)
+target_link_libraries(test_protocol PRIVATE teensy_motor_io_core)
+add_test(NAME protocol COMMAND test_protocol)
+
+add_executable(test_safety_state tests/test_safety_state.cpp)
+target_link_libraries(test_safety_state PRIVATE teensy_motor_io_core)
+add_test(NAME safety_state COMMAND test_safety_state)

--- a/firmware/teensy_motor_io/README.md
+++ b/firmware/teensy_motor_io/README.md
@@ -1,0 +1,31 @@
+# Teensy motor IO firmware
+
+This is the host-testable core for the Teensy 4.1 motor IO controller.
+
+The Teensy is treated as a hard real-time IO adapter, not as a ROS node. The
+Jetson sends framed USB CDC serial commands; the Teensy applies local safety
+checks, drives the motor controllers, counts encoders, and reports telemetry
+back to ROS through the Jetson bridge.
+
+## Design rules
+
+- All command frames are versioned, COBS-framed, and protected by CRC-16.
+- Bad frames are ignored. They must not change outputs.
+- If the Jetson heartbeat goes stale, motor outputs go to zero.
+- E-stop, motion inhibit, controller faults, and an unconfirmed current-limit
+  configuration force outputs to zero.
+- Pin assignments live in the Teensy hardware adapter, not in the protocol or
+  safety core.
+
+## Host tests
+
+These tests run without Arduino tooling:
+
+```bash
+cmake -S firmware/teensy_motor_io -B build/teensy_motor_io
+cmake --build build/teensy_motor_io
+ctest --test-dir build/teensy_motor_io --output-on-failure
+```
+
+The Arduino/Teensy sketch should stay thin: serial read/write, GPIO/PWM setup,
+encoder ISR wiring, and calls into this core.

--- a/firmware/teensy_motor_io/include/teensy_motor_io/protocol.hpp
+++ b/firmware/teensy_motor_io/include/teensy_motor_io/protocol.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace teensy_motor_io {
+
+constexpr std::uint8_t kProtocolVersion = 1;
+constexpr std::size_t kMaxFramePayloadBytes = 96;
+
+enum class MessageType : std::uint8_t {
+    kHeartbeat = 1,
+    kDriveCommand = 2,
+    kControlFlags = 3,
+    kResetFaults = 4,
+    kStatus = 0x80,
+    kDrivetrainTelemetry = 0x81,
+    kFaultEvent = 0x82,
+};
+
+struct Frame {
+    std::uint8_t version{kProtocolVersion};
+    MessageType type{MessageType::kHeartbeat};
+    std::uint16_t sequence{0};
+    std::vector<std::uint8_t> body{};
+};
+
+struct DecodeResult {
+    bool ok{false};
+    const char* error{nullptr};
+    Frame frame{};
+};
+
+std::uint16_t crc16_ccitt(const std::uint8_t* data, std::size_t length);
+std::vector<std::uint8_t> encode_frame(const Frame& frame);
+DecodeResult decode_frame(const std::uint8_t* data, std::size_t length);
+
+}  // namespace teensy_motor_io

--- a/firmware/teensy_motor_io/include/teensy_motor_io/safety_state.hpp
+++ b/firmware/teensy_motor_io/include/teensy_motor_io/safety_state.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+
+namespace teensy_motor_io {
+
+enum class ControllerState : std::uint8_t {
+    kUninitialised = 0,
+    kReady = 1,
+    kDriving = 2,
+    kFault = 4,
+    kEstop = 5,
+};
+
+enum class FaultCode : std::uint16_t {
+    kNone = 0,
+    kEstop = 1,
+    kEncoderStall = 2,
+    kControllerOffline = 3,
+    kOvercurrent = 4,
+    kCommandTimeout = 5,
+    kBadCurrentLimit = 6,
+    kJetsonHeartbeatTimeout = 7,
+};
+
+struct SafetyInputs {
+    bool estop_active{false};
+    bool motion_inhibited{false};
+    bool driver_fault{false};
+    bool current_limit_configured{false};
+    bool heartbeat_fresh{false};
+    bool reset_faults_requested{false};
+};
+
+struct SafetyOutput {
+    ControllerState state{ControllerState::kUninitialised};
+    FaultCode fault{FaultCode::kNone};
+    bool outputs_enabled{false};
+};
+
+class SafetyStateMachine {
+public:
+    SafetyOutput update(const SafetyInputs& inputs, bool drive_requested);
+    SafetyOutput output() const { return output_; }
+
+private:
+    SafetyOutput output_{};
+};
+
+}  // namespace teensy_motor_io

--- a/firmware/teensy_motor_io/src/protocol.cpp
+++ b/firmware/teensy_motor_io/src/protocol.cpp
@@ -1,0 +1,139 @@
+#include "teensy_motor_io/protocol.hpp"
+
+#include <array>
+
+namespace teensy_motor_io {
+namespace {
+
+constexpr std::size_t kHeaderBytes = 4;
+constexpr std::size_t kCrcBytes = 2;
+
+void append_u16_le(std::vector<std::uint8_t>& out, std::uint16_t value) {
+    out.push_back(static_cast<std::uint8_t>(value & 0xFF));
+    out.push_back(static_cast<std::uint8_t>((value >> 8) & 0xFF));
+}
+
+std::uint16_t read_u16_le(const std::uint8_t* data) {
+    return static_cast<std::uint16_t>(data[0])
+        | static_cast<std::uint16_t>(data[1] << 8);
+}
+
+std::vector<std::uint8_t> cobs_encode(const std::vector<std::uint8_t>& input) {
+    std::vector<std::uint8_t> out;
+    out.reserve(input.size() + 2);
+
+    std::size_t code_index = 0;
+    std::uint8_t code = 1;
+    out.push_back(0);
+
+    for (std::uint8_t byte : input) {
+        if (byte == 0) {
+            out[code_index] = code;
+            code_index = out.size();
+            out.push_back(0);
+            code = 1;
+            continue;
+        }
+
+        out.push_back(byte);
+        ++code;
+        if (code == 0xFF) {
+            out[code_index] = code;
+            code_index = out.size();
+            out.push_back(0);
+            code = 1;
+        }
+    }
+
+    out[code_index] = code;
+    out.push_back(0);
+    return out;
+}
+
+bool cobs_decode(
+    const std::uint8_t* data,
+    std::size_t length,
+    std::vector<std::uint8_t>& out
+) {
+    out.clear();
+    if (length == 0 || data[length - 1] != 0) {
+        return false;
+    }
+
+    std::size_t index = 0;
+    const std::size_t end = length - 1;
+    while (index < end) {
+        const std::uint8_t code = data[index++];
+        if (code == 0 || index + code - 1 > end) {
+            return false;
+        }
+
+        for (std::uint8_t i = 1; i < code; ++i) {
+            out.push_back(data[index++]);
+        }
+        if (code < 0xFF && index < end) {
+            out.push_back(0);
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+std::uint16_t crc16_ccitt(const std::uint8_t* data, std::size_t length) {
+    std::uint16_t crc = 0xFFFF;
+    for (std::size_t i = 0; i < length; ++i) {
+        crc ^= static_cast<std::uint16_t>(data[i] << 8);
+        for (int bit = 0; bit < 8; ++bit) {
+            if ((crc & 0x8000) != 0) {
+                crc = static_cast<std::uint16_t>((crc << 1) ^ 0x1021);
+            } else {
+                crc = static_cast<std::uint16_t>(crc << 1);
+            }
+        }
+    }
+    return crc;
+}
+
+std::vector<std::uint8_t> encode_frame(const Frame& frame) {
+    std::vector<std::uint8_t> payload;
+    payload.reserve(kHeaderBytes + frame.body.size() + kCrcBytes);
+    payload.push_back(frame.version);
+    payload.push_back(static_cast<std::uint8_t>(frame.type));
+    append_u16_le(payload, frame.sequence);
+    payload.insert(payload.end(), frame.body.begin(), frame.body.end());
+    append_u16_le(payload, crc16_ccitt(payload.data(), payload.size()));
+    return cobs_encode(payload);
+}
+
+DecodeResult decode_frame(const std::uint8_t* data, std::size_t length) {
+    std::vector<std::uint8_t> payload;
+    if (!cobs_decode(data, length, payload)) {
+        return {false, "invalid COBS frame", {}};
+    }
+    if (payload.size() < kHeaderBytes + kCrcBytes) {
+        return {false, "frame too short", {}};
+    }
+    if (payload.size() > kHeaderBytes + kMaxFramePayloadBytes + kCrcBytes) {
+        return {false, "frame too large", {}};
+    }
+
+    const std::size_t crc_offset = payload.size() - kCrcBytes;
+    const std::uint16_t expected_crc = read_u16_le(payload.data() + crc_offset);
+    const std::uint16_t actual_crc = crc16_ccitt(payload.data(), crc_offset);
+    if (expected_crc != actual_crc) {
+        return {false, "crc mismatch", {}};
+    }
+    if (payload[0] != kProtocolVersion) {
+        return {false, "unsupported protocol version", {}};
+    }
+
+    Frame frame;
+    frame.version = payload[0];
+    frame.type = static_cast<MessageType>(payload[1]);
+    frame.sequence = read_u16_le(payload.data() + 2);
+    frame.body.assign(payload.begin() + kHeaderBytes, payload.begin() + crc_offset);
+    return {true, nullptr, frame};
+}
+
+}  // namespace teensy_motor_io

--- a/firmware/teensy_motor_io/src/safety_state.cpp
+++ b/firmware/teensy_motor_io/src/safety_state.cpp
@@ -1,0 +1,45 @@
+#include "teensy_motor_io/safety_state.hpp"
+
+namespace teensy_motor_io {
+
+SafetyOutput SafetyStateMachine::update(
+    const SafetyInputs& inputs,
+    bool drive_requested
+) {
+    if (inputs.estop_active) {
+        output_ = {ControllerState::kEstop, FaultCode::kEstop, false};
+        return output_;
+    }
+    if (inputs.driver_fault) {
+        output_ = {ControllerState::kFault, FaultCode::kControllerOffline, false};
+        return output_;
+    }
+    if (!inputs.current_limit_configured) {
+        output_ = {ControllerState::kFault, FaultCode::kBadCurrentLimit, false};
+        return output_;
+    }
+    if (!inputs.heartbeat_fresh) {
+        output_ = {
+            ControllerState::kFault,
+            FaultCode::kJetsonHeartbeatTimeout,
+            false,
+        };
+        return output_;
+    }
+    if (inputs.motion_inhibited) {
+        output_ = {ControllerState::kReady, FaultCode::kNone, false};
+        return output_;
+    }
+
+    if (output_.state == ControllerState::kFault && !inputs.reset_faults_requested) {
+        output_.outputs_enabled = false;
+        return output_;
+    }
+
+    output_.fault = FaultCode::kNone;
+    output_.state = drive_requested ? ControllerState::kDriving : ControllerState::kReady;
+    output_.outputs_enabled = drive_requested;
+    return output_;
+}
+
+}  // namespace teensy_motor_io

--- a/firmware/teensy_motor_io/tests/test_protocol.cpp
+++ b/firmware/teensy_motor_io/tests/test_protocol.cpp
@@ -1,0 +1,32 @@
+#include "teensy_motor_io/protocol.hpp"
+
+#include <cassert>
+#include <cstdint>
+
+using teensy_motor_io::Frame;
+using teensy_motor_io::MessageType;
+
+int main() {
+    Frame frame;
+    frame.type = MessageType::kDriveCommand;
+    frame.sequence = 42;
+    frame.body = {0x01, 0x00, 0x7F, 0x00, 0x80};
+
+    const auto encoded = teensy_motor_io::encode_frame(frame);
+    assert(!encoded.empty());
+    assert(encoded.back() == 0);
+
+    const auto decoded = teensy_motor_io::decode_frame(encoded.data(), encoded.size());
+    assert(decoded.ok);
+    assert(decoded.frame.version == teensy_motor_io::kProtocolVersion);
+    assert(decoded.frame.type == MessageType::kDriveCommand);
+    assert(decoded.frame.sequence == 42);
+    assert(decoded.frame.body == frame.body);
+
+    auto corrupted = encoded;
+    corrupted[2] ^= 0x55;
+    const auto bad = teensy_motor_io::decode_frame(corrupted.data(), corrupted.size());
+    assert(!bad.ok);
+
+    return 0;
+}

--- a/firmware/teensy_motor_io/tests/test_safety_state.cpp
+++ b/firmware/teensy_motor_io/tests/test_safety_state.cpp
@@ -1,0 +1,47 @@
+#include "teensy_motor_io/safety_state.hpp"
+
+#include <cassert>
+
+using teensy_motor_io::ControllerState;
+using teensy_motor_io::FaultCode;
+using teensy_motor_io::SafetyInputs;
+using teensy_motor_io::SafetyStateMachine;
+
+int main() {
+    SafetyStateMachine machine;
+    SafetyInputs ok;
+    ok.current_limit_configured = true;
+    ok.heartbeat_fresh = true;
+
+    auto out = machine.update(ok, false);
+    assert(out.state == ControllerState::kReady);
+    assert(out.fault == FaultCode::kNone);
+    assert(!out.outputs_enabled);
+
+    out = machine.update(ok, true);
+    assert(out.state == ControllerState::kDriving);
+    assert(out.outputs_enabled);
+
+    auto estop = ok;
+    estop.estop_active = true;
+    out = machine.update(estop, true);
+    assert(out.state == ControllerState::kEstop);
+    assert(out.fault == FaultCode::kEstop);
+    assert(!out.outputs_enabled);
+
+    auto stale = ok;
+    stale.heartbeat_fresh = false;
+    out = machine.update(stale, true);
+    assert(out.state == ControllerState::kFault);
+    assert(out.fault == FaultCode::kJetsonHeartbeatTimeout);
+    assert(!out.outputs_enabled);
+
+    auto not_limited = ok;
+    not_limited.current_limit_configured = false;
+    out = machine.update(not_limited, true);
+    assert(out.state == ControllerState::kFault);
+    assert(out.fault == FaultCode::kBadCurrentLimit);
+    assert(!out.outputs_enabled);
+
+    return 0;
+}

--- a/src/lunabot_drivetrain/README.md
+++ b/src/lunabot_drivetrain/README.md
@@ -1,17 +1,19 @@
 # lunabot_drivetrain
 
-Drivetrain bridge for the INNEX-1 four-wheel skid-steer rover. Converts
-`cmd_vel` to Sabertooth serial commands over UART and publishes
-encoder-derived odometry and telemetry.
+Drivetrain bridge for the INNEX-1 four-wheel skid-steer rover. It keeps the
+existing direct Sabertooth UART bench path and adds the Teensy 4.1 USB serial
+path from the updated electrical CDR.
 
 ## Hardware
 
 - **Motors**: 4x GR-WM4-V4 brushed DC with Hall-sensor quadrature encoders.
-- **Controllers**: 2x Sabertooth 2x32 on Jetson UART (`/dev/ttyTHS1`,
-  9600 baud).
-- **Default protocol**: Legacy Simplified Serial, matching the electrical CDR's
-  "Simplified Serial" wiring. Packet Serial is also supported by setting
-  `serial_protocol:=packetized`.
+- **Controllers**: 2x Sabertooth 2x32. The old bench path talks directly from
+  Jetson UART (`/dev/ttyTHS1`, 9600 baud). The competition path talks from
+  Jetson USB to Teensy, then Teensy to Sabertooth Packet Serial.
+- **Default bench protocol**: Legacy Simplified Serial for the direct UART path,
+  with Packet Serial still supported by setting `serial_protocol:=packetized`.
+- **Teensy protocol**: versioned USB CDC serial with COBS framing and
+  CRC-16/CCITT-FALSE. See `docs/teensy_motor_io.md`.
 
 Real hardware launches fail closed if the serial port is unavailable. For
 desktop or Jetson dry-runs without motor output, set `dry_run:=true`
@@ -42,6 +44,36 @@ State machine: `UNINITIALISED → READY ⇄ DRIVING → FAULT` and `ESTOP`.
   the Sabertooth to reboot before transitioning back to READY.
 - **Command timeout**: if no `cmd_vel` arrives within `command_timeout_s`, motors
   are stopped.
+
+### `teensy_drivetrain_bridge`
+
+Same ROS-facing contract as `drivetrain_bridge`, but the low-level transport is
+Jetson USB serial to the Teensy 4.1 motor IO controller.
+
+| Direction | Topic | Type |
+|-----------|-------|------|
+| Subscribe | `/cmd_vel_gated` | `geometry_msgs/Twist` |
+| Subscribe | `/safety/motion_inhibit` | `std_msgs/Bool` (transient-local) |
+| Subscribe | `/safety/estop` | `std_msgs/Bool` |
+| Publish | `/drivetrain/status` | `lunabot_interfaces/DrivetrainStatus` |
+| Publish | `/drivetrain/telemetry` | `lunabot_interfaces/DrivetrainTelemetry` |
+| Publish | `/odom_wheels` | `nav_msgs/Odometry` |
+| Publish | `/joint_states_wheels` | `sensor_msgs/JointState` |
+
+The Teensy path is selected with:
+
+```bash
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py \
+  bridge_backend:=teensy \
+  serial_port:=/dev/teensy_motor_io \
+  max_throttle:=0.2
+```
+
+The Teensy launch path uses `teensy_baud_rate:=115200` by default. The direct
+Sabertooth path keeps `baud_rate:=9600` by default.
+
+Incoming Teensy telemetry can assert E-stop or inhibit, but it must not clear
+the ROS E-stop or latched motion-inhibit state.
 
 ## Jetson bench bring-up
 
@@ -84,7 +116,9 @@ source install/setup.bash
 Start the bridge with a low throttle cap:
 
 ```bash
-ros2 launch lunabot_drivetrain drivetrain_bench.launch.py max_throttle:=0.2
+ros2 launch lunabot_drivetrain drivetrain_bench.launch.py \
+  bridge_backend:=sabertooth \
+  max_throttle:=0.2
 ```
 
 In a second terminal, send a short forward command:
@@ -120,7 +154,7 @@ The joystick path is:
 
 `game_controller_node` → `/joy` → `teleop_twist_joy` → `/cmd_vel_teleop` →
 `twist_mux` → `/cmd_vel_safe` → `velocity_gate` → `/cmd_vel_gated` →
-`drivetrain_bridge` → Sabertooth serial.
+selected drivetrain bridge.
 
 If the controller is not picked up as device `0`, try:
 
@@ -136,14 +170,10 @@ ros2 launch lunabot_drivetrain drivetrain_bench.launch.py enable_teleop:=true jo
 
 ## micro-ROS?
 
-micro-ROS is useful when the Arduino is staying in the system as a ROS-aware
-microcontroller. For this drivetrain, it is not the simplest first step: the
-Jetson can already publish ROS 2 velocity commands and this package already
-speaks Sabertooth serial.
-
-Use micro-ROS later if the Arduino needs to remain responsible for hard
-real-time IO, encoder counting, watchdogs, or extra sensors. For first motion,
-keep the chain shorter: Jetson ROS 2 node → UART → Sabertooth.
+Do not use micro-ROS for this path. The Teensy is a deterministic motor IO
+controller with a small serial protocol; ROS 2 stays on the Jetson. That keeps
+the hard real-time safety loop small and keeps the existing ROS topic contracts
+unchanged.
 
 ### `velocity_gate`
 
@@ -165,6 +195,9 @@ zero twist.
   stall thresholds, control/telemetry rates).
 - `lunabot_drivetrain/sabertooth_serial.py`: low-level Simplified Serial and
   Packet Serial framing helpers.
+- `lunabot_drivetrain/teensy_protocol.py`: Jetson-side Teensy protocol codec.
+- `lunabot_drivetrain/teensy_serial.py`: pyserial-style Teensy client.
+- `lunabot_drivetrain/fake_teensy.py`: pseudo-terminal fake Teensy for tests.
 
 ## Common failure modes
 

--- a/src/lunabot_drivetrain/config/drivetrain.yaml
+++ b/src/lunabot_drivetrain/config/drivetrain.yaml
@@ -57,3 +57,22 @@ drivetrain_bridge:
     # --- Rates ---
     control_loop_hz: 20.0
     telemetry_publish_hz: 10.0
+
+teensy_drivetrain_bridge:
+  ros__parameters:
+    # Teensy 4.1 USB CDC endpoint. Prefer a udev symlink on the Jetson.
+    serial_port: "/dev/teensy_motor_io"
+    baud_rate: 115200
+    dry_run: false
+    cmd_vel_topic: "/cmd_vel_gated"
+
+    track_width_m: 0.44
+    wheel_radius_m: 0.065
+    encoder_counts_per_rev: 720
+
+    command_timeout_s: 0.5
+    teensy_timeout_s: 0.35
+    max_throttle: 1.0
+
+    control_loop_hz: 20.0
+    telemetry_publish_hz: 10.0

--- a/src/lunabot_drivetrain/launch/drivetrain_bench.launch.py
+++ b/src/lunabot_drivetrain/launch/drivetrain_bench.launch.py
@@ -72,35 +72,73 @@ def _create_optional_teleop_nodes(context):
     return [joystick_teleop, twist_mux]
 
 
-def generate_launch_description():
-    """Generate the drivetrain bench launch description."""
+def _create_drivetrain_bridge_node(context):
+    """Create the selected drivetrain hardware bridge."""
+    backend = LaunchConfiguration("bridge_backend").perform(context).strip().lower()
     config_path = _share_path("lunabot_drivetrain", "config", "drivetrain.yaml")
 
     serial_port = LaunchConfiguration("serial_port")
     baud_rate = LaunchConfiguration("baud_rate")
+    teensy_baud_rate = LaunchConfiguration("teensy_baud_rate")
     serial_protocol = LaunchConfiguration("serial_protocol")
     max_throttle = LaunchConfiguration("max_throttle")
     dry_run = LaunchConfiguration("dry_run")
 
-    drivetrain_bridge = Node(
-        package="lunabot_drivetrain",
-        executable="drivetrain_bridge",
-        name="drivetrain_bridge",
-        output="screen",
-        parameters=[
-            config_path,
-            {
-                "serial_port": ParameterValue(serial_port, value_type=str),
-                "baud_rate": ParameterValue(baud_rate, value_type=int),
-                "serial_protocol": ParameterValue(
-                    serial_protocol, value_type=str
-                ),
-                "max_throttle": ParameterValue(max_throttle, value_type=float),
-                "dry_run": ParameterValue(dry_run, value_type=bool),
-            },
-        ],
+    if backend == "sabertooth":
+        return [
+            Node(
+                package="lunabot_drivetrain",
+                executable="drivetrain_bridge",
+                name="drivetrain_bridge",
+                output="screen",
+                parameters=[
+                    config_path,
+                    {
+                        "serial_port": ParameterValue(serial_port, value_type=str),
+                        "baud_rate": ParameterValue(baud_rate, value_type=int),
+                        "serial_protocol": ParameterValue(
+                            serial_protocol, value_type=str
+                        ),
+                        "max_throttle": ParameterValue(
+                            max_throttle, value_type=float
+                        ),
+                        "dry_run": ParameterValue(dry_run, value_type=bool),
+                    },
+                ],
+            )
+        ]
+
+    if backend == "teensy":
+        return [
+            Node(
+                package="lunabot_drivetrain",
+                executable="teensy_drivetrain_bridge",
+                name="teensy_drivetrain_bridge",
+                output="screen",
+                parameters=[
+                    config_path,
+                    {
+                        "serial_port": ParameterValue(serial_port, value_type=str),
+                        "baud_rate": ParameterValue(
+                            teensy_baud_rate, value_type=int
+                        ),
+                        "max_throttle": ParameterValue(
+                            max_throttle, value_type=float
+                        ),
+                        "dry_run": ParameterValue(dry_run, value_type=bool),
+                    },
+                ],
+            )
+        ]
+
+    raise ValueError(
+        "bridge_backend must be 'sabertooth' or 'teensy', "
+        f"got {backend!r}"
     )
 
+
+def generate_launch_description():
+    """Generate the drivetrain bench launch description."""
     velocity_gate = Node(
         package="lunabot_drivetrain",
         executable="velocity_gate",
@@ -111,14 +149,31 @@ def generate_launch_description():
     return LaunchDescription(
         [
             DeclareLaunchArgument(
+                "bridge_backend",
+                default_value="sabertooth",
+                description=(
+                    "Hardware bridge to run: sabertooth for direct Jetson UART "
+                    "or teensy for Jetson USB serial to Teensy 4.1."
+                ),
+            ),
+            DeclareLaunchArgument(
                 "serial_port",
                 default_value="/dev/ttyTHS1",
-                description="Jetson UART device connected to the Sabertooth S1 pins.",
+                description=(
+                    "Serial device for the selected backend. Use /dev/ttyTHS1 "
+                    "for direct Sabertooth UART or /dev/teensy_motor_io for "
+                    "the Teensy USB endpoint."
+                ),
             ),
             DeclareLaunchArgument(
                 "baud_rate",
                 default_value="9600",
-                description="Sabertooth serial baud rate.",
+                description="Direct Sabertooth serial baud rate.",
+            ),
+            DeclareLaunchArgument(
+                "teensy_baud_rate",
+                default_value="115200",
+                description="Teensy USB CDC serial baud rate.",
             ),
             DeclareLaunchArgument(
                 "serial_protocol",
@@ -143,7 +198,9 @@ def generate_launch_description():
             DeclareLaunchArgument(
                 "enable_teleop",
                 default_value="false",
-                description="Start joystick teleop and route it through the safety gate.",
+                description=(
+                    "Start joystick teleop and route it through the safety gate."
+                ),
             ),
             DeclareLaunchArgument(
                 "joy_device_id",
@@ -156,7 +213,7 @@ def generate_launch_description():
                 description="Optional SDL controller name to match.",
             ),
             velocity_gate,
-            drivetrain_bridge,
+            OpaqueFunction(function=_create_drivetrain_bridge_node),
             OpaqueFunction(function=_create_optional_teleop_nodes),
         ]
     )

--- a/src/lunabot_drivetrain/lunabot_drivetrain/fake_teensy.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/fake_teensy.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fake Teensy motor IO endpoint for bridge testing."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pty
+import sys
+import time
+import tty
+
+from lunabot_drivetrain.teensy_protocol import (
+    DriveCommand,
+    DrivetrainTelemetry,
+    Frame,
+    MessageType,
+    ProtocolError,
+    TeensyStatus,
+    decode_frame,
+    encode_frame,
+    pack_drivetrain_telemetry,
+    pack_status,
+    unpack_drive_command,
+)
+
+
+class FakeTeensy:
+    """Small serial-loop simulator for the Teensy protocol."""
+
+    def __init__(self, fd: int, telemetry_hz: float = 20.0) -> None:
+        self._fd = fd
+        self._sequence = 0
+        self._rx = bytearray()
+        self._last_command = DriveCommand(
+            left=0.0,
+            right=0.0,
+            enabled=False,
+            estop_active=False,
+            motion_inhibited=False,
+        )
+        self._ticks = [0, 0, 0, 0]
+        self._period = 1.0 / telemetry_hz
+        os.set_blocking(self._fd, False)
+
+    def run(self) -> None:
+        """Serve fake status and telemetry until interrupted."""
+        next_publish = time.monotonic()
+        while True:
+            self._read_available()
+            now = time.monotonic()
+            if now >= next_publish:
+                self._publish()
+                next_publish = now + self._period
+            time.sleep(0.002)
+
+    def _read_available(self) -> None:
+        try:
+            chunk = os.read(self._fd, 256)
+        except BlockingIOError:
+            return
+        except OSError:
+            return
+        self._rx.extend(chunk)
+        while 0 in self._rx:
+            index = self._rx.index(0)
+            raw = bytes(self._rx[: index + 1])
+            del self._rx[: index + 1]
+            try:
+                frame = decode_frame(raw)
+            except ProtocolError:
+                continue
+            if frame.msg_type == MessageType.DRIVE_COMMAND:
+                self._last_command = unpack_drive_command(frame.body)
+
+    def _publish(self) -> None:
+        left = self._last_command.left if self._last_command.enabled else 0.0
+        right = self._last_command.right if self._last_command.enabled else 0.0
+        self._ticks[0] += int(left * 18)
+        self._ticks[2] += int(left * 18)
+        self._ticks[1] += int(right * 18)
+        self._ticks[3] += int(right * 18)
+
+        state = 2 if self._last_command.enabled and (left or right) else 1
+        status = TeensyStatus(
+            state=state,
+            fault_code=0,
+            estop_active=self._last_command.estop_active,
+            motion_inhibited=self._last_command.motion_inhibited,
+            controller_online=(True, True),
+        )
+        telemetry = DrivetrainTelemetry(
+            encoder_ticks=tuple(self._ticks),
+            wheel_velocity_rps=(left, right, left, right),
+            fault_code=0,
+            estop_active=self._last_command.estop_active,
+            motion_inhibited=self._last_command.motion_inhibited,
+            controller_online=(True, True),
+        )
+        self._write(MessageType.STATUS, pack_status(status))
+        self._write(
+            MessageType.DRIVETRAIN_TELEMETRY,
+            pack_drivetrain_telemetry(telemetry),
+        )
+
+    def _write(self, msg_type: MessageType, body: bytes) -> None:
+        self._sequence = (self._sequence + 1) & 0xFFFF
+        os.write(
+            self._fd,
+            encode_frame(Frame(msg_type=msg_type, sequence=self._sequence, body=body)),
+        )
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run a fake Teensy and print the PTY path for the bridge."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--telemetry-hz", type=float, default=20.0)
+    args = parser.parse_args(argv)
+
+    master, slave = pty.openpty()
+    tty.setraw(slave)
+    print(os.ttyname(slave), flush=True)
+    try:
+        FakeTeensy(master, telemetry_hz=args.telemetry_hz).run()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        os.close(master)
+        os.close(slave)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/lunabot_drivetrain/lunabot_drivetrain/teensy_drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/teensy_drivetrain_bridge.py
@@ -1,0 +1,496 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ROS bridge for the Teensy 4.1 motor IO controller."""
+
+from __future__ import annotations
+
+import math
+import time
+from typing import Any, Optional
+
+import rclpy
+from geometry_msgs.msg import Twist
+from nav_msgs.msg import Odometry
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Bool
+
+from lunabot_drivetrain.teensy_protocol import (
+    DriveCommand,
+    MessageType,
+    ProtocolError,
+    unpack_drivetrain_telemetry,
+    unpack_status,
+)
+from lunabot_drivetrain.teensy_serial import TeensySerialClient
+from lunabot_interfaces.msg import DrivetrainStatus, DrivetrainTelemetry
+
+_INHIBIT_QOS = QoSProfile(
+    history=HistoryPolicy.KEEP_LAST,
+    depth=1,
+    reliability=ReliabilityPolicy.RELIABLE,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
+)
+
+_WHEEL_NAMES = ["wheel_fl", "wheel_fr", "wheel_rl", "wheel_rr"]
+
+
+class TeensyDrivetrainBridge(Node):
+    """Bridge ROS drivetrain contracts to the Teensy USB serial endpoint."""
+
+    def __init__(self) -> None:
+        super().__init__("teensy_drivetrain_bridge")
+        self._declare_parameters()
+        self._validate_parameters()
+        self._init_state()
+        self._init_serial()
+        self._init_ros()
+        self.get_logger().info(
+            f"Teensy drivetrain bridge started — port={self._serial_port}, "
+            f"dry_run={self._dry_run}, cmd_vel_topic={self._cmd_vel_topic}"
+        )
+
+    def _declare_parameters(self) -> None:
+        self.declare_parameter("serial_port", "/dev/teensy_motor_io")
+        self.declare_parameter("baud_rate", 115200)
+        self.declare_parameter("dry_run", False)
+        self.declare_parameter("cmd_vel_topic", "/cmd_vel_gated")
+        self.declare_parameter("track_width_m", 0.44)
+        self.declare_parameter("wheel_radius_m", 0.065)
+        self.declare_parameter("encoder_counts_per_rev", 720)
+        self.declare_parameter("command_timeout_s", 0.5)
+        self.declare_parameter("teensy_timeout_s", 0.35)
+        self.declare_parameter("max_throttle", 1.0)
+        self.declare_parameter("control_loop_hz", 20.0)
+        self.declare_parameter("telemetry_publish_hz", 10.0)
+
+    def _validate_parameters(self) -> None:
+        self._serial_port = str(self.get_parameter("serial_port").value).strip()
+        self._baud_rate = int(self.get_parameter("baud_rate").value)
+        self._dry_run = bool(self.get_parameter("dry_run").value)
+        self._cmd_vel_topic = str(self.get_parameter("cmd_vel_topic").value).strip()
+        self._track_width = float(self.get_parameter("track_width_m").value)
+        self._wheel_radius = float(self.get_parameter("wheel_radius_m").value)
+        self._encoder_cpr = int(self.get_parameter("encoder_counts_per_rev").value)
+        self._cmd_timeout = float(self.get_parameter("command_timeout_s").value)
+        self._teensy_timeout = float(self.get_parameter("teensy_timeout_s").value)
+        self._max_throttle = float(self.get_parameter("max_throttle").value)
+        ctrl_hz = float(self.get_parameter("control_loop_hz").value)
+        self._telem_hz = float(self.get_parameter("telemetry_publish_hz").value)
+
+        if not self._serial_port:
+            raise ValueError("serial_port must not be empty")
+        if self._baud_rate <= 0:
+            raise ValueError("baud_rate must be positive")
+        if not self._cmd_vel_topic:
+            raise ValueError("cmd_vel_topic must not be empty")
+        if self._track_width <= 0.0:
+            raise ValueError("track_width_m must be positive")
+        if self._wheel_radius <= 0.0:
+            raise ValueError("wheel_radius_m must be positive")
+        if self._encoder_cpr <= 0:
+            raise ValueError("encoder_counts_per_rev must be positive")
+        if self._cmd_timeout <= 0.0:
+            raise ValueError("command_timeout_s must be positive")
+        if self._teensy_timeout <= 0.0:
+            raise ValueError("teensy_timeout_s must be positive")
+        if not 0.0 < self._max_throttle <= 1.0:
+            raise ValueError("max_throttle must be in (0, 1]")
+        if ctrl_hz <= 0.0:
+            raise ValueError("control_loop_hz must be positive")
+        if self._telem_hz <= 0.0:
+            raise ValueError("telemetry_publish_hz must be positive")
+        self._control_period = 1.0 / ctrl_hz
+
+    def _init_state(self) -> None:
+        self._state = DrivetrainStatus.STATE_UNINITIALISED
+        self._fault_code = DrivetrainStatus.FAULT_NONE
+        self._teensy_state = DrivetrainStatus.STATE_UNINITIALISED
+        self._teensy_fault_code = DrivetrainStatus.FAULT_NONE
+        self._teensy_status_fault_code = DrivetrainStatus.FAULT_NONE
+        self._teensy_telemetry_fault_code = DrivetrainStatus.FAULT_NONE
+        self._ros_estop_active = False
+        self._ros_motion_inhibited = False
+        self._teensy_estop_active = False
+        self._teensy_motion_inhibited = False
+        self._motion_inhibited = False
+        self._estop_active = False
+        self._controller_online = [False, False]
+        self._controller_offline_latched = False
+        self._startup_time = time.monotonic()
+        self._last_cmd_time: Optional[float] = None
+        self._last_twist = Twist()
+        self._encoder_ticks = [0, 0, 0, 0]
+        self._wheel_velocity_rps = [0.0, 0.0, 0.0, 0.0]
+        self._last_odom_time: Optional[float] = None
+        self._odom_x = 0.0
+        self._odom_y = 0.0
+        self._odom_yaw = 0.0
+        self._client: TeensySerialClient | None = None
+        self._serial: Any = None
+
+    def _init_serial(self) -> None:
+        try:
+            import serial as pyserial
+        except ImportError as exc:
+            self._handle_serial_unavailable(exc)
+            return
+
+        try:
+            self._serial = pyserial.Serial(
+                self._serial_port,
+                self._baud_rate,
+                timeout=0,
+                write_timeout=0.1,
+            )
+        except (OSError, pyserial.SerialException) as exc:
+            self._handle_serial_unavailable(exc)
+            return
+
+        self._client = TeensySerialClient(self._serial)
+        self._state = DrivetrainStatus.STATE_READY
+        self.get_logger().info(f"Teensy serial port {self._serial_port} opened")
+
+    def _handle_serial_unavailable(self, exc: Exception) -> None:
+        if self._dry_run:
+            self.get_logger().warn(
+                f"Teensy serial port {self._serial_port} unavailable: {exc}. "
+                "Explicit dry-run enabled; no motor output will be sent."
+            )
+            self._state = DrivetrainStatus.STATE_READY
+            return
+        self.get_logger().error(
+            f"Teensy serial port {self._serial_port} unavailable: {exc}. "
+            "Bridge is FAULTED and will not accept motion commands."
+        )
+        self._fault_code = DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
+        self._state = DrivetrainStatus.STATE_FAULT
+
+    def _init_ros(self) -> None:
+        self._cmd_vel_sub = self.create_subscription(
+            Twist, self._cmd_vel_topic, self._cmd_vel_callback, 10
+        )
+        self._inhibit_sub = self.create_subscription(
+            Bool,
+            "/safety/motion_inhibit",
+            self._inhibit_callback,
+            _INHIBIT_QOS,
+        )
+        self._estop_sub = self.create_subscription(
+            Bool, "/safety/estop", self._estop_callback, 10
+        )
+        self._status_pub = self.create_publisher(
+            DrivetrainStatus, "/drivetrain/status", 10
+        )
+        self._telem_pub = self.create_publisher(
+            DrivetrainTelemetry, "/drivetrain/telemetry", 10
+        )
+        self._odom_pub = self.create_publisher(Odometry, "/odom_wheels", 10)
+        self._joint_pub = self.create_publisher(
+            JointState, "/joint_states_wheels", 10
+        )
+
+        self._control_timer = self.create_timer(
+            self._control_period, self._control_loop
+        )
+        self._telem_timer = self.create_timer(
+            1.0 / self._telem_hz, self._publish_telemetry
+        )
+
+    def _cmd_vel_callback(self, msg: Twist) -> None:
+        self._last_twist = msg
+        self._last_cmd_time = time.monotonic()
+
+    def _inhibit_callback(self, msg: Bool) -> None:
+        self._ros_motion_inhibited = msg.data
+        self._sync_safety_state()
+
+    def _estop_callback(self, msg: Bool) -> None:
+        self._ros_estop_active = msg.data
+        self._sync_safety_state()
+        if msg.data:
+            self._state = DrivetrainStatus.STATE_ESTOP
+            self._fault_code = DrivetrainStatus.FAULT_ESTOP
+
+    def _control_loop(self) -> None:
+        now = time.monotonic()
+        self._read_teensy_frames(now)
+
+        if self._client is None:
+            return
+
+        try:
+            self._client.send_heartbeat()
+            self._client.send_drive_command(self._build_drive_command(now))
+        except OSError as exc:
+            self._mark_controller_offline(f"Teensy serial write failed: {exc}")
+            return
+
+        if self._link_stale(now):
+            self._mark_controller_offline("No fresh Teensy telemetry")
+
+    def _build_drive_command(self, now: float) -> DriveCommand:
+        stale = (
+            self._last_cmd_time is None
+            or (now - self._last_cmd_time) > self._cmd_timeout
+        )
+        blocked = self._estop_active or self._motion_inhibited or stale
+        blocked = blocked or self._teensy_fault_code != DrivetrainStatus.FAULT_NONE
+        blocked = blocked or self._teensy_state == DrivetrainStatus.STATE_FAULT
+        if blocked:
+            if (
+                stale
+                and self._state == DrivetrainStatus.STATE_DRIVING
+                and self._teensy_fault_code == DrivetrainStatus.FAULT_NONE
+            ):
+                self._state = DrivetrainStatus.STATE_READY
+            return DriveCommand(
+                left=0.0,
+                right=0.0,
+                enabled=False,
+                estop_active=self._estop_active,
+                motion_inhibited=self._motion_inhibited,
+            )
+
+        left, right = self._twist_to_wheel_speeds(
+            self._last_twist.linear.x,
+            self._last_twist.angular.z,
+        )
+        enabled = abs(left) > 0.01 or abs(right) > 0.01
+        self._state = (
+            DrivetrainStatus.STATE_DRIVING
+            if enabled
+            else DrivetrainStatus.STATE_READY
+        )
+        self._fault_code = DrivetrainStatus.FAULT_NONE
+        return DriveCommand(
+            left=left,
+            right=right,
+            enabled=enabled,
+            estop_active=False,
+            motion_inhibited=False,
+        )
+
+    def _read_teensy_frames(self, now: float) -> None:
+        if self._client is None:
+            return
+        try:
+            frames = self._client.read_frames()
+        except OSError as exc:
+            self._mark_controller_offline(f"Teensy serial read failed: {exc}")
+            return
+
+        for frame in frames:
+            try:
+                if frame.msg_type == MessageType.STATUS:
+                    self._apply_status(frame.body)
+                elif frame.msg_type == MessageType.DRIVETRAIN_TELEMETRY:
+                    self._apply_telemetry(frame.body)
+            except ProtocolError as exc:
+                self.get_logger().warn(f"Ignoring bad Teensy payload: {exc}")
+
+        if self._client.last_rx_time is not None and not self._link_stale(now):
+            if self._controller_offline_latched and not self._estop_active:
+                self._controller_offline_latched = False
+                self._fault_code = DrivetrainStatus.FAULT_NONE
+                self._state = DrivetrainStatus.STATE_READY
+
+    def _apply_status(self, body: bytes) -> None:
+        status = unpack_status(body)
+        self._teensy_state = status.state
+        self._teensy_status_fault_code = status.fault_code
+        self._apply_teensy_health()
+        self._teensy_estop_active = status.estop_active
+        self._teensy_motion_inhibited = status.motion_inhibited
+        self._sync_safety_state()
+        self._controller_online = list(status.controller_online)
+
+    def _apply_telemetry(self, body: bytes) -> None:
+        telemetry = unpack_drivetrain_telemetry(body)
+        self._encoder_ticks = list(telemetry.encoder_ticks)
+        self._wheel_velocity_rps = list(telemetry.wheel_velocity_rps)
+        self._teensy_telemetry_fault_code = telemetry.fault_code
+        self._apply_teensy_health()
+        self._teensy_estop_active = telemetry.estop_active
+        self._teensy_motion_inhibited = telemetry.motion_inhibited
+        self._sync_safety_state()
+        self._controller_online = list(telemetry.controller_online)
+
+    def _apply_teensy_health(self) -> None:
+        self._teensy_fault_code = max(
+            self._teensy_status_fault_code,
+            self._teensy_telemetry_fault_code,
+        )
+
+        if self._teensy_state == DrivetrainStatus.STATE_FAULT:
+            self._state = DrivetrainStatus.STATE_FAULT
+        elif self._teensy_state in {
+            DrivetrainStatus.STATE_READY,
+            DrivetrainStatus.STATE_DRIVING,
+            DrivetrainStatus.STATE_ESTOP,
+        }:
+            self._state = self._teensy_state
+
+        self._fault_code = self._teensy_fault_code
+        if self._teensy_fault_code != DrivetrainStatus.FAULT_NONE:
+            self._state = DrivetrainStatus.STATE_FAULT
+
+    def _sync_safety_state(self) -> None:
+        self._estop_active = self._ros_estop_active or self._teensy_estop_active
+        self._motion_inhibited = (
+            self._ros_motion_inhibited or self._teensy_motion_inhibited
+        )
+        if self._estop_active:
+            self._state = DrivetrainStatus.STATE_ESTOP
+            self._fault_code = DrivetrainStatus.FAULT_ESTOP
+
+    def _link_stale(self, now: float) -> bool:
+        if self._dry_run:
+            return False
+        if self._client is None or self._client.last_rx_time is None:
+            return (now - self._startup_time) > self._teensy_timeout
+        return (now - self._client.last_rx_time) > self._teensy_timeout
+
+    def _mark_controller_offline(self, reason: str) -> None:
+        if self._state != DrivetrainStatus.STATE_FAULT:
+            self.get_logger().error(reason)
+        self._controller_online = [False, False]
+        self._controller_offline_latched = True
+        self._fault_code = DrivetrainStatus.FAULT_CONTROLLER_OFFLINE
+        self._state = DrivetrainStatus.STATE_FAULT
+
+    def _twist_to_wheel_speeds(
+        self, linear_x: float, angular_z: float
+    ) -> tuple[float, float]:
+        half_track = self._track_width / 2.0
+        left_vel = linear_x - angular_z * half_track
+        right_vel = linear_x + angular_z * half_track
+        max_vel = max(abs(left_vel), abs(right_vel), 0.001)
+        max_speed = 0.3
+        scale = min(1.0, max_speed / max_vel)
+        limit = self._max_throttle
+        left = max(-limit, min(limit, (left_vel * scale) / max_speed))
+        right = max(-limit, min(limit, (right_vel * scale) / max_speed))
+        return left, right
+
+    def _publish_telemetry(self) -> None:
+        stamp = self.get_clock().now().to_msg()
+        status = DrivetrainStatus()
+        status.header.stamp = stamp
+        status.state = self._state
+        status.fault_code = self._fault_code
+        status.estop_active = self._estop_active
+        status.motion_inhibited = self._motion_inhibited
+        status.controller_online = self._controller_online
+        self._status_pub.publish(status)
+
+        telem = DrivetrainTelemetry()
+        telem.header.stamp = stamp
+        telem.wheel_velocity_rps = self._wheel_velocity_rps
+        telem.encoder_ticks = self._encoder_ticks
+        telem.controller_online = self._controller_online
+        telem.estop_active = self._estop_active
+        telem.motion_inhibited = self._motion_inhibited
+        telem.fault_code = self._fault_code
+        self._telem_pub.publish(telem)
+        self._publish_odometry(stamp)
+        self._publish_joint_state(stamp)
+
+    def _publish_odometry(self, stamp) -> None:
+        now = time.monotonic()
+        if self._last_odom_time is None:
+            dt = 0.0
+        else:
+            dt = max(0.0, now - self._last_odom_time)
+        self._last_odom_time = now
+
+        left_rps = (self._wheel_velocity_rps[0] + self._wheel_velocity_rps[2]) / 2.0
+        right_rps = (self._wheel_velocity_rps[1] + self._wheel_velocity_rps[3]) / 2.0
+        wheel_circumference = 2.0 * math.pi * self._wheel_radius
+        left_mps = left_rps * wheel_circumference
+        right_mps = right_rps * wheel_circumference
+        linear_x = (left_mps + right_mps) / 2.0
+        angular_z = (right_mps - left_mps) / self._track_width
+
+        if dt > 0.0:
+            self._odom_x += linear_x * math.cos(self._odom_yaw) * dt
+            self._odom_y += linear_x * math.sin(self._odom_yaw) * dt
+            self._odom_yaw += angular_z * dt
+
+        odom = Odometry()
+        odom.header.stamp = stamp
+        odom.header.frame_id = "odom"
+        odom.child_frame_id = "base_footprint"
+        odom.pose.pose.position.x = float(self._odom_x)
+        odom.pose.pose.position.y = float(self._odom_y)
+        odom.pose.pose.orientation.z = math.sin(self._odom_yaw / 2.0)
+        odom.pose.pose.orientation.w = math.cos(self._odom_yaw / 2.0)
+        odom.twist.twist.linear.x = float(linear_x)
+        odom.twist.twist.angular.z = float(angular_z)
+        self._odom_pub.publish(odom)
+
+    def _publish_joint_state(self, stamp) -> None:
+        joint_state = JointState()
+        joint_state.header.stamp = stamp
+        joint_state.name = list(_WHEEL_NAMES)
+        joint_state.velocity = [
+            float(v * 2.0 * math.pi) for v in self._wheel_velocity_rps
+        ]
+        joint_state.position = [
+            float(t / self._encoder_cpr * 2.0 * math.pi)
+            for t in self._encoder_ticks
+        ]
+        joint_state.effort = []
+        self._joint_pub.publish(joint_state)
+
+    def destroy_node(self) -> None:
+        if self._client is not None:
+            try:
+                self._client.send_drive_command(
+                    DriveCommand(
+                        left=0.0,
+                        right=0.0,
+                        enabled=False,
+                        estop_active=True,
+                        motion_inhibited=True,
+                    )
+                )
+            except OSError:
+                pass
+        if self._serial is not None:
+            try:
+                self._serial.close()
+            except OSError as exc:
+                self.get_logger().warn(f"Teensy serial close failed: {exc}")
+        super().destroy_node()
+
+
+def main(args=None) -> None:
+    """Entry point for the teensy_drivetrain_bridge executable."""
+    rclpy.init(args=args)
+    node = TeensyDrivetrainBridge()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/src/lunabot_drivetrain/lunabot_drivetrain/teensy_protocol.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/teensy_protocol.py
@@ -1,0 +1,275 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Framed USB serial protocol for the Teensy motor IO controller."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+import struct
+
+PROTOCOL_VERSION = 1
+MAX_BODY_BYTES = 96
+
+
+class MessageType(IntEnum):
+    """Protocol message identifiers."""
+
+    HEARTBEAT = 1
+    DRIVE_COMMAND = 2
+    CONTROL_FLAGS = 3
+    RESET_FAULTS = 4
+    STATUS = 0x80
+    DRIVETRAIN_TELEMETRY = 0x81
+    FAULT_EVENT = 0x82
+
+
+class ProtocolError(ValueError):
+    """Raised when an encoded frame is invalid."""
+
+
+@dataclass(frozen=True)
+class Frame:
+    """Decoded Teensy protocol frame."""
+
+    msg_type: MessageType
+    sequence: int
+    body: bytes = b""
+    version: int = PROTOCOL_VERSION
+
+
+@dataclass(frozen=True)
+class DriveCommand:
+    """Normalised per-side drivetrain command."""
+
+    left: float
+    right: float
+    enabled: bool
+    estop_active: bool
+    motion_inhibited: bool
+
+
+@dataclass(frozen=True)
+class TeensyStatus:
+    """Controller status reported by the Teensy."""
+
+    state: int
+    fault_code: int
+    estop_active: bool
+    motion_inhibited: bool
+    controller_online: tuple[bool, bool]
+
+
+@dataclass(frozen=True)
+class DrivetrainTelemetry:
+    """Drivetrain telemetry reported by the Teensy."""
+
+    encoder_ticks: tuple[int, int, int, int]
+    wheel_velocity_rps: tuple[float, float, float, float]
+    fault_code: int
+    estop_active: bool
+    motion_inhibited: bool
+    controller_online: tuple[bool, bool]
+
+
+def crc16_ccitt(data: bytes) -> int:
+    """Return CRC-16/CCITT-FALSE for *data*."""
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = ((crc << 1) ^ 0x1021) & 0xFFFF
+            else:
+                crc = (crc << 1) & 0xFFFF
+    return crc
+
+
+def cobs_encode(data: bytes) -> bytes:
+    """COBS-encode *data* and append a zero frame delimiter."""
+    out = bytearray()
+    code_index = 0
+    code = 1
+    out.append(0)
+
+    for byte in data:
+        if byte == 0:
+            out[code_index] = code
+            code_index = len(out)
+            out.append(0)
+            code = 1
+            continue
+
+        out.append(byte)
+        code += 1
+        if code == 0xFF:
+            out[code_index] = code
+            code_index = len(out)
+            out.append(0)
+            code = 1
+
+    out[code_index] = code
+    out.append(0)
+    return bytes(out)
+
+
+def cobs_decode(frame: bytes) -> bytes:
+    """Decode one zero-delimited COBS frame."""
+    if not frame or frame[-1] != 0:
+        raise ProtocolError("COBS frame must end with zero delimiter")
+
+    out = bytearray()
+    index = 0
+    end = len(frame) - 1
+    while index < end:
+        code = frame[index]
+        index += 1
+        if code == 0 or index + code - 1 > end:
+            raise ProtocolError("invalid COBS code")
+        out.extend(frame[index:index + code - 1])
+        index += code - 1
+        if code < 0xFF and index < end:
+            out.append(0)
+    return bytes(out)
+
+
+def encode_frame(frame: Frame) -> bytes:
+    """Encode a protocol frame for serial transmission."""
+    if frame.version != PROTOCOL_VERSION:
+        raise ProtocolError(f"unsupported protocol version {frame.version}")
+    if len(frame.body) > MAX_BODY_BYTES:
+        raise ProtocolError(f"frame body too large: {len(frame.body)}")
+    payload = struct.pack("<BBH", frame.version, int(frame.msg_type), frame.sequence)
+    payload += frame.body
+    payload += struct.pack("<H", crc16_ccitt(payload))
+    return cobs_encode(payload)
+
+
+def decode_frame(frame: bytes) -> Frame:
+    """Decode and validate one protocol frame."""
+    payload = cobs_decode(frame)
+    if len(payload) < 6:
+        raise ProtocolError("frame too short")
+    if len(payload) > 4 + MAX_BODY_BYTES + 2:
+        raise ProtocolError("frame too large")
+
+    expected_crc = struct.unpack_from("<H", payload, len(payload) - 2)[0]
+    body_without_crc = payload[:-2]
+    actual_crc = crc16_ccitt(body_without_crc)
+    if expected_crc != actual_crc:
+        raise ProtocolError("crc mismatch")
+
+    version, raw_type, sequence = struct.unpack_from("<BBH", body_without_crc)
+    if version != PROTOCOL_VERSION:
+        raise ProtocolError(f"unsupported protocol version {version}")
+    try:
+        msg_type = MessageType(raw_type)
+    except ValueError as exc:
+        raise ProtocolError(f"unknown message type {raw_type}") from exc
+    return Frame(msg_type=msg_type, sequence=sequence, body=body_without_crc[4:])
+
+
+def _scale_throttle(value: float) -> int:
+    clamped = max(-1.0, min(1.0, float(value)))
+    return int(round(clamped * 10000))
+
+
+def pack_drive_command(command: DriveCommand) -> bytes:
+    """Pack a drivetrain command body."""
+    flags = 0
+    flags |= int(command.enabled) << 0
+    flags |= int(command.estop_active) << 1
+    flags |= int(command.motion_inhibited) << 2
+    return struct.pack(
+        "<hhB",
+        _scale_throttle(command.left),
+        _scale_throttle(command.right),
+        flags,
+    )
+
+
+def unpack_drive_command(body: bytes) -> DriveCommand:
+    """Unpack a drivetrain command body."""
+    if len(body) != 5:
+        raise ProtocolError(f"drive command body must be 5 bytes, got {len(body)}")
+    left, right, flags = struct.unpack("<hhB", body)
+    return DriveCommand(
+        left=left / 10000.0,
+        right=right / 10000.0,
+        enabled=bool(flags & 0x01),
+        estop_active=bool(flags & 0x02),
+        motion_inhibited=bool(flags & 0x04),
+    )
+
+
+def pack_status(status: TeensyStatus) -> bytes:
+    """Pack a Teensy status body."""
+    flags = int(status.estop_active) | (int(status.motion_inhibited) << 1)
+    online = int(status.controller_online[0]) | (int(status.controller_online[1]) << 1)
+    return struct.pack("<BHBB", status.state, status.fault_code, flags, online)
+
+
+def unpack_status(body: bytes) -> TeensyStatus:
+    """Unpack a Teensy status body."""
+    if len(body) != 5:
+        raise ProtocolError(f"status body must be 5 bytes, got {len(body)}")
+    state, fault_code, flags, online = struct.unpack("<BHBB", body)
+    return TeensyStatus(
+        state=state,
+        fault_code=fault_code,
+        estop_active=bool(flags & 0x01),
+        motion_inhibited=bool(flags & 0x02),
+        controller_online=(bool(online & 0x01), bool(online & 0x02)),
+    )
+
+
+def pack_drivetrain_telemetry(telemetry: DrivetrainTelemetry) -> bytes:
+    """Pack drivetrain telemetry."""
+    velocities_millirps = [
+        int(round(value * 1000.0))
+        for value in telemetry.wheel_velocity_rps
+    ]
+    flags = int(telemetry.estop_active) | (int(telemetry.motion_inhibited) << 1)
+    online = int(telemetry.controller_online[0]) | (
+        int(telemetry.controller_online[1]) << 1
+    )
+    return struct.pack(
+        "<4i4hHBB",
+        *telemetry.encoder_ticks,
+        *velocities_millirps,
+        telemetry.fault_code,
+        flags,
+        online,
+    )
+
+
+def unpack_drivetrain_telemetry(body: bytes) -> DrivetrainTelemetry:
+    """Unpack drivetrain telemetry."""
+    if len(body) != 28:
+        raise ProtocolError(f"telemetry body must be 28 bytes, got {len(body)}")
+    unpacked = struct.unpack("<4i4hHBB", body)
+    ticks = tuple(int(value) for value in unpacked[:4])
+    velocities = tuple(float(value) / 1000.0 for value in unpacked[4:8])
+    fault_code = int(unpacked[8])
+    flags = int(unpacked[9])
+    online = int(unpacked[10])
+    return DrivetrainTelemetry(
+        encoder_ticks=ticks,
+        wheel_velocity_rps=velocities,
+        fault_code=fault_code,
+        estop_active=bool(flags & 0x01),
+        motion_inhibited=bool(flags & 0x02),
+        controller_online=(bool(online & 0x01), bool(online & 0x02)),
+    )

--- a/src/lunabot_drivetrain/lunabot_drivetrain/teensy_serial.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/teensy_serial.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure serial client for the Teensy motor IO protocol."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from lunabot_drivetrain.teensy_protocol import (
+    DriveCommand,
+    Frame,
+    MessageType,
+    ProtocolError,
+    decode_frame,
+    encode_frame,
+    pack_drive_command,
+)
+
+
+class TeensySerialClient:
+    """Frame-oriented protocol client around a pyserial-like port."""
+
+    def __init__(self, port, now: Callable[[], float] | None = None) -> None:
+        self._port = port
+        self._now = now or time.monotonic
+        self._sequence = 0
+        self._rx = bytearray()
+        self.last_rx_time: float | None = None
+
+    def send_heartbeat(self) -> None:
+        """Send a heartbeat frame."""
+        self._write(MessageType.HEARTBEAT, b"")
+
+    def send_reset_faults(self) -> None:
+        """Ask the Teensy to clear resettable faults."""
+        self._write(MessageType.RESET_FAULTS, b"")
+
+    def send_drive_command(self, command: DriveCommand) -> None:
+        """Send one normalised drivetrain command."""
+        self._write(MessageType.DRIVE_COMMAND, pack_drive_command(command))
+
+    def read_frames(self) -> list[Frame]:
+        """Read and decode all complete frames currently available."""
+        try:
+            waiting = getattr(self._port, "in_waiting", 0)
+            chunk = self._port.read(waiting or 1)
+        except OSError:
+            raise
+        if chunk:
+            self._rx.extend(chunk)
+
+        frames: list[Frame] = []
+        while 0 in self._rx:
+            index = self._rx.index(0)
+            raw = bytes(self._rx[: index + 1])
+            del self._rx[: index + 1]
+            try:
+                frames.append(decode_frame(raw))
+                self.last_rx_time = self._now()
+            except ProtocolError:
+                continue
+        return frames
+
+    def _write(self, msg_type: MessageType, body: bytes) -> None:
+        self._sequence = (self._sequence + 1) & 0xFFFF
+        payload = encode_frame(
+            Frame(msg_type=msg_type, sequence=self._sequence, body=body)
+        )
+        self._port.write(payload)

--- a/src/lunabot_drivetrain/setup.py
+++ b/src/lunabot_drivetrain/setup.py
@@ -46,6 +46,9 @@ setup(
     entry_points={
         "console_scripts": [
             "drivetrain_bridge = lunabot_drivetrain.drivetrain_bridge:main",
+            "fake_teensy = lunabot_drivetrain.fake_teensy:main",
+            "teensy_drivetrain_bridge = "
+            "lunabot_drivetrain.teensy_drivetrain_bridge:main",
             "velocity_gate = lunabot_drivetrain.velocity_gate:main",
         ],
     },

--- a/src/lunabot_drivetrain/test/test_teensy_drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/test/test_teensy_drivetrain_bridge.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behaviour tests for the Teensy drivetrain bridge safety state."""
+
+import time
+import types
+
+from builtin_interfaces.msg import Time
+from geometry_msgs.msg import Twist
+
+from lunabot_drivetrain.teensy_drivetrain_bridge import TeensyDrivetrainBridge
+from lunabot_drivetrain.teensy_protocol import (
+    DrivetrainTelemetry,
+    TeensyStatus,
+    pack_drivetrain_telemetry,
+    pack_status,
+)
+from lunabot_interfaces.msg import DrivetrainStatus
+
+
+def _bridge_for_command_tests():
+    bridge = object.__new__(TeensyDrivetrainBridge)
+    bridge._state = DrivetrainStatus.STATE_READY
+    bridge._fault_code = DrivetrainStatus.FAULT_NONE
+    bridge._teensy_state = DrivetrainStatus.STATE_READY
+    bridge._teensy_fault_code = DrivetrainStatus.FAULT_NONE
+    bridge._teensy_status_fault_code = DrivetrainStatus.FAULT_NONE
+    bridge._teensy_telemetry_fault_code = DrivetrainStatus.FAULT_NONE
+    bridge._ros_estop_active = False
+    bridge._ros_motion_inhibited = False
+    bridge._teensy_estop_active = False
+    bridge._teensy_motion_inhibited = False
+    bridge._motion_inhibited = False
+    bridge._estop_active = False
+    bridge._controller_online = [True, True]
+    bridge._last_cmd_time = time.monotonic()
+    bridge._last_twist = Twist()
+    bridge._last_twist.linear.x = 0.2
+    bridge._track_width = 0.44
+    bridge._wheel_radius = 0.065
+    bridge._max_throttle = 1.0
+    bridge._cmd_timeout = 0.5
+    bridge._last_odom_time = None
+    bridge._odom_x = 0.0
+    bridge._odom_y = 0.0
+    bridge._odom_yaw = 0.0
+    return bridge
+
+
+def test_teensy_fault_is_not_cleared_by_next_drive_command():
+    bridge = _bridge_for_command_tests()
+
+    bridge._apply_status(
+        pack_status(
+            TeensyStatus(
+                state=DrivetrainStatus.STATE_FAULT,
+                fault_code=DrivetrainStatus.FAULT_OVERCURRENT,
+                estop_active=False,
+                motion_inhibited=False,
+                controller_online=(True, True),
+            )
+        )
+    )
+    command = bridge._build_drive_command(time.monotonic())
+
+    assert bridge._state == DrivetrainStatus.STATE_FAULT
+    assert bridge._fault_code == DrivetrainStatus.FAULT_OVERCURRENT
+    assert command.enabled is False
+    assert command.left == 0.0
+    assert command.right == 0.0
+
+
+def test_odometry_is_published_from_teensy_wheel_velocity():
+    bridge = _bridge_for_command_tests()
+    published = []
+    bridge._odom_pub = types.SimpleNamespace(publish=published.append)
+    bridge._wheel_velocity_rps = [1.0, 1.0, 1.0, 1.0]
+    bridge._last_odom_time = time.monotonic() - 1.0
+
+    bridge._publish_odometry(Time())
+
+    assert len(published) == 1
+    odom = published[0]
+    assert odom.header.frame_id == "odom"
+    assert odom.child_frame_id == "base_footprint"
+    assert odom.pose.pose.position.x > 0.3
+    assert (
+        abs(odom.twist.twist.linear.x - (2.0 * 3.141592653589793 * 0.065))
+        < 0.01
+    )
+
+
+def test_telemetry_without_fault_does_not_clear_status_fault():
+    bridge = _bridge_for_command_tests()
+
+    bridge._apply_status(
+        pack_status(
+            TeensyStatus(
+                state=DrivetrainStatus.STATE_FAULT,
+                fault_code=DrivetrainStatus.FAULT_OVERCURRENT,
+                estop_active=False,
+                motion_inhibited=False,
+                controller_online=(True, True),
+            )
+        )
+    )
+    bridge._apply_telemetry(
+        pack_drivetrain_telemetry(
+            DrivetrainTelemetry(
+                encoder_ticks=(0, 0, 0, 0),
+                wheel_velocity_rps=(0.0, 0.0, 0.0, 0.0),
+                fault_code=DrivetrainStatus.FAULT_NONE,
+                estop_active=False,
+                motion_inhibited=False,
+                controller_online=(True, True),
+            )
+        )
+    )
+
+    assert bridge._state == DrivetrainStatus.STATE_FAULT
+    assert bridge._fault_code == DrivetrainStatus.FAULT_OVERCURRENT

--- a/src/lunabot_drivetrain/test/test_teensy_protocol.py
+++ b/src/lunabot_drivetrain/test/test_teensy_protocol.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Teensy motor IO serial protocol."""
+
+import pytest
+
+from lunabot_drivetrain.teensy_protocol import (
+    DriveCommand,
+    DrivetrainTelemetry,
+    Frame,
+    MessageType,
+    ProtocolError,
+    TeensyStatus,
+    decode_frame,
+    encode_frame,
+    pack_drive_command,
+    pack_drivetrain_telemetry,
+    pack_status,
+    unpack_drive_command,
+    unpack_drivetrain_telemetry,
+    unpack_status,
+)
+
+
+def test_frame_round_trip_preserves_type_sequence_and_body():
+    frame = Frame(
+        msg_type=MessageType.DRIVE_COMMAND,
+        sequence=42,
+        body=b"\x01\x00\x7f\x00\x80",
+    )
+
+    decoded = decode_frame(encode_frame(frame))
+
+    assert decoded == frame
+
+
+def test_corrupted_frame_is_rejected():
+    encoded = bytearray(encode_frame(Frame(MessageType.HEARTBEAT, 1, b"")))
+    encoded[2] ^= 0x55
+
+    with pytest.raises(ProtocolError):
+        decode_frame(bytes(encoded))
+
+
+def test_drive_command_body_round_trips_and_clamps():
+    command = DriveCommand(
+        left=2.0,
+        right=-0.25,
+        enabled=True,
+        estop_active=False,
+        motion_inhibited=True,
+    )
+
+    decoded = unpack_drive_command(pack_drive_command(command))
+
+    assert decoded.left == 1.0
+    assert decoded.right == -0.25
+    assert decoded.enabled is True
+    assert decoded.estop_active is False
+    assert decoded.motion_inhibited is True
+
+
+def test_status_body_round_trips():
+    status = TeensyStatus(
+        state=2,
+        fault_code=0,
+        estop_active=False,
+        motion_inhibited=True,
+        controller_online=(True, False),
+    )
+
+    assert unpack_status(pack_status(status)) == status
+
+
+def test_telemetry_body_round_trips_scaled_values():
+    telemetry = DrivetrainTelemetry(
+        encoder_ticks=(1, -2, 3, -4),
+        wheel_velocity_rps=(0.1234, -0.5, 1.0, 0.0),
+        fault_code=4,
+        estop_active=True,
+        motion_inhibited=False,
+        controller_online=(True, True),
+    )
+
+    decoded = unpack_drivetrain_telemetry(pack_drivetrain_telemetry(telemetry))
+
+    assert decoded.encoder_ticks == telemetry.encoder_ticks
+    assert decoded.wheel_velocity_rps == (0.123, -0.5, 1.0, 0.0)
+    assert decoded.fault_code == telemetry.fault_code
+    assert decoded.estop_active is True
+    assert decoded.motion_inhibited is False
+    assert decoded.controller_online == (True, True)

--- a/src/lunabot_drivetrain/test/test_teensy_serial.py
+++ b/src/lunabot_drivetrain/test/test_teensy_serial.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Leicester Lunabotics Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the pure Teensy serial client."""
+
+from lunabot_drivetrain.teensy_protocol import (
+    DriveCommand,
+    Frame,
+    MessageType,
+    decode_frame,
+    encode_frame,
+    unpack_drive_command,
+)
+from lunabot_drivetrain.teensy_serial import TeensySerialClient
+
+
+class FakePort:
+    def __init__(self) -> None:
+        self.writes = bytearray()
+        self.reads = bytearray()
+
+    @property
+    def in_waiting(self) -> int:
+        return len(self.reads)
+
+    def write(self, data: bytes) -> int:
+        self.writes.extend(data)
+        return len(data)
+
+    def read(self, size: int) -> bytes:
+        chunk = bytes(self.reads[:size])
+        del self.reads[:size]
+        return chunk
+
+
+def test_send_drive_command_writes_framed_payload():
+    port = FakePort()
+    client = TeensySerialClient(port)
+
+    client.send_drive_command(
+        DriveCommand(
+            left=0.25,
+            right=-0.5,
+            enabled=True,
+            estop_active=False,
+            motion_inhibited=False,
+        )
+    )
+
+    frame = decode_frame(bytes(port.writes))
+    command = unpack_drive_command(frame.body)
+    assert frame.msg_type == MessageType.DRIVE_COMMAND
+    assert command.left == 0.25
+    assert command.right == -0.5
+    assert command.enabled is True
+
+
+def test_read_frames_discards_corrupt_frame_and_keeps_good_frame():
+    now = [10.0]
+    port = FakePort()
+    client = TeensySerialClient(port, now=lambda: now[0])
+    bad = bytearray(encode_frame(Frame(MessageType.HEARTBEAT, 1, b"")))
+    bad[2] ^= 0x44
+    good = encode_frame(Frame(MessageType.STATUS, 2, b"\x01\x00\x00\x00\x03"))
+    port.reads.extend(bytes(bad) + good)
+
+    frames = client.read_frames()
+
+    assert len(frames) == 1
+    assert frames[0].msg_type == MessageType.STATUS
+    assert frames[0].sequence == 2
+    assert client.last_rx_time == 10.0


### PR DESCRIPTION
## Summary

Adds the first Teensy 4.1 motor IO foundation for the updated electrical CDR:

- host-testable Teensy firmware core under `firmware/teensy_motor_io`;
- COBS-framed, CRC-checked Jetson↔Teensy protocol;
- Jetson-side Teensy serial client and fake Teensy PTY endpoint;
- `teensy_drivetrain_bridge` preserving the existing drivetrain ROS contract;
- `bridge_backend:=sabertooth|teensy` selection in drivetrain bench launch;
- docs, wiki notes, and scratch log for decisions, validation, and open electrical items.

The old direct Jetson-to-Sabertooth bridge remains the default bench path.

## Validation

Local:

- `cmake --build build/teensy_motor_io && ctest --test-dir build/teensy_motor_io --output-on-failure`
- `PYTHONPATH=src/lunabot_drivetrain uv run --with pytest python -m pytest src/lunabot_drivetrain/test/test_teensy_protocol.py src/lunabot_drivetrain/test/test_teensy_serial.py -q`
- `uv run --with ruff ruff check ...` on the new Python files
- `python3 -m compileall` on the new Python files
- `git diff --check`

Jetson over SSH:

- `cmake -S firmware/teensy_motor_io -B build/teensy_motor_io && cmake --build build/teensy_motor_io && ctest --test-dir build/teensy_motor_io --output-on-failure`
- `PYTHONPATH=src/lunabot_drivetrain python3 -m pytest src/lunabot_drivetrain/test/test_teensy_protocol.py src/lunabot_drivetrain/test/test_teensy_serial.py -q`
- `colcon build --symlink-install --packages-select lunabot_interfaces lunabot_drivetrain`
- `colcon test --packages-select lunabot_drivetrain --event-handlers console_direct+` → 46 passed, 2 deprecation warnings
- fake Teensy ROS smoke test: single `teensy_drivetrain_bridge` node against fake PTY, `/drivetrain/status.state=1`, `/drivetrain/telemetry.controller_online=[True, True]`

## Electrical Follow-Ups

- Export/commit the Sabertooth DEScribe profile: Packet Serial with CRC, serial timeout, conservative ramping, and `<=10 A` per-channel soft current limit.
- Finalise and label the Teensy pin map once the harness is built.
- Resolve the UK Lunabotics 2026 v1.0 E-stop wording. Repo electrical notes currently keep compute live through E-stop, but the rulebook wording says E-stop isolates batteries from active subsystems.

Linear parent: INX-70.
