### PR TITLE
Add C++ legal LiDAR filter

### DIFF
--- a/docs/active_runtime_paths.md
+++ b/docs/active_runtime_paths.md
@@ -21,8 +21,9 @@ ros2 launch lunabot_bringup navigation.launch.py
 
 - `lunabot_bringup/localisation.launch.py`
 - `lunabot_bringup/nav2_navigation.launch.py`
-- optional `lunabot_localisation/legal_lidar_filter` and KISS-ICP when
-  `lidar_odometry_backend:=kiss_icp`
+- optional `lunabot_localisation_cpp/legal_lidar_filter_cpp` and KISS-ICP when
+  `lidar_odometry_backend:=kiss_icp`; pass
+  `legal_lidar_filter_impl:=python` only for the Python fallback
 - `lunabot_perception/arena_boundary_filter` for front/rear camera clouds and
   Ouster clouds
 - `lunabot_perception/crater_detection`
@@ -58,6 +59,10 @@ For a legal LiDAR-odometry rehearsal, pass
 `max_shuttle_cycles` to `2` or `3`.
 Use the `debug` evidence profile so `/localisation/lidar/points_legal`,
 `/localisation/lidar/odometry`, and filter diagnostics are recorded.
+
+On hardware, the Ouster driver publishes `os_sensor -> os_lidar`. When using a
+temporary static transform for filter-only tests, attach the test root to
+`os_sensor`, not `os_lidar`, so the legal filter can resolve a single TF tree.
 
 ## Mission Manager Only
 

--- a/src/lunabot_localisation/README.md
+++ b/src/lunabot_localisation/README.md
@@ -10,11 +10,15 @@ The localisation pipeline has two layers:
   selected legal LiDAR odometry source to produce a smooth
   `odom -> base_footprint` transform and `/odometry/local`.
 2. **Optional legal LiDAR odometry**: when
-  `lidar_odometry_backend:=kiss_icp`, `/ouster/points` is first filtered by
-  `legal_lidar_filter` into `/localisation/lidar/points_legal`. The filter
-  uses arena-frame bounds to reject wall/out-of-field points, but republishes
-  the surviving points in the original LiDAR frame and preserves the original
-  `PointCloud2` fields for odometry deskewing.
+  `lidar_odometry_backend:=kiss_icp` or `lidar_odometry_backend:=rko_lio`,
+  `/ouster/points` is first filtered into
+  `/localisation/lidar/points_legal`. The default implementation is the C++
+  `lunabot_localisation_cpp/legal_lidar_filter_cpp` hot path; the Python
+  `lunabot_localisation/legal_lidar_filter` node is kept as a fallback via
+  `legal_lidar_filter_impl:=python`. The filter uses arena-frame bounds to
+  reject wall/out-of-field points, but republishes the surviving records in the
+  original LiDAR frame and preserves the original `PointCloud2` fields for
+  odometry deskewing.
 3. **Optional RTAB-Map SLAM** (`rtabmap_slam`): when
   `enable_visual_slam:=true`, subscribes to RGB-D images from the front depth
   camera and `/odometry/local`. It publishes the `map -> odom` correction via
@@ -56,8 +60,10 @@ frame with the known tag position.
   testing before promotion.
 - `config/rtabmap.yaml`: RTAB-Map SLAM parameters.
 - `launch/localisation.launch.py`: localisation bring-up.
-- `lunabot_localisation/legal_lidar_filter.py`: field-preserving wall filter
-  for OS1 localisation input.
+- `../lunabot_localisation_cpp/`: default C++ field-preserving wall filter for
+  OS1 localisation input.
+- `lunabot_localisation/legal_lidar_filter.py`: Python fallback for the same
+  legal LiDAR filter contract.
 - `lunabot_localisation/tag_pose_publisher.py`: tag detection to pose bridge.
 - `lunabot_localisation/start_zone_localiser.py`: tag search and readiness gate.
 
@@ -71,6 +77,9 @@ frame with the known tag position.
   that will later be claimed as competition-legal.
 - LiDAR filters that rebuild a cloud as plain XYZ and accidentally drop Ouster
   fields such as timestamp, ring, intensity or reflectivity.
+- Test static TFs attached directly to `os_lidar` while the Ouster driver is
+  also publishing `os_sensor -> os_lidar`. For hardware probes, attach the test
+  root to `os_sensor` so TF remains a single tree.
 
 ## Related docs
 

--- a/src/lunabot_localisation/launch/localisation.launch.py
+++ b/src/lunabot_localisation/launch/localisation.launch.py
@@ -20,6 +20,7 @@ from launch_ros.substitutions import FindPackageShare
 TRUTHY_VALUES = ("1", "true", "yes", "on")
 FALSEY_VALUES = ("0", "false", "no", "off")
 LIDAR_ODOMETRY_BACKENDS = ("none", "kiss_icp", "rko_lio")
+LEGAL_LIDAR_FILTER_IMPLEMENTATIONS = ("cpp", "python")
 
 
 def _config_path(*parts: str) -> str:
@@ -110,6 +111,12 @@ def _validate_boolean_launch_arguments(context):
             "Expected lidar_odometry_backend to be one of "
             f"{LIDAR_ODOMETRY_BACKENDS}, got '{backend}'."
         )
+    filter_impl = LaunchConfiguration("legal_lidar_filter_impl").perform(context)
+    if filter_impl.strip().lower() not in LEGAL_LIDAR_FILTER_IMPLEMENTATIONS:
+        raise ValueError(
+            "Expected legal_lidar_filter_impl to be one of "
+            f"{LEGAL_LIDAR_FILTER_IMPLEMENTATIONS}, got '{filter_impl}'."
+        )
     return []
 
 
@@ -141,6 +148,7 @@ def generate_launch_description():
     legal_lidar_input_topic = LaunchConfiguration("legal_lidar_input_topic")
     legal_lidar_output_topic = LaunchConfiguration("legal_lidar_output_topic")
     legal_lidar_mask_frame = LaunchConfiguration("legal_lidar_mask_frame")
+    legal_lidar_filter_impl = LaunchConfiguration("legal_lidar_filter_impl")
     cmd_vel_topic = LaunchConfiguration("cmd_vel_topic")
     camera_info_topic = LaunchConfiguration("camera_info_topic")
     sync_sim_camera_info = LaunchConfiguration("sync_sim_camera_info")
@@ -177,12 +185,25 @@ def generate_launch_description():
             ]
         )
     )
-    lidar_filter_condition = IfCondition(
+    lidar_filter_cpp_condition = IfCondition(
         PythonExpression(
             [
                 "'",
                 lidar_odometry_backend,
-                "'.strip().lower() != 'none'",
+                "'.strip().lower() != 'none' and '",
+                legal_lidar_filter_impl,
+                "'.strip().lower() == 'cpp'",
+            ]
+        )
+    )
+    lidar_filter_python_condition = IfCondition(
+        PythonExpression(
+            [
+                "'",
+                lidar_odometry_backend,
+                "'.strip().lower() != 'none' and '",
+                legal_lidar_filter_impl,
+                "'.strip().lower() == 'python'",
             ]
         )
     )
@@ -243,6 +264,11 @@ def generate_launch_description():
                 description="Field-preserved, wall-excluded cloud for LiDAR odometry.",
             ),
             DeclareLaunchArgument(
+                "legal_lidar_filter_impl",
+                default_value="cpp",
+                description="Legal LiDAR filter implementation: cpp or python.",
+            ),
+            DeclareLaunchArgument(
                 "legal_lidar_mask_frame",
                 default_value="odom",
                 description="Arena frame used only for deciding legal point membership.",
@@ -290,7 +316,23 @@ def generate_launch_description():
                 description=("Configured map-frame yaw of the start-zone tag."),
             ),
             OpaqueFunction(function=_validate_boolean_launch_arguments),
-            # --- Legal LiDAR filter: preserves Ouster point fields for odometry ---
+            # --- Legal LiDAR filter: C++ hot path, Python fallback ---
+            Node(
+                package="lunabot_localisation_cpp",
+                executable="legal_lidar_filter_cpp",
+                name="legal_lidar_filter_ouster",
+                output="screen",
+                parameters=[
+                    {"use_sim_time": use_sim_time},
+                    {
+                        "input_topic": legal_lidar_input_topic,
+                        "output_topic": legal_lidar_output_topic,
+                        "source_name": "ouster",
+                        "mask_frame": legal_lidar_mask_frame,
+                    },
+                ],
+                condition=lidar_filter_cpp_condition,
+            ),
             Node(
                 package="lunabot_localisation",
                 executable="legal_lidar_filter",
@@ -305,7 +347,7 @@ def generate_launch_description():
                         "mask_frame": legal_lidar_mask_frame,
                     },
                 ],
-                condition=lidar_filter_condition,
+                condition=lidar_filter_python_condition,
             ),
             # --- KISS-ICP: first legal LiDAR odometry baseline ---
             Node(

--- a/src/lunabot_localisation/package.xml
+++ b/src/lunabot_localisation/package.xml
@@ -24,6 +24,7 @@
   <exec_depend>apriltag_draw</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>lunabot_interfaces</exec_depend>
+  <exec_depend>lunabot_localisation_cpp</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>rclpy</exec_depend>

--- a/src/lunabot_localisation/test/test_localisation_launch.py
+++ b/src/lunabot_localisation/test/test_localisation_launch.py
@@ -142,6 +142,7 @@ def test_validate_boolean_launch_arguments_rejects_invalid_launch_value():
     context.launch_configurations["enable_apriltag_debug"] = "false"
     context.launch_configurations["sync_sim_camera_info"] = "false"
     context.launch_configurations["lidar_odometry_backend"] = "none"
+    context.launch_configurations["legal_lidar_filter_impl"] = "cpp"
 
     with pytest.raises(ValueError, match="lidar_costmap_phase"):
         launch_module._validate_boolean_launch_arguments(context)
@@ -156,8 +157,24 @@ def test_validate_lidar_odometry_backend_rejects_unknown_backend():
     context.launch_configurations["enable_apriltag_debug"] = "false"
     context.launch_configurations["sync_sim_camera_info"] = "false"
     context.launch_configurations["lidar_odometry_backend"] = "magic"
+    context.launch_configurations["legal_lidar_filter_impl"] = "cpp"
 
     with pytest.raises(ValueError, match="lidar_odometry_backend"):
+        launch_module._validate_boolean_launch_arguments(context)
+
+
+def test_validate_legal_lidar_filter_impl_rejects_unknown_impl():
+    launch_module = _load_launch_module()
+    context = LaunchContext()
+    context.launch_configurations["lidar_costmap_phase"] = "false"
+    context.launch_configurations["enable_visual_slam"] = "false"
+    context.launch_configurations["use_sim_time"] = "true"
+    context.launch_configurations["enable_apriltag_debug"] = "false"
+    context.launch_configurations["sync_sim_camera_info"] = "false"
+    context.launch_configurations["lidar_odometry_backend"] = "kiss_icp"
+    context.launch_configurations["legal_lidar_filter_impl"] = "rust"
+
+    with pytest.raises(ValueError, match="legal_lidar_filter_impl"):
         launch_module._validate_boolean_launch_arguments(context)
 
 
@@ -197,7 +214,41 @@ def test_generate_launch_description_has_validation_and_sim_camera_info_aligner(
     assert len(validators) == 1
     assert len(tag_pose_publishers) == 1
     assert len(camera_info_aligners) == 1
-    assert len(legal_lidar_filters) == 1
+    assert len(legal_lidar_filters) == 2
+
+
+def test_legal_lidar_filter_launch_selector_has_exactly_one_active_filter(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    launch_module = _load_launch_module()
+    monkeypatch.setattr(
+        launch_module,
+        "get_package_share_directory",
+        lambda _package: "/tmp/lunabot_localisation",
+    )
+    description = launch_module.generate_launch_description()
+
+    filters = [
+        entity
+        for entity in description.entities
+        if isinstance(entity, Node)
+        and entity.__dict__.get("_Node__node_name") == "legal_lidar_filter_ouster"
+    ]
+    assert {
+        entity.__dict__.get("_Node__package")
+        for entity in filters
+    } == {"lunabot_localisation_cpp", "lunabot_localisation"}
+
+    conditions = {
+        entity.__dict__.get("_Node__package"): _condition_text(entity.condition)
+        for entity in filters
+    }
+    assert "legal_lidar_filter_impl" in conditions["lunabot_localisation_cpp"]
+    assert "== 'cpp'" in conditions["lunabot_localisation_cpp"]
+    assert "legal_lidar_filter_impl" in conditions["lunabot_localisation"]
+    assert "== 'python'" in conditions["lunabot_localisation"]
+    assert "!= 'none'" in conditions["lunabot_localisation_cpp"]
+    assert "!= 'none'" in conditions["lunabot_localisation"]
 
 
 def test_kiss_icp_uses_legal_lidar_topic_and_disables_tf(

--- a/src/lunabot_localisation_cpp/CMakeLists.txt
+++ b/src/lunabot_localisation_cpp/CMakeLists.txt
@@ -1,0 +1,99 @@
+cmake_minimum_required(VERSION 3.8)
+project(lunabot_localisation_cpp)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(diagnostic_updater REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+
+add_library(legal_lidar_filter_core
+  src/legal_lidar_filter_core.cpp
+)
+set_target_properties(legal_lidar_filter_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(legal_lidar_filter_core PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+ament_target_dependencies(legal_lidar_filter_core
+  sensor_msgs
+)
+
+add_library(legal_lidar_filter_component SHARED
+  src/legal_lidar_filter_node.cpp
+)
+target_include_directories(legal_lidar_filter_component PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+target_link_libraries(legal_lidar_filter_component
+  legal_lidar_filter_core
+)
+ament_target_dependencies(legal_lidar_filter_component
+  diagnostic_msgs
+  diagnostic_updater
+  geometry_msgs
+  rclcpp
+  rclcpp_components
+  sensor_msgs
+  tf2
+  tf2_ros
+)
+
+rclcpp_components_register_node(legal_lidar_filter_component
+  PLUGIN "lunabot_localisation_cpp::LegalLidarFilterNode"
+  EXECUTABLE legal_lidar_filter_cpp
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS legal_lidar_filter_core legal_lidar_filter_component
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_legal_lidar_filter_core
+    test/test_legal_lidar_filter_core.cpp
+  )
+  target_link_libraries(test_legal_lidar_filter_core
+    legal_lidar_filter_core
+  )
+  target_include_directories(test_legal_lidar_filter_core PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  )
+
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_include_directories(include)
+ament_export_dependencies(
+  diagnostic_msgs
+  diagnostic_updater
+  geometry_msgs
+  rclcpp
+  rclcpp_components
+  sensor_msgs
+  tf2
+  tf2_ros
+)
+ament_package()

--- a/src/lunabot_localisation_cpp/README.md
+++ b/src/lunabot_localisation_cpp/README.md
@@ -1,0 +1,31 @@
+# lunabot_localisation_cpp
+
+C++ localisation hot-path nodes for the rover stack.
+
+The first node in this package is `legal_lidar_filter_cpp`, a field-preserving
+filter for the Ouster OS1 localisation path. It subscribes to `/ouster/points`
+by default, tests each point against the legal arena interior in `mask_frame`,
+and republishes the surviving point records to
+`/localisation/lidar/points_legal`.
+
+The output cloud deliberately stays in the original LiDAR frame. The transform
+is used only to decide whether each point is inside the legal mask. Each kept
+record is copied byte-for-byte, so Ouster-native fields such as timestamp, ring,
+reflectivity, intensity and near-infrared data are still available to LiDAR
+odometry backends.
+
+`lunabot_localisation/launch/localisation.launch.py` selects this C++ node by
+default with `legal_lidar_filter_impl:=cpp`. Use
+`legal_lidar_filter_impl:=python` only as a fallback when diagnosing the C++
+path.
+
+## Hardware Notes
+
+The OS1 debug config currently publishes native 1024 x 32 clouds at about
+10 Hz with `point_step` 48 and BEST_EFFORT QoS. On the Jetson, the C++ filter
+has been smoke-tested against that live stream with `odom` statically attached
+to `os_sensor`; it processed 32768-point native clouds in about 18 ms.
+
+For quick hardware probes, do not publish a second static transform directly to
+`os_lidar`. The Ouster driver already publishes `os_sensor -> os_lidar`, so a
+test root should attach to `os_sensor` to avoid disconnected TF trees.

--- a/src/lunabot_localisation_cpp/include/lunabot_localisation_cpp/legal_lidar_filter_core.hpp
+++ b/src/lunabot_localisation_cpp/include/lunabot_localisation_cpp/legal_lidar_filter_core.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "sensor_msgs/msg/point_field.hpp"
+
+namespace lunabot_localisation_cpp
+{
+
+struct ArenaBounds
+{
+  double min_x{-1.0};
+  double max_x{6.9};
+  double min_y{-3.3};
+  double max_y{1.1};
+  double wall_exclusion_margin_m{0.35};
+
+  void validate() const;
+  double legal_min_x() const;
+  double legal_max_x() const;
+  double legal_min_y() const;
+  double legal_max_y() const;
+};
+
+struct RigidTransform
+{
+  std::array<double, 3> translation_xyz{0.0, 0.0, 0.0};
+  std::array<double, 4> quaternion_xyzw{0.0, 0.0, 0.0, 1.0};
+};
+
+struct LegalLidarFilterResult
+{
+  sensor_msgs::msg::PointCloud2 cloud;
+  std::size_t raw_count{0};
+  std::size_t finite_count{0};
+  std::size_t kept_count{0};
+  std::size_t rejected_count{0};
+
+  double reject_ratio() const;
+};
+
+LegalLidarFilterResult filter_cloud_to_legal_bounds(
+  const sensor_msgs::msg::PointCloud2 & cloud,
+  const ArenaBounds & bounds,
+  const RigidTransform & mask_from_cloud);
+
+}  // namespace lunabot_localisation_cpp

--- a/src/lunabot_localisation_cpp/include/lunabot_localisation_cpp/legal_lidar_filter_node.hpp
+++ b/src/lunabot_localisation_cpp/include/lunabot_localisation_cpp/legal_lidar_filter_node.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "diagnostic_updater/diagnostic_updater.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
+
+#include "lunabot_localisation_cpp/legal_lidar_filter_core.hpp"
+
+namespace lunabot_localisation_cpp
+{
+
+class LegalLidarFilterNode : public rclcpp::Node
+{
+public:
+  explicit LegalLidarFilterNode(const rclcpp::NodeOptions & options);
+
+private:
+  void cloud_callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
+  bool lookup_cloud_transform(
+    const sensor_msgs::msg::PointCloud2 & msg,
+    RigidTransform & transform);
+  void publish_diagnostics(diagnostic_updater::DiagnosticStatusWrapper & status);
+  ArenaBounds load_bounds() const;
+
+  std::string input_topic_;
+  std::string output_topic_;
+  std::string source_name_;
+  std::string mask_frame_;
+  double stale_timeout_s_{2.5};
+  double tf_lookup_timeout_s_{0.05};
+  bool allow_latest_tf_on_future_extrapolation_{false};
+  ArenaBounds bounds_;
+
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr cloud_sub_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr cloud_pub_;
+  diagnostic_updater::Updater diagnostics_;
+  rclcpp::TimerBase::SharedPtr diagnostic_timer_;
+
+  bool has_result_{false};
+  bool has_cloud_time_{false};
+  rclcpp::Time last_cloud_time_{0, 0, RCL_ROS_TIME};
+  std::string last_error_;
+  LegalLidarFilterResult last_result_;
+  std::size_t input_cloud_count_{0};
+  std::size_t output_cloud_count_{0};
+  std::size_t tf_failure_count_{0};
+  double last_processing_ms_{0.0};
+};
+
+}  // namespace lunabot_localisation_cpp

--- a/src/lunabot_localisation_cpp/package.xml
+++ b/src/lunabot_localisation_cpp/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>lunabot_localisation_cpp</name>
+  <version>0.1.0</version>
+  <description>C++ localisation hot-path nodes for Lunabot.</description>
+  <maintainer email="lunabotics@le.ac.uk">Leicester Lunabotics Team</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>diagnostic_updater</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/lunabot_localisation_cpp/src/legal_lidar_filter_core.cpp
+++ b/src/lunabot_localisation_cpp/src/legal_lidar_filter_core.cpp
@@ -1,0 +1,272 @@
+#include "lunabot_localisation_cpp/legal_lidar_filter_core.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+namespace lunabot_localisation_cpp
+{
+namespace
+{
+
+struct FieldView
+{
+  std::uint32_t offset{0};
+  std::uint8_t datatype{0};
+};
+
+struct PreparedTransform
+{
+  std::array<double, 3> translation{};
+  std::array<double, 9> rotation{};
+};
+
+bool host_is_bigendian()
+{
+  const std::uint16_t value = 0x0102;
+  return *reinterpret_cast<const std::uint8_t *>(&value) == 0x01;
+}
+
+std::size_t datatype_size(const std::uint8_t datatype)
+{
+  switch (datatype) {
+    case sensor_msgs::msg::PointField::INT8:
+    case sensor_msgs::msg::PointField::UINT8:
+      return 1;
+    case sensor_msgs::msg::PointField::INT16:
+    case sensor_msgs::msg::PointField::UINT16:
+      return 2;
+    case sensor_msgs::msg::PointField::INT32:
+    case sensor_msgs::msg::PointField::UINT32:
+    case sensor_msgs::msg::PointField::FLOAT32:
+      return 4;
+    case sensor_msgs::msg::PointField::FLOAT64:
+      return 8;
+    default:
+      throw std::invalid_argument("Unsupported PointCloud2 datatype " + std::to_string(datatype));
+  }
+}
+
+FieldView find_xyz_field(
+  const sensor_msgs::msg::PointCloud2 & cloud,
+  const std::string & name)
+{
+  const auto field_it = std::find_if(
+    cloud.fields.begin(),
+    cloud.fields.end(),
+    [&name](const sensor_msgs::msg::PointField & field) {
+      return field.name == name;
+    });
+
+  if (field_it == cloud.fields.end()) {
+    throw std::invalid_argument("PointCloud2 is missing required field '" + name + "'");
+  }
+  if (
+    field_it->datatype != sensor_msgs::msg::PointField::FLOAT32 &&
+    field_it->datatype != sensor_msgs::msg::PointField::FLOAT64)
+  {
+    throw std::invalid_argument("PointCloud2 field '" + name + "' must be FLOAT32 or FLOAT64");
+  }
+  if (field_it->count != 1) {
+    throw std::invalid_argument("PointCloud2 field '" + name + "' must have count 1");
+  }
+
+  const auto field_size = datatype_size(field_it->datatype);
+  if (static_cast<std::size_t>(field_it->offset) + field_size > cloud.point_step) {
+    throw std::invalid_argument("PointCloud2 field '" + name + "' exceeds point_step");
+  }
+
+  return FieldView{field_it->offset, field_it->datatype};
+}
+
+template<typename T>
+T read_scalar(const std::uint8_t * bytes, const bool data_is_bigendian)
+{
+  std::array<std::uint8_t, sizeof(T)> value_bytes{};
+  std::memcpy(value_bytes.data(), bytes, sizeof(T));
+  if (data_is_bigendian != host_is_bigendian()) {
+    std::reverse(value_bytes.begin(), value_bytes.end());
+  }
+
+  T value{};
+  std::memcpy(&value, value_bytes.data(), sizeof(T));
+  return value;
+}
+
+double read_coordinate(
+  const std::uint8_t * point_bytes,
+  const FieldView & field,
+  const bool data_is_bigendian)
+{
+  const auto * field_bytes = point_bytes + field.offset;
+  if (field.datatype == sensor_msgs::msg::PointField::FLOAT32) {
+    return static_cast<double>(read_scalar<float>(field_bytes, data_is_bigendian));
+  }
+  return read_scalar<double>(field_bytes, data_is_bigendian);
+}
+
+PreparedTransform prepare_transform(const RigidTransform & transform)
+{
+  auto x = transform.quaternion_xyzw[0];
+  auto y = transform.quaternion_xyzw[1];
+  auto z = transform.quaternion_xyzw[2];
+  auto w = transform.quaternion_xyzw[3];
+  const auto norm = std::sqrt((x * x) + (y * y) + (z * z) + (w * w));
+  if (norm == 0.0) {
+    throw std::invalid_argument("quaternion must be non-zero");
+  }
+
+  x /= norm;
+  y /= norm;
+  z /= norm;
+  w /= norm;
+
+  return PreparedTransform{
+    transform.translation_xyz,
+    {
+      1.0 - 2.0 * ((y * y) + (z * z)),
+      2.0 * ((x * y) - (z * w)),
+      2.0 * ((x * z) + (y * w)),
+      2.0 * ((x * y) + (z * w)),
+      1.0 - 2.0 * ((x * x) + (z * z)),
+      2.0 * ((y * z) - (x * w)),
+      2.0 * ((x * z) - (y * w)),
+      2.0 * ((y * z) + (x * w)),
+      1.0 - 2.0 * ((x * x) + (y * y)),
+    },
+  };
+}
+
+std::array<double, 3> transform_point(
+  const std::array<double, 3> & point,
+  const PreparedTransform & transform)
+{
+  const auto & r = transform.rotation;
+
+  return {
+    (r[0] * point[0]) + (r[1] * point[1]) + (r[2] * point[2]) + transform.translation[0],
+    (r[3] * point[0]) + (r[4] * point[1]) + (r[5] * point[2]) + transform.translation[1],
+    (r[6] * point[0]) + (r[7] * point[1]) + (r[8] * point[2]) + transform.translation[2],
+  };
+}
+
+bool inside_legal_bounds(const std::array<double, 3> & point, const ArenaBounds & bounds)
+{
+  return std::isfinite(point[0]) && std::isfinite(point[1]) && std::isfinite(point[2]) &&
+         point[0] >= bounds.legal_min_x() && point[0] <= bounds.legal_max_x() &&
+         point[1] >= bounds.legal_min_y() && point[1] <= bounds.legal_max_y();
+}
+
+}  // namespace
+
+void ArenaBounds::validate() const
+{
+  if (min_x >= max_x) {
+    throw std::invalid_argument("arena_min_x must be less than arena_max_x");
+  }
+  if (min_y >= max_y) {
+    throw std::invalid_argument("arena_min_y must be less than arena_max_y");
+  }
+  if (wall_exclusion_margin_m < 0.0) {
+    throw std::invalid_argument("wall_exclusion_margin_m must be >= 0");
+  }
+  if (2.0 * wall_exclusion_margin_m >= (max_x - min_x)) {
+    throw std::invalid_argument("wall_exclusion_margin_m removes all legal arena width");
+  }
+  if (2.0 * wall_exclusion_margin_m >= (max_y - min_y)) {
+    throw std::invalid_argument("wall_exclusion_margin_m removes all legal arena height");
+  }
+}
+
+double ArenaBounds::legal_min_x() const {return min_x + wall_exclusion_margin_m;}
+double ArenaBounds::legal_max_x() const {return max_x - wall_exclusion_margin_m;}
+double ArenaBounds::legal_min_y() const {return min_y + wall_exclusion_margin_m;}
+double ArenaBounds::legal_max_y() const {return max_y - wall_exclusion_margin_m;}
+
+double LegalLidarFilterResult::reject_ratio() const
+{
+  if (finite_count == 0) {
+    return 0.0;
+  }
+  return static_cast<double>(rejected_count) / static_cast<double>(finite_count);
+}
+
+LegalLidarFilterResult filter_cloud_to_legal_bounds(
+  const sensor_msgs::msg::PointCloud2 & cloud,
+  const ArenaBounds & bounds,
+  const RigidTransform & mask_from_cloud)
+{
+  bounds.validate();
+  if (cloud.point_step == 0) {
+    throw std::invalid_argument("PointCloud2 point_step must be > 0");
+  }
+
+  const auto row_point_bytes = static_cast<std::size_t>(cloud.width) * cloud.point_step;
+  if (cloud.row_step < row_point_bytes) {
+    throw std::invalid_argument("PointCloud2 row_step is smaller than width * point_step");
+  }
+
+  const auto required_bytes = static_cast<std::size_t>(cloud.row_step) * cloud.height;
+  if (cloud.data.size() < required_bytes) {
+    throw std::invalid_argument("PointCloud2 data is smaller than row_step * height");
+  }
+
+  const auto x_field = find_xyz_field(cloud, "x");
+  const auto y_field = find_xyz_field(cloud, "y");
+  const auto z_field = find_xyz_field(cloud, "z");
+  const auto transform = prepare_transform(mask_from_cloud);
+
+  LegalLidarFilterResult result;
+  result.raw_count = static_cast<std::size_t>(cloud.width) * cloud.height;
+  result.cloud.header = cloud.header;
+  result.cloud.fields = cloud.fields;
+  result.cloud.is_bigendian = cloud.is_bigendian;
+  result.cloud.point_step = cloud.point_step;
+  result.cloud.is_dense = true;
+  result.cloud.height = 1;
+  result.cloud.width = 0;
+  result.cloud.row_step = 0;
+  result.cloud.data.resize(result.raw_count * cloud.point_step);
+
+  std::size_t output_offset = 0;
+  const auto * input_data = cloud.data.data();
+  for (std::uint32_t row = 0; row < cloud.height; ++row) {
+    const auto row_offset = static_cast<std::size_t>(row) * cloud.row_step;
+    for (std::uint32_t col = 0; col < cloud.width; ++col) {
+      const auto point_offset = row_offset + (static_cast<std::size_t>(col) * cloud.point_step);
+      const auto * point_bytes = input_data + point_offset;
+      const std::array<double, 3> point = {
+        read_coordinate(point_bytes, x_field, cloud.is_bigendian),
+        read_coordinate(point_bytes, y_field, cloud.is_bigendian),
+        read_coordinate(point_bytes, z_field, cloud.is_bigendian),
+      };
+
+      if (
+        std::isfinite(point[0]) && std::isfinite(point[1]) &&
+        std::isfinite(point[2]))
+      {
+        ++result.finite_count;
+      }
+
+      const auto mask_point = transform_point(point, transform);
+      if (!inside_legal_bounds(mask_point, bounds)) {
+        continue;
+      }
+
+      std::memcpy(result.cloud.data.data() + output_offset, point_bytes, cloud.point_step);
+      output_offset += cloud.point_step;
+      ++result.kept_count;
+    }
+  }
+
+  result.rejected_count = result.finite_count - result.kept_count;
+  result.cloud.width = static_cast<std::uint32_t>(result.kept_count);
+  result.cloud.row_step = result.cloud.point_step * result.cloud.width;
+  result.cloud.data.resize(output_offset);
+  return result;
+}
+
+}  // namespace lunabot_localisation_cpp

--- a/src/lunabot_localisation_cpp/src/legal_lidar_filter_node.cpp
+++ b/src/lunabot_localisation_cpp/src/legal_lidar_filter_node.cpp
@@ -1,0 +1,268 @@
+#include "lunabot_localisation_cpp/legal_lidar_filter_node.hpp"
+
+#include <chrono>
+#include <exception>
+#include <string>
+
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+#include "tf2/exceptions.h"
+
+namespace lunabot_localisation_cpp
+{
+namespace
+{
+
+using Clock = std::chrono::steady_clock;
+
+RigidTransform transform_from_msg(const geometry_msgs::msg::TransformStamped & transform)
+{
+  const auto & translation = transform.transform.translation;
+  const auto & rotation = transform.transform.rotation;
+  return RigidTransform{
+    {translation.x, translation.y, translation.z},
+    {rotation.x, rotation.y, rotation.z, rotation.w},
+  };
+}
+
+}  // namespace
+
+LegalLidarFilterNode::LegalLidarFilterNode(const rclcpp::NodeOptions & options)
+: rclcpp::Node("legal_lidar_filter", options),
+  diagnostics_(this)
+{
+  declare_parameter<std::string>("input_topic", "/ouster/points");
+  declare_parameter<std::string>("output_topic", "/localisation/lidar/points_legal");
+  declare_parameter<std::string>("source_name", "ouster");
+  declare_parameter<std::string>("mask_frame", "odom");
+  declare_parameter<double>("arena_min_x", -1.0);
+  declare_parameter<double>("arena_max_x", 6.9);
+  declare_parameter<double>("arena_min_y", -3.3);
+  declare_parameter<double>("arena_max_y", 1.1);
+  declare_parameter<double>("wall_exclusion_margin_m", 0.35);
+  declare_parameter<double>("diagnostic_publish_hz", 1.0);
+  declare_parameter<double>("stale_timeout_s", 2.5);
+  declare_parameter<double>("tf_lookup_timeout_s", 0.05);
+  declare_parameter<bool>("allow_latest_tf_on_future_extrapolation", false);
+
+  input_topic_ = get_parameter("input_topic").as_string();
+  output_topic_ = get_parameter("output_topic").as_string();
+  source_name_ = get_parameter("source_name").as_string();
+  mask_frame_ = get_parameter("mask_frame").as_string();
+  stale_timeout_s_ = get_parameter("stale_timeout_s").as_double();
+  tf_lookup_timeout_s_ = get_parameter("tf_lookup_timeout_s").as_double();
+  allow_latest_tf_on_future_extrapolation_ =
+    get_parameter("allow_latest_tf_on_future_extrapolation").as_bool();
+  const auto diagnostic_publish_hz = get_parameter("diagnostic_publish_hz").as_double();
+  bounds_ = load_bounds();
+
+  if (diagnostic_publish_hz <= 0.0) {
+    throw std::invalid_argument("diagnostic_publish_hz must be > 0");
+  }
+  if (stale_timeout_s_ <= 0.0) {
+    throw std::invalid_argument("stale_timeout_s must be > 0");
+  }
+  if (tf_lookup_timeout_s_ < 0.0) {
+    throw std::invalid_argument("tf_lookup_timeout_s must be >= 0");
+  }
+
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+  cloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
+    output_topic_,
+    rclcpp::SensorDataQoS());
+  cloud_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+    input_topic_,
+    rclcpp::SensorDataQoS(),
+    [this](const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg) {
+      cloud_callback(msg);
+    });
+
+  diagnostics_.setHardwareID(source_name_);
+  diagnostics_.add(
+    "legal_lidar_filter",
+    this,
+    &LegalLidarFilterNode::publish_diagnostics);
+  diagnostic_timer_ = create_wall_timer(
+    std::chrono::duration<double>(1.0 / diagnostic_publish_hz),
+    [this]() {
+      diagnostics_.force_update();
+    });
+
+  RCLCPP_INFO(
+    get_logger(),
+    "Legal LiDAR C++ filter %s: %s -> %s; mask in %s; output frame stays sensor-native",
+    source_name_.c_str(),
+    input_topic_.c_str(),
+    output_topic_.c_str(),
+    mask_frame_.c_str());
+}
+
+ArenaBounds LegalLidarFilterNode::load_bounds() const
+{
+  ArenaBounds bounds{
+    get_parameter("arena_min_x").as_double(),
+    get_parameter("arena_max_x").as_double(),
+    get_parameter("arena_min_y").as_double(),
+    get_parameter("arena_max_y").as_double(),
+    get_parameter("wall_exclusion_margin_m").as_double(),
+  };
+  bounds.validate();
+  return bounds;
+}
+
+void LegalLidarFilterNode::cloud_callback(
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
+{
+  ++input_cloud_count_;
+
+  RigidTransform mask_from_cloud;
+  if (!lookup_cloud_transform(*msg, mask_from_cloud)) {
+    return;
+  }
+
+  const auto started_at = Clock::now();
+  try {
+    auto result = filter_cloud_to_legal_bounds(*msg, bounds_, mask_from_cloud);
+    last_processing_ms_ =
+      std::chrono::duration<double, std::milli>(Clock::now() - started_at).count();
+    cloud_pub_->publish(result.cloud);
+    last_result_ = std::move(result);
+    has_result_ = true;
+    has_cloud_time_ = true;
+    last_cloud_time_ = now();
+    last_error_.clear();
+    ++output_cloud_count_;
+  } catch (const std::exception & error) {
+    last_error_ = error.what();
+    RCLCPP_WARN_THROTTLE(
+      get_logger(),
+      *get_clock(),
+      5000,
+      "Failed to filter legal LiDAR cloud: %s",
+      error.what());
+  }
+}
+
+bool LegalLidarFilterNode::lookup_cloud_transform(
+  const sensor_msgs::msg::PointCloud2 & msg,
+  RigidTransform & transform)
+{
+  try {
+    transform = transform_from_msg(
+      tf_buffer_->lookupTransform(
+        mask_frame_,
+        msg.header.frame_id,
+        msg.header.stamp,
+        rclcpp::Duration::from_seconds(tf_lookup_timeout_s_)));
+    return true;
+  } catch (const tf2::ExtrapolationException & error) {
+    if (!allow_latest_tf_on_future_extrapolation_) {
+      last_error_ = error.what();
+      ++tf_failure_count_;
+      RCLCPP_WARN_THROTTLE(
+        get_logger(),
+        *get_clock(),
+        5000,
+        "TF lookup %s -> %s failed; dropping cloud: %s",
+        msg.header.frame_id.c_str(),
+        mask_frame_.c_str(),
+        error.what());
+      return false;
+    }
+    try {
+      transform = transform_from_msg(
+        tf_buffer_->lookupTransform(
+          mask_frame_,
+          msg.header.frame_id,
+          rclcpp::Time(0, 0, get_clock()->get_clock_type()),
+          rclcpp::Duration::from_seconds(tf_lookup_timeout_s_)));
+      RCLCPP_WARN_THROTTLE(
+        get_logger(),
+        *get_clock(),
+        5000,
+        "TF lookup %s -> %s needed extrapolation; using latest available transform: %s",
+        msg.header.frame_id.c_str(),
+        mask_frame_.c_str(),
+        error.what());
+      return true;
+    } catch (const tf2::TransformException & latest_error) {
+      last_error_ = latest_error.what();
+      ++tf_failure_count_;
+      RCLCPP_WARN_THROTTLE(
+        get_logger(),
+        *get_clock(),
+        5000,
+        "Latest TF lookup %s -> %s failed; dropping cloud: %s",
+        msg.header.frame_id.c_str(),
+        mask_frame_.c_str(),
+        latest_error.what());
+      return false;
+    }
+  } catch (const tf2::TransformException & error) {
+    last_error_ = error.what();
+    ++tf_failure_count_;
+    RCLCPP_WARN_THROTTLE(
+      get_logger(),
+      *get_clock(),
+      5000,
+      "TF lookup %s -> %s failed; dropping cloud: %s",
+      msg.header.frame_id.c_str(),
+      mask_frame_.c_str(),
+      error.what());
+    return false;
+  }
+}
+
+void LegalLidarFilterNode::publish_diagnostics(
+  diagnostic_updater::DiagnosticStatusWrapper & status)
+{
+  double age_s = -1.0;
+  if (!has_result_ || !has_cloud_time_) {
+    status.summary(
+      diagnostic_msgs::msg::DiagnosticStatus::STALE,
+      "No legal LiDAR cloud published yet");
+  } else {
+    age_s = (now() - last_cloud_time_).seconds();
+    if (age_s > stale_timeout_s_) {
+      status.summary(
+        diagnostic_msgs::msg::DiagnosticStatus::STALE,
+        "No fresh legal LiDAR cloud");
+    } else if (!last_error_.empty()) {
+      status.summary(
+        diagnostic_msgs::msg::DiagnosticStatus::WARN,
+        "Legal LiDAR filtering warning");
+    } else {
+      status.summary(
+        diagnostic_msgs::msg::DiagnosticStatus::OK,
+        "Filtering LiDAR wall/out-of-field points");
+    }
+  }
+
+  status.add("input_topic", input_topic_);
+  status.add("output_topic", output_topic_);
+  status.add("mask_frame", mask_frame_);
+  status.add("source_name", source_name_);
+  status.add("raw_count", static_cast<int>(last_result_.raw_count));
+  status.add("finite_count", static_cast<int>(last_result_.finite_count));
+  status.add("kept_count", static_cast<int>(last_result_.kept_count));
+  status.add("rejected_count", static_cast<int>(last_result_.rejected_count));
+  status.add("reject_ratio", last_result_.reject_ratio());
+  status.add("last_cloud_age_s", age_s);
+  status.add("last_processing_ms", last_processing_ms_);
+  status.add("input_cloud_count", static_cast<int>(input_cloud_count_));
+  status.add("output_cloud_count", static_cast<int>(output_cloud_count_));
+  status.add("tf_failure_count", static_cast<int>(tf_failure_count_));
+  status.add("legal_min_x", bounds_.legal_min_x());
+  status.add("legal_max_x", bounds_.legal_max_x());
+  status.add("legal_min_y", bounds_.legal_min_y());
+  status.add("legal_max_y", bounds_.legal_max_y());
+  status.add("wall_exclusion_margin_m", bounds_.wall_exclusion_margin_m);
+  status.add("last_error", last_error_);
+}
+
+}  // namespace lunabot_localisation_cpp
+
+RCLCPP_COMPONENTS_REGISTER_NODE(lunabot_localisation_cpp::LegalLidarFilterNode)

--- a/src/lunabot_localisation_cpp/test/test_legal_lidar_filter_core.cpp
+++ b/src/lunabot_localisation_cpp/test/test_legal_lidar_filter_core.cpp
@@ -1,0 +1,202 @@
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "lunabot_localisation_cpp/legal_lidar_filter_core.hpp"
+
+namespace
+{
+
+using lunabot_localisation_cpp::ArenaBounds;
+using lunabot_localisation_cpp::RigidTransform;
+using sensor_msgs::msg::PointCloud2;
+using sensor_msgs::msg::PointField;
+
+PointField field(
+  const std::string & name,
+  const std::uint32_t offset,
+  const std::uint8_t datatype,
+  const std::uint32_t count = 1)
+{
+  PointField point_field;
+  point_field.name = name;
+  point_field.offset = offset;
+  point_field.datatype = datatype;
+  point_field.count = count;
+  return point_field;
+}
+
+bool host_is_bigendian()
+{
+  const std::uint16_t value = 0x0102;
+  return *reinterpret_cast<const std::uint8_t *>(&value) == 0x01;
+}
+
+template<typename T>
+void write_scalar(std::vector<std::uint8_t> & data, std::size_t offset, T value, bool bigendian)
+{
+  std::array<std::uint8_t, sizeof(T)> bytes{};
+  std::memcpy(bytes.data(), &value, sizeof(T));
+  if (bigendian != host_is_bigendian()) {
+    std::reverse(bytes.begin(), bytes.end());
+  }
+  std::memcpy(data.data() + offset, bytes.data(), sizeof(T));
+}
+
+PointCloud2 make_cloud(
+  const std::uint32_t width,
+  const std::uint32_t height,
+  const std::uint32_t point_step,
+  const std::uint32_t row_padding,
+  const bool bigendian = false)
+{
+  PointCloud2 cloud;
+  cloud.header.frame_id = "os_lidar";
+  cloud.height = height;
+  cloud.width = width;
+  cloud.fields = {
+    field("y", 0, PointField::FLOAT32),
+    field("x", 4, PointField::FLOAT32),
+    field("z", 8, PointField::FLOAT32),
+    field("intensity", 12, PointField::FLOAT32),
+    field("t", 16, PointField::UINT32),
+    field("ring", 20, PointField::UINT16),
+  };
+  cloud.is_bigendian = bigendian;
+  cloud.point_step = point_step;
+  cloud.row_step = (width * point_step) + row_padding;
+  cloud.is_dense = false;
+  cloud.data.assign(static_cast<std::size_t>(cloud.row_step) * height, 0xA5);
+  return cloud;
+}
+
+void write_point(
+  PointCloud2 & cloud,
+  const std::uint32_t row,
+  const std::uint32_t col,
+  const float x,
+  const float y,
+  const float z,
+  const float intensity,
+  const std::uint32_t t,
+  const std::uint16_t ring)
+{
+  const auto offset = static_cast<std::size_t>(row) * cloud.row_step +
+    static_cast<std::size_t>(col) * cloud.point_step;
+  write_scalar(cloud.data, offset + 0, y, cloud.is_bigendian);
+  write_scalar(cloud.data, offset + 4, x, cloud.is_bigendian);
+  write_scalar(cloud.data, offset + 8, z, cloud.is_bigendian);
+  write_scalar(cloud.data, offset + 12, intensity, cloud.is_bigendian);
+  write_scalar(cloud.data, offset + 16, t, cloud.is_bigendian);
+  write_scalar(cloud.data, offset + 20, ring, cloud.is_bigendian);
+}
+
+std::vector<std::uint8_t> point_record(
+  const PointCloud2 & cloud,
+  const std::uint32_t row,
+  const std::uint32_t col)
+{
+  const auto offset = static_cast<std::size_t>(row) * cloud.row_step +
+    static_cast<std::size_t>(col) * cloud.point_step;
+  return {
+    cloud.data.begin() + static_cast<std::ptrdiff_t>(offset),
+    cloud.data.begin() + static_cast<std::ptrdiff_t>(offset + cloud.point_step),
+  };
+}
+
+}  // namespace
+
+TEST(LegalLidarFilterCore, PreservesKeptPointBytesAndHandlesRowPadding)
+{
+  auto cloud = make_cloud(3, 2, 24, 8);
+  write_point(cloud, 0, 0, -0.9F, 0.0F, 0.2F, 10.0F, 1000, 1);
+  write_point(cloud, 0, 1, 8.0F, 0.0F, 0.2F, 11.0F, 1001, 2);
+  write_point(cloud, 0, 2, NAN, 0.0F, 0.2F, 12.0F, 1002, 3);
+  write_point(cloud, 1, 0, 0.0F, 0.0F, 0.2F, 13.0F, 1003, 4);
+  write_point(cloud, 1, 1, 0.5F, -3.2F, 0.2F, 14.0F, 1004, 5);
+  write_point(cloud, 1, 2, 6.0F, 0.0F, 0.2F, 15.0F, 1005, 6);
+  const auto expected_first = point_record(cloud, 1, 0);
+  const auto expected_second = point_record(cloud, 1, 2);
+
+  const auto result = lunabot_localisation_cpp::filter_cloud_to_legal_bounds(
+    cloud,
+    ArenaBounds{},
+    RigidTransform{});
+
+  EXPECT_EQ(result.raw_count, 6U);
+  EXPECT_EQ(result.finite_count, 5U);
+  EXPECT_EQ(result.kept_count, 2U);
+  EXPECT_EQ(result.rejected_count, 3U);
+  EXPECT_EQ(result.cloud.header.frame_id, "os_lidar");
+  EXPECT_TRUE(result.cloud.is_dense);
+  EXPECT_EQ(result.cloud.height, 1U);
+  EXPECT_EQ(result.cloud.width, 2U);
+  EXPECT_EQ(result.cloud.row_step, result.cloud.point_step * result.cloud.width);
+  ASSERT_EQ(result.cloud.data.size(), 2U * cloud.point_step);
+  EXPECT_TRUE(std::equal(expected_first.begin(), expected_first.end(), result.cloud.data.begin()));
+  EXPECT_TRUE(
+    std::equal(
+      expected_second.begin(),
+      expected_second.end(),
+      result.cloud.data.begin() + cloud.point_step));
+}
+
+TEST(LegalLidarFilterCore, UsesTransformForMembershipWithoutRewritingPointBytes)
+{
+  auto cloud = make_cloud(1, 1, 24, 0);
+  write_point(cloud, 0, 0, 0.0F, 0.0F, 0.2F, 20.0F, 2000, 7);
+  const auto expected = point_record(cloud, 0, 0);
+
+  const auto result = lunabot_localisation_cpp::filter_cloud_to_legal_bounds(
+    cloud,
+    ArenaBounds{0.0, 2.0, 0.0, 2.0, 0.35},
+    RigidTransform{{0.5, 0.5, 0.0}, {0.0, 0.0, 0.0, 1.0}});
+
+  EXPECT_EQ(result.kept_count, 1U);
+  EXPECT_TRUE(std::equal(expected.begin(), expected.end(), result.cloud.data.begin()));
+}
+
+TEST(LegalLidarFilterCore, ReadsBigEndianFloatFields)
+{
+  auto cloud = make_cloud(1, 1, 24, 0, true);
+  write_point(cloud, 0, 0, 0.0F, 0.0F, 0.2F, 30.0F, 3000, 8);
+
+  const auto result = lunabot_localisation_cpp::filter_cloud_to_legal_bounds(
+    cloud,
+    ArenaBounds{},
+    RigidTransform{});
+
+  EXPECT_EQ(result.kept_count, 1U);
+  EXPECT_EQ(result.cloud.is_bigendian, true);
+}
+
+TEST(LegalLidarFilterCore, RejectsMissingOrInvalidXyzFieldsLoudly)
+{
+  auto cloud = make_cloud(1, 1, 24, 0);
+  cloud.fields[1].datatype = PointField::UINT32;
+
+  EXPECT_THROW(
+    lunabot_localisation_cpp::filter_cloud_to_legal_bounds(
+      cloud,
+      ArenaBounds{},
+      RigidTransform{}),
+    std::invalid_argument);
+}
+
+TEST(LegalLidarFilterCore, RejectsMalformedRowStep)
+{
+  auto cloud = make_cloud(2, 1, 24, 0);
+  cloud.row_step = 12;
+
+  EXPECT_THROW(
+    lunabot_localisation_cpp::filter_cloud_to_legal_bounds(
+      cloud,
+      ArenaBounds{},
+      RigidTransform{}),
+    std::invalid_argument);
+}


### PR DESCRIPTION
## Summary

- Adds `lunabot_localisation_cpp`, an `ament_cmake` package with a C++ `legal_lidar_filter_cpp` node and reusable core filter.
- Makes the C++ implementation the default legal LiDAR filter when LiDAR odometry is enabled, with `legal_lidar_filter_impl:=python` retained as a fallback.
- Preserves Ouster-native `PointCloud2` records byte-for-byte for kept points while using TF only for legal arena membership checks.
- Updates launch tests and docs for the C++ default, Python fallback, and the Ouster `os_sensor -> os_lidar` TF root.

## Research / design notes

Implementation was guided by ROS 2 Humble docs for `sensor_msgs/PointCloud2`, `tf2_ros::Buffer::lookupTransform`, rclcpp composition, `diagnostic_updater`, and C++ GTest. The main design choices were:

- Avoid PCL conversion in the hot path so Ouster timestamp/ring/reflectivity/intensity/NIR fields survive for odometry deskewing.
- Validate `point_step`, `row_step`, `row_step * height`, and required `x/y/z` field layout before reading bytes.
- Handle row padding, organised clouds, FLOAT32/FLOAT64 XYZ, and endianness.
- Do one bounded TF lookup per cloud, then prepare the rotation matrix once per callback.
- Keep output in the original LiDAR frame; transform only decides legal membership.
- Publish diagnostics for counts, reject ratio, TF failures, timing, and stale output.

## Review fixes

A repo-specific review pass found install/export risks. Fixed before PR:

- Corrected installed header layout from the double-nested symlink path to normal `include/lunabot_localisation_cpp/...`.
- Exported include directories and all dependencies needed by installed targets.
- Confirmed `rclcpp_components_register_node(... EXECUTABLE legal_lidar_filter_cpp)` installs a discoverable executable on Humble.
- Matched the Python fallback metadata contract by setting filtered output `is_dense=true` after rejecting non-finite XYZ.

## Jetson verification

Ran on `innex1-jetson` with the real OS1-128 reachable over the router.

- Clean package rebuild after removing stale `build/lunabot_localisation_cpp` and `install/lunabot_localisation_cpp`:
  - `colcon build --packages-select lunabot_localisation_cpp lunabot_localisation --symlink-install --event-handlers console_direct+`
- Install/discovery checks:
  - `ros2 pkg executables lunabot_localisation_cpp` lists `legal_lidar_filter_cpp`
  - executable exists at `install/lunabot_localisation_cpp/lib/lunabot_localisation_cpp/legal_lidar_filter_cpp`
  - header exists at `install/lunabot_localisation_cpp/include/lunabot_localisation_cpp/legal_lidar_filter_core.hpp`
- Tests:
  - `colcon test --packages-select lunabot_localisation_cpp lunabot_localisation --event-handlers console_direct+`
  - `lunabot_localisation_cpp`: 5/5 tests passed
  - `lunabot_localisation`: 51 passed, 1 skipped
- Live Ouster smoke:
  - `/ouster/points`: 1024 x 32, `point_step` 48, ~9-10 Hz, BEST_EFFORT
  - C++ filter received/published real native clouds with `odom` temporarily attached to `os_sensor`
  - latest smoke received 69 filtered clouds in 8 s
  - example output: width 25859, height 1, `point_step` 48, 1,241,232 bytes, `is_dense=True`
  - diagnostics: raw_count 32768, kept_count around 25800-25900, `last_processing_ms` around 17.9-19.7 ms, input/output counts matched, TF failures 0

## Local checks

- `uv run --with-requirements .github/requirements-preflight.txt python .github/scripts/run_quality_checks.py --mode blocking`
- `uvx --with pyyaml python .github/scripts/run_preflight_checks.py`
- `python3 .github/scripts/check_interface_contracts.py`

## Operational note

For hardware-only filter probes, attach temporary static TF to `os_sensor`, not `os_lidar`. The Ouster driver already publishes `os_sensor -> os_lidar`; attaching a second root directly to `os_lidar` creates disconnected TF trees and the filter correctly drops clouds.

Closes INX-77.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a new C++ legal LiDAR filter implementation (`lunabot_localisation_cpp/legal_lidar_filter_cpp`) as the default filtering node when LiDAR odometry is enabled. The C++ implementation is optimized for performance by preserving Ouster-native PointCloud2 data byte-for-byte for retained points and avoiding PCL conversion in the hot path.

## Key Changes

**New Package and Implementation**
- Added `lunabot_localisation_cpp` package providing:
  - `legal_lidar_filter_cpp` ROS 2 component node (C++ implementation)
  - Core filtering library with arena bounds validation and point filtering logic
  - Configurable arena bounds, TF-based membership evaluation, and diagnostic metrics (counts, reject ratio, timing, TF failures)

**Launch Configuration**
- Updated `localisation.launch.py` to introduce `legal_lidar_filter_impl` launch argument (default: `cpp`)
- Launch configuration now conditionally starts either the C++ filter or falls back to the existing Python `legal_lidar_filter` node via `legal_lidar_filter_impl:=python`
- Added validation to whitelist allowed filter implementations

**Documentation and Testing**
- Updated `src/lunabot_localisation/README.md` to document the C++ default and Python fallback, plus clarified TF tree setup for filter-only testing
- Updated `docs/active_runtime_paths.md` with recommended parameters for `kiss_icp` backend setup
- Extended launch tests to validate the new `legal_lidar_filter_impl` parameter and verify exactly one filter implementation is active at a time
- Added GTest suite for core filter functionality (point cloud layout validation, endianness handling, bounds membership)

**Dependencies**
- Added `lunabot_localisation_cpp` as a runtime dependency of `lunabot_localisation`

## Backward Compatibility

The Python `legal_lidar_filter` node remains available via `legal_lidar_filter_impl:=python`, maintaining existing behavior for users who prefer the Python implementation.

## Verification

Built and tested on innex1-jetson with real OS1-128 hardware; all launch tests passed (51 passed, 1 skipped) and live Ouster smoke tests validated diagnostics reporting. Closes INX-77.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KJdotIO/innex1-rover/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->