### PR TITLE
Document local robotics skill usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,16 @@ Treat these as important local sources of truth:
 - the GitHub wiki when it is checked out at `wiki/`
 
 When a change touches a ROS interface, TF frame, action, topic, launch file, parameter file, hardware bridge or simulation bridge, check the relevant local contract and docs before recommending a fix.
+
+## Local Robotics Skills
+
+If local robotics skills are available, use the relevant skill before planning or editing. These skills are not vendored into the repo, so treat them as optional help rather than a hard dependency.
+
+- Use `ros2-development` for ROS 2 Humble nodes, launch files, parameters, QoS, actions, lifecycle nodes, Nav2, DDS, `colcon`, `ament`, `package.xml`, `setup.py`, `CMakeLists.txt`, rosdep and workspace overlay work.
+- Use `robotics-design-patterns` for rover architecture, behaviour trees or state machines, watchdogs, heartbeats, fail-closed behaviour, graceful degradation, hardware abstraction layers and sim-to-real decisions.
+- Use `robotics-software-principles` for robotics code reviews, module boundaries, hardware interfaces, dependency direction, configuration management, error handling and refactors that could affect robot behaviour.
+- Use `robotics-testing` for unit tests, launch tests, integration tests, mock hardware, deterministic replay, CI checks, hardware-in-the-loop plans and regression tests for safety or runtime behaviour.
+- Use `robot-perception` for OAK-D, camera calibration, depth topics, AprilTags, Ouster/LiDAR, point clouds, TF/extrinsics, sensor timing, perception latency and sensor bring-up.
+- Use `robotics-security` for SSH, router/network hardening, secrets, certificates, Docker/devcontainer security, ROS 2/DDS security, E-stop security and competition network exposure.
+
+If a skill is unavailable, continue with the repo docs and say that the local skill was not available. Do not invent skill output.

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ The workflow is documented in
 For first-motion, ground-control, comms and evidence-capture procedure on the
 Jetson, use [`docs/hardware_week_runbook.md`](docs/hardware_week_runbook.md).
 
-For remote support after the lab handoff, use
-[`docs/remote_competition_handoff.md`](docs/remote_competition_handoff.md).
+For remote support before competition, use
+[`docs/competition_remote_support.md`](docs/competition_remote_support.md).
 
 ## Active runtime paths
 
@@ -164,7 +164,7 @@ and operator telemetry.
 
 ## Doctor and Docker
 
-Run the doctor before setup, handoff, or hardware work:
+Run the doctor before setup, competition readiness, or hardware work:
 
 ```bash
 python3 tools/doctor.py --profile developer
@@ -233,8 +233,8 @@ If you rename a topic, action, or TF link, update the contract JSON in the same 
 - Operations: https://github.com/KJdotIO/innex1-rover/wiki/Operations
 - Contracts: https://github.com/KJdotIO/innex1-rover/wiki/Contracts
 - Local inspection packet: [docs/competition_inspection_packet.md](docs/competition_inspection_packet.md)
-- Remote competition handoff: [docs/remote_competition_handoff.md](docs/remote_competition_handoff.md)
-- Agent handoff: [docs/agent_handoff.md](docs/agent_handoff.md)
+- Competition remote support: [docs/competition_remote_support.md](docs/competition_remote_support.md)
+- Remote support workflow: [docs/remote_support_workflow.md](docs/remote_support_workflow.md)
 - Docker workflow: [docs/docker_workflow.md](docs/docker_workflow.md)
 
 ## Contributing and licence

--- a/docs/competition_remote_support.md
+++ b/docs/competition_remote_support.md
@@ -1,8 +1,8 @@
-# Remote Competition Handoff
+# Competition Remote Support
 
-This is the short handoff for the period after the main software lead leaves the
-lab. The target is to have the rover ready for competition use by 2026-06-15,
-with the competition on 2026-06-16 and 2026-06-17.
+Use this for the remote support period before competition. The target is to have
+the rover ready for competition use by 2026-06-15, with the competition on
+2026-06-16 and 2026-06-17.
 
 Assume the Friday 2026-05-29 lab checklist was not completed unless there is
 fresh evidence in Linear, a dated note, a rosbag, or a commit that says it was.
@@ -30,7 +30,7 @@ Can it be done with the repo, Linear, GitHub, simulation, or a shell on the Jets
 Do not commit passwords, private keys, Tailscale auth keys, or router admin
 credentials to this repo.
 
-Keep the actual values in the team's private handoff channel:
+Keep the actual values in the team's private channel:
 
 ```text
 Jetson SSH user:
@@ -235,15 +235,15 @@ Use a 2026-06-15 milestone with these tracks:
 - OAK-D and AprilTag validation;
 - Ouster mounting, TF and legal LiDAR path;
 - power telemetry and inspection evidence;
-- final docs, agent guidance, and runbook rehearsal.
+- final docs, review guidance, and runbook rehearsal.
 
 Every ticket should say whether it is remote-friendly or lab-required. If a
 ticket needs hands in the lab, name the physical action in the first paragraph.
 
-## Agent Use
+## Coding Assistance
 
-Agents are useful here, but only when they are given the rover's real constraints.
-Point them at:
+Coding assistants are useful here only when they are given the rover's real
+constraints. Start with:
 
 - `AGENTS.md`;
 - `README.md`;
@@ -254,6 +254,6 @@ Point them at:
 - package READMEs under `src/*/README.md`;
 - any checked-out wiki pages, if present.
 
-Before accepting an agent change that touches topics, TF, launch files, hardware
+Before accepting a change that touches topics, TF, launch files, hardware
 bridges, safety, power, or operator command paths, check the contracts, run the
 relevant tests, and make sure the change fails closed on real hardware.

--- a/docs/docker_workflow.md
+++ b/docs/docker_workflow.md
@@ -62,5 +62,5 @@ the image changes only when the environment changes.
 Docker does not replace the Jetson, the router, sensor USB/Ethernet checks,
 E-stop wiring, motor direction checks, fuse checks or any real motion test.
 
-Use it for repo work, agent handoff, cheap tests and consistent contributor
+Use it for repo work, remote support, cheap tests and consistent contributor
 setup. Use the actual rover for hardware truth.

--- a/docs/hardware/software-team-notes.md
+++ b/docs/hardware/software-team-notes.md
@@ -1,5 +1,5 @@
 # INNEX-1 Software Team Notes
-*Electrical team handoff — hardware constraints and configuration requirements*
+*Electrical hardware constraints and configuration requirements*
 
 ---
 
@@ -270,6 +270,6 @@ device.setIrFloodLightIntensity(0.0)          # 0.0 = off (default)
 
 | Date | Author | Change |
 |------|--------|--------|
-| 2026-05-23 | eniomecaj | Initial handoff document |
+| 2026-05-23 | eniomecaj | Initial hardware notes |
 | 2026-05-23 | eniomecaj | Clarified Sabertooth current limit to ≤ 10 A/channel; added fuse safety dependency note; updated TODO to required action with wiring safety context |
 | 2026-05-23 | eniomecaj | Fixed network topology: OS1 connects via router, not direct to Jetson (Jetson has one Ethernet port); corrected router band to 2.4 GHz |

--- a/docs/remote_support_workflow.md
+++ b/docs/remote_support_workflow.md
@@ -1,14 +1,13 @@
-# Agent Handoff
+# Remote Support Workflow
 
-Use this when asking Codex, Nexy, Claude Code, or another coding agent to work on
-the rover repo.
+Use this before remote repo work, review work, or competition-readiness changes.
 
-The short version: give the agent the rover context before asking it to be clever.
-Robots are quite good at punishing cleverness.
+The short version: start from the rover context, then make the change. Robots
+punish guesswork.
 
 ## Sources Of Truth
 
-Start every serious agent task with these files:
+Start every serious remote-support task with these files:
 
 - `AGENTS.md`
 - `README.md`
@@ -16,14 +15,34 @@ Start every serious agent task with these files:
 - `.github/contracts/interface_contracts.json`
 - `docs/active_runtime_paths.md`
 - `docs/hardware_week_runbook.md`
-- `docs/remote_competition_handoff.md`
+- `docs/competition_remote_support.md`
 - package READMEs under `src/*/README.md`
 
 If a local `wiki/` checkout exists, include the relevant wiki page too. If the
 wiki is not checked out, say so in the task prompt rather than pretending the
-agent can see it.
+context is available.
 
-## Good Agent Tasks
+## Installed Robotics Skills
+
+If local robotics skills are available, use the matching skill before editing or
+reviewing. This repo does not include the skill files.
+
+- `ros2-development` for ROS 2 Humble, `colcon`, launch files, parameters,
+  QoS, actions, Nav2, DDS, package metadata and build issues.
+- `robotics-design-patterns` for fail-closed behaviour, watchdogs, safety
+  architecture, hardware abstraction, state machines and sim-to-real choices.
+- `robotics-software-principles` for robotics code reviews, module boundaries,
+  hardware interfaces, configuration and risky refactors.
+- `robotics-testing` for ROS tests, launch tests, mock hardware, deterministic
+  replay, CI and hardware-in-the-loop planning.
+- `robot-perception` for OAK-D, depth, AprilTags, Ouster/LiDAR, point clouds,
+  TF/extrinsics, calibration and sensor timing.
+- `robotics-security` for SSH, router/network exposure, secrets, certificates,
+  Docker/devcontainer hardening, DDS security and E-stop security.
+
+If a skill is missing, say so and continue from the repo docs.
+
+## Good Task Prompts
 
 Good tasks are bounded and testable:
 
@@ -58,9 +77,9 @@ Fix the rover.
 Those are not impossible, but they invite guesswork at exactly the point where
 the rover needs boring, inspectable steps.
 
-## Hardware Rules For Agents
+## Hardware Rules
 
-Tell agents these constraints explicitly:
+Keep these constraints explicit:
 
 - real motion must fail closed;
 - the safety stack and E-stop path are not optional for hardware work;
@@ -71,9 +90,9 @@ Tell agents these constraints explicitly:
 - private SSH keys, router passwords, Tailscale keys, and tokens must not be
   committed.
 
-For remote support, the agent can change code and docs, but someone in the lab
-must handle plugs, power, E-stop tests, sensor placement, motor direction, and
-anything involving physical risk.
+Remote support can cover code and docs, but someone in the lab must handle
+plugs, power, E-stop tests, sensor placement, motor direction, and anything
+involving physical risk.
 
 ## Review Bar
 

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -525,7 +525,7 @@ def check_rover_lan_ip() -> CheckResult:
         "WARN",
         "Rover LAN IP",
         f"{ROVER_IP} not found on local interfaces",
-        "The current handoff and Ouster debug config expect the Jetson on 192.168.8.20.",
+        "The current router and Ouster debug config expect the Jetson on 192.168.8.20.",
     )
 
 
@@ -541,7 +541,7 @@ def check_router_config_consistency() -> CheckResult:
             "WARN",
             "Router IP docs",
             f"Skipped missing files: {', '.join(missing)}",
-            "Restore the router, Foxglove and Ouster config docs before final handoff.",
+            "Restore the router, Foxglove and Ouster config docs before competition readiness checks.",
         )
     stale = [
         name
@@ -556,7 +556,7 @@ def check_router_config_consistency() -> CheckResult:
         "WARN",
         "Router IP docs",
         f"{ROVER_IP} missing from: {', '.join(stale)}",
-        "Keep router docs, Foxglove docs and Ouster udp_dest aligned before lab handoff.",
+        "Keep router docs, Foxglove docs and Ouster udp_dest aligned before competition testing.",
     )
 
 

--- a/tools/teensy/README.md
+++ b/tools/teensy/README.md
@@ -12,7 +12,7 @@ Teensy pins 15-22 <- FL/RL/FR/RR quadrature encoders
 ```
 
 See `docs/teensy_drivetrain_bringup.md` for the wiring tables, safety notes,
-captured encoder counts, Jetson handoff, and ROS bridge results.
+captured encoder counts, Jetson integration notes, and ROS bridge results.
 
 ## Sketches
 


### PR DESCRIPTION
## Summary
- add local robotics skill guidance to AGENTS.md
- rename the support docs to direct operational names
- replace stale handoff wording with remote support, competition readiness and review workflow language

## Validation
- git diff --check
- python3 -m compileall -q tools/doctor.py