### PR TITLE
[codex] Add bucket ladder actuator control

### DIFF
--- a/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
@@ -31,7 +31,7 @@ from rclpy.qos import (
     ReliabilityPolicy,
 )
 from sensor_msgs.msg import JointState
-from std_msgs.msg import Bool
+from std_msgs.msg import Bool, Int8MultiArray
 
 from lunabot_drivetrain import sabertooth_serial, teensy_serial
 from lunabot_interfaces.msg import (
@@ -307,6 +307,9 @@ class DrivetrainBridge(Node):
         self._estop_sub = self.create_subscription(
             Bool, "/safety/estop", self._estop_callback, 10
         )
+        self._actuator_sub = self.create_subscription(
+            Int8MultiArray, "/actuator/cmd", self._actuator_cmd_callback, 10
+        )
         self._status_pub = self.create_publisher(
             DrivetrainStatus, "/drivetrain/status", 10
         )
@@ -336,6 +339,20 @@ class DrivetrainBridge(Node):
     def _inhibit_callback(self, msg: Bool) -> None:
         """Update motion inhibit state from safety node."""
         self._motion_inhibited = msg.data
+
+    def _actuator_cmd_callback(self, msg: Int8MultiArray) -> None:
+        if self._serial is None or self._serial_protocol not in _TEENSY_PROTOCOLS:
+            return
+        if len(msg.data) < 2:
+            return
+        try:
+            teensy_serial.send_actuator_cmd(
+                self._serial,
+                int(msg.data[0]),
+                int(msg.data[1]),
+            )
+        except OSError as exc:
+            self._mark_controller_offline(f"Actuator serial write failed: {exc}")
 
     def _estop_callback(self, msg: Bool) -> None:
         """Update e-stop state."""

--- a/src/lunabot_drivetrain/lunabot_drivetrain/teensy_serial.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/teensy_serial.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 
 
 MAX_COMMAND = 127
+ACTUATOR_1_DUTY = 230
+ACTUATOR_2_DUTY = 255
 
 
 @dataclass(frozen=True)
@@ -136,3 +138,41 @@ def parse_telemetry_line(line: bytes | str) -> TeensyTelemetry | None:
             int(fields[12]),
         ],
     )
+
+
+def _clamp_actuator_duty(value: int) -> int:
+    return max(0, min(255, int(value)))
+
+
+def actuator_to_bytes(
+    dir1: int,
+    dir2: int,
+    duty1: int = ACTUATOR_1_DUTY,
+    duty2: int = ACTUATOR_2_DUTY,
+) -> bytes:
+    d1 = max(-1, min(1, int(dir1)))
+    d2 = max(-1, min(1, int(dir2)))
+    p1 = _clamp_actuator_duty(duty1)
+    p2 = _clamp_actuator_duty(duty2)
+    eol = chr(10)
+    return (
+        "C "
+        + str(d1)
+        + " "
+        + str(d2)
+        + " "
+        + str(p1)
+        + " "
+        + str(p2)
+        + eol
+    ).encode("ascii")
+
+
+def send_actuator_cmd(
+    port,
+    dir1: int,
+    dir2: int,
+    duty1: int = ACTUATOR_1_DUTY,
+    duty2: int = ACTUATOR_2_DUTY,
+) -> None:
+    port.write(actuator_to_bytes(dir1, dir2, duty1, duty2))

--- a/src/lunabot_drivetrain/test/test_sabertooth_serial.py
+++ b/src/lunabot_drivetrain/test/test_sabertooth_serial.py
@@ -105,6 +105,10 @@ def _install_ros_fakes():
         def __init__(self):
             self.data = False
 
+    class Int8MultiArray:
+        def __init__(self):
+            self.data = []
+
     class Node:
         pass
 
@@ -138,6 +142,7 @@ def _install_ros_fakes():
     std_msgs = types.ModuleType("std_msgs")
     std_msg = types.ModuleType("std_msgs.msg")
     std_msg.Bool = Bool
+    std_msg.Int8MultiArray = Int8MultiArray
     sys.modules["std_msgs"] = std_msgs
     sys.modules["std_msgs.msg"] = std_msg
 
@@ -260,6 +265,15 @@ class TestTeensySerial:
         assert teensy_serial.estop_to_bytes() == b"E\n"
         assert teensy_serial.release_estop_to_bytes() == b"U\n"
         assert teensy_serial.restart_to_bytes() == b"R\n"
+
+    def test_actuator_command_uses_tuned_default_duty(self):
+        assert teensy_serial.actuator_to_bytes(1, -1) == b"C 1 -1 230 255\n"
+
+    def test_actuator_command_clamps_direction_and_duty(self):
+        assert (
+            teensy_serial.actuator_to_bytes(3, -3, -10, 300)
+            == b"C 1 -1 0 255\n"
+        )
 
     def test_parse_telemetry_reorders_ticks_to_ros_wheel_order(self):
         telemetry = teensy_serial.parse_telemetry_line(
@@ -398,6 +412,24 @@ class TestDrivetrainBridgeSerialDispatch:
         bridge._send_wheel_throttles(0.2, -0.1)
 
         assert calls == [(bridge._serial, 0.2, -0.1)]
+
+    def test_actuator_topic_uses_teensy_cytron_path(self, monkeypatch):
+        from std_msgs.msg import Int8MultiArray
+
+        calls = []
+
+        monkeypatch.setattr(
+            teensy_serial,
+            "send_actuator_cmd",
+            lambda port, dir1, dir2: calls.append((port, dir1, dir2)),
+        )
+
+        bridge = self._make_bridge("teensy_line")
+        msg = Int8MultiArray()
+        msg.data = [1, 1]
+        bridge._actuator_cmd_callback(msg)
+
+        assert calls == [(bridge._serial, 1, 1)]
 
     def test_legacy_simplified_stop_path(self, monkeypatch):
         calls = []

--- a/tools/teensy/drivetrain_serial_firmware/drivetrain_serial_firmware.ino
+++ b/tools/teensy/drivetrain_serial_firmware/drivetrain_serial_firmware.ino
@@ -2,6 +2,8 @@
 //
 // Jetson/Mac USB serial commands, 115200 baud:
 //   V <left> <right>   Set side throttle targets, -127..127.
+//   C <dir1> <dir2> [duty1] [duty2]
+//                      Set Cytron MDD10A #1 directions and optional PWM duty, 0..255.
 //   X                  Immediate hard stop, keeps motion allowed.
 //   E                  Simulated/physical E-stop active: hard stop + latch inhibit.
 //   U                  E-stop released, restart still required.
@@ -14,15 +16,20 @@
 //
 // Wiring:
 //   Left Sabertooth S1  <- Teensy pin 1  (Serial1 TX)
-//   Right Sabertooth S1 <- Teensy pin 8  (Serial2 TX)
+//   Right Sabertooth S1 <- Teensy pin 29 (Serial7 TX)
 //   Sabertooth 0V       <-> Teensy GND
 //   Encoders red/black  -> Teensy 3.3V/GND
 //   Encoder A/B pins: FL 15/16, RL 17/18, FR 19/20, RR 21/22
+//   Cytron MDD10A #1 Act1: PWM <- pin 2, DIR <- pin 9
+//   Cytron MDD10A #1 Act2: PWM <- pin 3, DIR <- pin 28
 
 constexpr uint8_t ENCODER_COUNT = 4;
 constexpr uint8_t ENC_A[ENCODER_COUNT] = {15, 17, 19, 21};
 constexpr uint8_t ENC_B[ENCODER_COUNT] = {16, 18, 20, 22};
 
+constexpr uint8_t CYTRON_PWM[2] = {2, 3};
+constexpr uint8_t CYTRON_DIR[2] = {9, 28};
+constexpr uint8_t CYTRON_DEFAULT_DUTY = 255;
 constexpr uint8_t LEFT_ADDRESS = 128;
 constexpr uint8_t RIGHT_ADDRESS = 128;
 constexpr uint32_t USB_BAUD = 115200;
@@ -43,6 +50,8 @@ enum MotionState : uint8_t {
 volatile int32_t encoder_ticks[ENCODER_COUNT] = {0, 0, 0, 0};
 volatile uint8_t last_encoder_state[ENCODER_COUNT] = {0, 0, 0, 0};
 
+int8_t cytron_dir[2] = {0, 0};
+uint8_t cytron_duty[2] = {CYTRON_DEFAULT_DUTY, CYTRON_DEFAULT_DUTY};
 int target_left = 0;
 int target_right = 0;
 int command_left = 0;
@@ -109,10 +118,17 @@ void saberMotor(HardwareSerial &port, uint8_t address, bool motor2, int speed) {
 void writeMotorOutputs() {
   saberMotor(Serial1, LEFT_ADDRESS, false, command_left);
   saberMotor(Serial1, LEFT_ADDRESS, true, command_left);
-  saberMotor(Serial2, RIGHT_ADDRESS, false, command_right);
-  saberMotor(Serial2, RIGHT_ADDRESS, true, command_right);
+  saberMotor(Serial7, RIGHT_ADDRESS, false, command_right);
+  saberMotor(Serial7, RIGHT_ADDRESS, true, command_right);
   Serial1.flush();
-  Serial2.flush();
+  Serial7.flush();
+}
+
+void stopCytronOutputs() {
+  cytron_dir[0] = 0;
+  cytron_dir[1] = 0;
+  analogWrite(CYTRON_PWM[0], 0);
+  analogWrite(CYTRON_PWM[1], 0);
 }
 
 void hardStop() {
@@ -121,6 +137,7 @@ void hardStop() {
   command_left = 0;
   command_right = 0;
   writeMotorOutputs();
+  stopCytronOutputs();
 }
 
 void resetEncoders() {
@@ -214,7 +231,7 @@ void publishTelemetry(uint32_t now_ms) {
 }
 
 void printHelp() {
-  Serial.println("OK H V <left> <right> | X | E | U | R | Z");
+  Serial.println("OK H V <left> <right> | C <d1> <d2> [duty1] [duty2] | X | E | U | R | Z");
 }
 
 void engageEstop() {
@@ -266,6 +283,54 @@ void setVelocityTargets(char *args) {
   Serial.println(target_right);
 }
 
+void setCytronOutputs() {
+  for (uint8_t i = 0; i < 2; ++i) {
+    pinMode(CYTRON_PWM[i], OUTPUT);
+    pinMode(CYTRON_DIR[i], OUTPUT);
+    if (cytron_dir[i] == 0) {
+      analogWrite(CYTRON_PWM[i], 0);
+      digitalWrite(CYTRON_PWM[i], LOW);
+      continue;
+    }
+    digitalWrite(CYTRON_DIR[i], cytron_dir[i] > 0 ? HIGH : LOW);
+    if (cytron_duty[i] >= 255) {
+      digitalWrite(CYTRON_PWM[i], HIGH);
+    } else {
+      analogWrite(CYTRON_PWM[i], cytron_duty[i]);
+    }
+  }
+}
+
+void setCytronCommand(char *args) {
+  char *dir1_text = strtok(args, " ");
+  char *dir2_text = strtok(nullptr, " ");
+  char *duty1_text = strtok(nullptr, " ");
+  char *duty2_text = strtok(nullptr, " ");
+  if (dir1_text == nullptr || dir2_text == nullptr) {
+    Serial.println("ERR C expected_dir1_dir2");
+    return;
+  }
+
+  cytron_dir[0] = constrain(atoi(dir1_text), -1, 1);
+  cytron_dir[1] = constrain(atoi(dir2_text), -1, 1);
+  cytron_duty[0] = duty1_text == nullptr
+                     ? CYTRON_DEFAULT_DUTY
+                     : static_cast<uint8_t>(constrain(atoi(duty1_text), 0, 255));
+  cytron_duty[1] = duty2_text == nullptr
+                     ? CYTRON_DEFAULT_DUTY
+                     : static_cast<uint8_t>(constrain(atoi(duty2_text), 0, 255));
+  setCytronOutputs();
+
+  Serial.print("OK C ");
+  Serial.print(cytron_dir[0]);
+  Serial.print(' ');
+  Serial.print(cytron_dir[1]);
+  Serial.print(" duty ");
+  Serial.print(cytron_duty[0]);
+  Serial.print(' ');
+  Serial.println(cytron_duty[1]);
+}
+
 void handleLine(char *line) {
   while (*line == ' ') {
     ++line;
@@ -283,6 +348,10 @@ void handleLine(char *line) {
     case 'V':
     case 'v':
       setVelocityTargets(line);
+      break;
+    case 'C':
+    case 'c':
+      setCytronCommand(line);
       break;
     case 'X':
     case 'x':
@@ -371,14 +440,21 @@ void setup() {
   attachInterrupt(digitalPinToInterrupt(ENC_A[3]), updateEncoderRR, CHANGE);
   attachInterrupt(digitalPinToInterrupt(ENC_B[3]), updateEncoderRR, CHANGE);
 
+  for (uint8_t i = 0; i < 2; ++i) {
+    pinMode(CYTRON_PWM[i], OUTPUT);
+    pinMode(CYTRON_DIR[i], OUTPUT);
+    analogWrite(CYTRON_PWM[i], 0);
+    digitalWrite(CYTRON_DIR[i], LOW);
+  }
+
   Serial.begin(USB_BAUD);
   Serial1.begin(SABER_BAUD);
-  Serial2.begin(SABER_BAUD);
+  Serial7.begin(SABER_BAUD);
   delay(1500);
 
   hardStop();
   saberSend(Serial1, LEFT_ADDRESS, 16, 20);
-  saberSend(Serial2, RIGHT_ADDRESS, 16, 20);
+  saberSend(Serial7, RIGHT_ADDRESS, 16, 20);
   last_velocity_command_ms = millis();
 
   Serial.println("BOOT innex1_teensy_drivetrain_serial v0");


### PR DESCRIPTION
## What changed
- Adds Teensy `C <dir1> <dir2> [duty1] [duty2]` support for the bucket ladder Cytron MDD10A pair.
- Routes `/actuator/cmd` from `drivetrain_bridge` to the Teensy `C` command with the tuned 230/255 duty split.
- Updates the Teensy right-side Sabertooth UART to Serial7 / pin 29 and records the Cytron pin map, including DIR channel 2 on pin 28.
- Adds regression coverage for actuator serial encoding and bridge dispatch.

## Why
Y/A controller testing confirmed the laptop publishes `std_msgs/Int8MultiArray` commands on `/actuator/cmd`; the bridge now forwards those to the tuned Cytron #1 actuator pair used to drive the bucket ladder into and out of the ground.

## Validation
- Live Jetson/controller test: `/actuator/cmd` showed `[1, 1]`, `[0, 0]`, and `[-1, -1]` from the laptop publisher while lab observers confirmed Y/A actuator movement.
- `PYTHONPATH=src/lunabot_drivetrain:src/lunabot_interfaces pytest -q src/lunabot_drivetrain/test/test_sabertooth_serial.py` -> 36 passed locally.
- Jetson: `python3 -m pytest -q src/lunabot_drivetrain/test/test_sabertooth_serial.py` -> 36 passed.
- Jetson: `colcon build --symlink-install --packages-select lunabot_drivetrain` -> passed.
- Jetson: `/home/innex-1/bin/arduino-cli compile --fqbn teensy:avr:teensy41 tools/teensy/drivetrain_serial_firmware` -> passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds bucket-ladder actuator control to the rover by implementing support for the Teensy-based Cytron MDD10A motor driver pair. The drivetrain bridge now subscribes to and forwards `/actuator/cmd` messages (containing direction and duty cycle values) to the Teensy firmware, which drives the bucket-ladder actuators in and out of the ground.

## Changes

- **Drivetrain Bridge**: Added subscription to `/actuator/cmd` topic that routes `Int8MultiArray` messages to the Teensy serial interface for actuator command dispatch
- **Teensy Serial Interface**: Introduced actuator command encoding and transmission functions with tuned default duty cycle values (230/255 split)
- **Teensy Firmware**: Extended command parser to support actuator control via USB serial, initialized Cytron PWM/DIR pins (Serial7 for right-side Sabertooth on pin 29, Cytron DIR channel 2 on pin 28), and updated motor stopping behavior to halt Cytron outputs
- **Test Coverage**: Added regression tests for actuator command encoding, duty cycle clamping, and bridge dispatch to Teensy via the new actuator command path

## Validation

- Live Jetson/controller testing confirmed Y/A actuator movement when publishing direction commands via `/actuator/cmd`
- All 36 unit tests pass locally and on Jetson
- Teensy firmware compiles successfully

<!-- end of auto-generated comment: release notes by coderabbit.ai -->