### PR TITLE
[codex] Add deposition actuator control

### DIFF
--- a/.github/contracts/interface_contracts.json
+++ b/.github/contracts/interface_contracts.json
@@ -126,6 +126,13 @@
       "phases": ["runtime", "hardware"]
     },
     {
+      "name": "/deposition/actuator/cmd",
+      "type": "std_msgs/msg/Int8MultiArray",
+      "kind": "subscription",
+      "source": "src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py",
+      "phases": ["runtime", "hardware"]
+    },
+    {
       "name": "/drivetrain/status",
       "type": "lunabot_interfaces/msg/DrivetrainStatus",
       "kind": "subscription",

--- a/docs/hardware/cytron-mdd10a.md
+++ b/docs/hardware/cytron-mdd10a.md
@@ -102,9 +102,9 @@ INNEX-1 uses **sign-magnitude PWM** mode: one PWM signal sets speed, one DIR sig
 | M1A / M1B | DCHOUSE 250mm Actuator #3 (Red +, Black −) |
 | M2A / M2B | DCHOUSE 250mm Actuator #4 (Red +, Black −) |
 | GND (header) | Teensy GND |
-| PWM1 | Teensy pin **4** |
+| PWM1 | Teensy pin **33** (remapped from Pin 4 after live deposition-door testing) |
 | DIR1 | Teensy pin **11** |
-| PWM2 | Teensy pin **5** |
+| PWM2 | Teensy pin **41** (remapped from Pin 5 after live deposition-door testing) |
 | DIR2 | Teensy pin **12** |
 
 ---

--- a/docs/hardware/dchouse-linear-actuator-250mm.md
+++ b/docs/hardware/dchouse-linear-actuator-250mm.md
@@ -77,7 +77,7 @@ This actuator has **2 wires only** — no encoder.
 | Supply to Cytron | 12 V from DollaTek buck converter (not direct motive rail) |
 | Actuators per controller | 2 (one per channel) |
 | Control type | **Open-loop — timed PWM commands, no position feedback** |
-| Teensy PWM pins | Pins 4, 5 (Actuators 3 & 4) |
+| Teensy PWM pins | Pins 33, 41 (Actuators 3 & 4) |
 | Teensy DIR pins | Pins 11, 12 (Actuators 3 & 4) |
 | Fuse (motive fuse block) | **15 A blade** — Cytron #2 slot (fuses the buck converter input) |
 

--- a/docs/hardware/software-team-notes.md
+++ b/docs/hardware/software-team-notes.md
@@ -52,7 +52,7 @@ The Jetson handles **high-level autonomy only**. All low-level motor I/O goes th
 | 29 | Serial7 TX | → | Sabertooth #2 (Right: FR + RR) — remapped from Pin 8 (dead on breakout board) |
 | 2, 3 | PWM ch1 & ch2 | → | Cytron MDD10A #1 (Actuators 1 & 2) |
 | 9, 28 | DIR ch1 & ch2 | → | Cytron MDD10A #1 — Pin 28 remapped from Pin 10 (dead) |
-| 4, 5 | PWM ch1 & ch2 | → | Cytron MDD10A #2 (Actuators 3 & 4) |
+| 33, 41 | PWM ch1 & ch2 | → | Cytron MDD10A #2 (Actuators 3 & 4) — remapped from Pins 4 and 5 after live deposition-door testing |
 | 11, 12 | DIR ch1 & ch2 | → | Cytron MDD10A #2 |
 | 6 | PWM (SV) | → | BLD-510B — excavation motor speed |
 | 13 | GPIO (F/R) | → | BLD-510B — direction |

--- a/docs/hardware/teensy-4.1-microcontroller.md
+++ b/docs/hardware/teensy-4.1-microcontroller.md
@@ -53,8 +53,8 @@
 | **3** | PWM ch2 | → | Cytron MDD10A #1 | Actuator 2 speed |
 | **9** | DIR ch1 | → | Cytron MDD10A #1 | Actuator 1 direction |
 | **28** | DIR ch2 | → | Cytron MDD10A #1 | Actuator 2 direction. Remapped from Pin 10 (dead) |
-| **4** | PWM ch1 | → | Cytron MDD10A #2 | Actuator 3 speed |
-| **5** | PWM ch2 | → | Cytron MDD10A #2 | Actuator 4 speed |
+| **33** | PWM ch1 | → | Cytron MDD10A #2 | Actuator 3 speed. Remapped from Pin 4 after live deposition-door testing |
+| **41** | PWM ch2 | → | Cytron MDD10A #2 | Actuator 4 speed. Remapped from Pin 5 after live deposition-door testing |
 | **11** | DIR ch1 | → | Cytron MDD10A #2 | Actuator 3 direction |
 | **12** | DIR ch2 | → | Cytron MDD10A #2 | Actuator 4 direction |
 | **6** | PWM (SV) | → | BLD-510B | Excavation speed — direct 1–2 kHz PWM to SV pin (no external RC filter needed; driver accepts PWM directly) |
@@ -102,7 +102,7 @@ corrections.
 | USB (virtual COM) | Serial | Jetson Orin Nano — bidirectional |
 | Serial1 (Pin 1) | Packetised serial, 9600 baud | Sabertooth 2×32 #1 (TX only) |
 | Serial7 (Pin 29) | Packetised serial, 9600 baud | Sabertooth 2×32 #2 (TX only) — remapped from Pin 8 (dead) |
-| GPIO PWM (Pins 2–6) | PWM + DIR | Cytron MDD10A #1 and #2, BLD-510B SV |
+| GPIO PWM (Pins 2, 3, 6, 33, 41) | PWM + DIR | Cytron MDD10A #1 and #2, BLD-510B SV |
 | GPIO (Pins 13–14) | Digital out, active-low | BLD-510B F/R and EN |
 | GPIO (Pins 15–22) | Quadrature encoder input | 4× GR-WM4-V3 drivetrain motor encoders |
 | GPIO (Pins 31–32) | Open-collector input | BLD-510B PG and ALM |

--- a/src/lunabot_drivetrain/README.md
+++ b/src/lunabot_drivetrain/README.md
@@ -38,6 +38,7 @@ Teensy `T ...` telemetry line.
 | Direction | Topic | Type |
 |-----------|-------|------|
 | Subscribe | `/cmd_vel_gated` | `geometry_msgs/Twist` |
+| Subscribe | `/deposition/actuator/cmd` | `std_msgs/Int8MultiArray` |
 | Subscribe | `/safety/motion_inhibit` | `std_msgs/Bool` (transient-local) |
 | Subscribe | `/safety/estop` | `std_msgs/Bool` |
 | Publish | `/drivetrain/status` | `lunabot_interfaces/DrivetrainStatus` |

--- a/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py
@@ -310,6 +310,12 @@ class DrivetrainBridge(Node):
         self._actuator_sub = self.create_subscription(
             Int8MultiArray, "/actuator/cmd", self._actuator_cmd_callback, 10
         )
+        self._deposition_actuator_sub = self.create_subscription(
+            Int8MultiArray,
+            "/deposition/actuator/cmd",
+            self._deposition_actuator_cmd_callback,
+            10,
+        )
         self._status_pub = self.create_publisher(
             DrivetrainStatus, "/drivetrain/status", 10
         )
@@ -353,6 +359,22 @@ class DrivetrainBridge(Node):
             )
         except OSError as exc:
             self._mark_controller_offline(f"Actuator serial write failed: {exc}")
+
+    def _deposition_actuator_cmd_callback(self, msg: Int8MultiArray) -> None:
+        if self._serial is None or self._serial_protocol not in _TEENSY_PROTOCOLS:
+            return
+        if len(msg.data) < 2:
+            return
+        try:
+            teensy_serial.send_deposition_actuator_cmd(
+                self._serial,
+                int(msg.data[0]),
+                int(msg.data[1]),
+            )
+        except OSError as exc:
+            self._mark_controller_offline(
+                f"Deposition actuator serial write failed: {exc}"
+            )
 
     def _estop_callback(self, msg: Bool) -> None:
         """Update e-stop state."""

--- a/src/lunabot_drivetrain/lunabot_drivetrain/teensy_serial.py
+++ b/src/lunabot_drivetrain/lunabot_drivetrain/teensy_serial.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 MAX_COMMAND = 127
 ACTUATOR_1_DUTY = 230
 ACTUATOR_2_DUTY = 255
+DEPOSITION_ACTUATOR_DUTY = 255
 
 
 @dataclass(frozen=True)
@@ -149,14 +150,19 @@ def actuator_to_bytes(
     dir2: int,
     duty1: int = ACTUATOR_1_DUTY,
     duty2: int = ACTUATOR_2_DUTY,
+    command: str = "C",
 ) -> bytes:
     d1 = max(-1, min(1, int(dir1)))
     d2 = max(-1, min(1, int(dir2)))
     p1 = _clamp_actuator_duty(duty1)
     p2 = _clamp_actuator_duty(duty2)
+    command_name = command[:1].upper()
+    if command_name not in {"C", "D"}:
+        raise ValueError(f"unsupported actuator command: {command!r}")
     eol = chr(10)
     return (
-        "C "
+        command_name
+        + " "
         + str(d1)
         + " "
         + str(d2)
@@ -176,3 +182,22 @@ def send_actuator_cmd(
     duty2: int = ACTUATOR_2_DUTY,
 ) -> None:
     port.write(actuator_to_bytes(dir1, dir2, duty1, duty2))
+
+
+def deposition_actuator_to_bytes(
+    dir1: int,
+    dir2: int,
+    duty1: int = DEPOSITION_ACTUATOR_DUTY,
+    duty2: int = DEPOSITION_ACTUATOR_DUTY,
+) -> bytes:
+    return actuator_to_bytes(dir1, dir2, duty1, duty2, command="D")
+
+
+def send_deposition_actuator_cmd(
+    port,
+    dir1: int,
+    dir2: int,
+    duty1: int = DEPOSITION_ACTUATOR_DUTY,
+    duty2: int = DEPOSITION_ACTUATOR_DUTY,
+) -> None:
+    port.write(deposition_actuator_to_bytes(dir1, dir2, duty1, duty2))

--- a/src/lunabot_drivetrain/test/test_sabertooth_serial.py
+++ b/src/lunabot_drivetrain/test/test_sabertooth_serial.py
@@ -275,6 +275,16 @@ class TestTeensySerial:
             == b"C 1 -1 0 255\n"
         )
 
+    def test_deposition_actuator_command_uses_cytron_two(self):
+        assert (
+            teensy_serial.deposition_actuator_to_bytes(1, -1)
+            == b"D 1 -1 255 255\n"
+        )
+
+    def test_actuator_command_rejects_unknown_channel_command(self):
+        with pytest.raises(ValueError):
+            teensy_serial.actuator_to_bytes(1, 1, command="Q")
+
     def test_parse_telemetry_reorders_ticks_to_ros_wheel_order(self):
         telemetry = teensy_serial.parse_telemetry_line(
             b"T 1234 1 0 0 30 30 28 29 10 20 30 40\n"
@@ -430,6 +440,24 @@ class TestDrivetrainBridgeSerialDispatch:
         bridge._actuator_cmd_callback(msg)
 
         assert calls == [(bridge._serial, 1, 1)]
+
+    def test_deposition_actuator_topic_uses_teensy_cytron_two_path(self, monkeypatch):
+        from std_msgs.msg import Int8MultiArray
+
+        calls = []
+
+        monkeypatch.setattr(
+            teensy_serial,
+            "send_deposition_actuator_cmd",
+            lambda port, dir1, dir2: calls.append((port, dir1, dir2)),
+        )
+
+        bridge = self._make_bridge("teensy_line")
+        msg = Int8MultiArray()
+        msg.data = [1, -1]
+        bridge._deposition_actuator_cmd_callback(msg)
+
+        assert calls == [(bridge._serial, 1, -1)]
 
     def test_legacy_simplified_stop_path(self, monkeypatch):
         calls = []

--- a/tools/teensy/drivetrain_serial_firmware/drivetrain_serial_firmware.ino
+++ b/tools/teensy/drivetrain_serial_firmware/drivetrain_serial_firmware.ino
@@ -2,8 +2,11 @@
 //
 // Jetson/Mac USB serial commands, 115200 baud:
 //   V <left> <right>   Set side throttle targets, -127..127.
+//   B <speed>          Set BLD-510B excavation motor speed, -127..127.
 //   C <dir1> <dir2> [duty1] [duty2]
 //                      Set Cytron MDD10A #1 directions and optional PWM duty, 0..255.
+//   D <dir1> <dir2> [duty1] [duty2]
+//                      Set Cytron MDD10A #2 directions and optional PWM duty, 0..255.
 //   X                  Immediate hard stop, keeps motion allowed.
 //   E                  Simulated/physical E-stop active: hard stop + latch inhibit.
 //   U                  E-stop released, restart still required.
@@ -22,14 +25,21 @@
 //   Encoder A/B pins: FL 15/16, RL 17/18, FR 19/20, RR 21/22
 //   Cytron MDD10A #1 Act1: PWM <- pin 2, DIR <- pin 9
 //   Cytron MDD10A #1 Act2: PWM <- pin 3, DIR <- pin 28
+//   Cytron MDD10A #2 Act1: PWM <- pin 33, DIR <- pin 11
+//   Cytron MDD10A #2 Act2: PWM <- pin 41, DIR <- pin 12
+//   BLD-510B: SV speed <- pin 6, F/R <- pin 13, EN <- pin 14
 
 constexpr uint8_t ENCODER_COUNT = 4;
 constexpr uint8_t ENC_A[ENCODER_COUNT] = {15, 17, 19, 21};
 constexpr uint8_t ENC_B[ENCODER_COUNT] = {16, 18, 20, 22};
 
-constexpr uint8_t CYTRON_PWM[2] = {2, 3};
-constexpr uint8_t CYTRON_DIR[2] = {9, 28};
+constexpr uint8_t CYTRON_COUNT = 4;
+constexpr uint8_t CYTRON_PWM[CYTRON_COUNT] = {2, 3, 33, 41};
+constexpr uint8_t CYTRON_DIR[CYTRON_COUNT] = {9, 28, 11, 12};
 constexpr uint8_t CYTRON_DEFAULT_DUTY = 255;
+constexpr uint8_t BLDC_PWM = 6;
+constexpr uint8_t BLDC_DIR = 13;
+constexpr uint8_t BLDC_EN = 14;
 constexpr uint8_t LEFT_ADDRESS = 128;
 constexpr uint8_t RIGHT_ADDRESS = 128;
 constexpr uint32_t USB_BAUD = 115200;
@@ -50,8 +60,17 @@ enum MotionState : uint8_t {
 volatile int32_t encoder_ticks[ENCODER_COUNT] = {0, 0, 0, 0};
 volatile uint8_t last_encoder_state[ENCODER_COUNT] = {0, 0, 0, 0};
 
-int8_t cytron_dir[2] = {0, 0};
-uint8_t cytron_duty[2] = {CYTRON_DEFAULT_DUTY, CYTRON_DEFAULT_DUTY};
+int8_t cytron_dir[CYTRON_COUNT] = {0, 0, 0, 0};
+uint8_t cytron_duty[CYTRON_COUNT] = {
+  CYTRON_DEFAULT_DUTY,
+  CYTRON_DEFAULT_DUTY,
+  CYTRON_DEFAULT_DUTY,
+  CYTRON_DEFAULT_DUTY,
+};
+// Actuator 4's M2A/M2B leads were swapped on Cytron #2 to keep the command
+// convention positive=extend and negative=retract.
+const bool CYTRON_DIR_INVERT[CYTRON_COUNT] = {false, false, false, false};
+int bldc_speed = 0;
 int target_left = 0;
 int target_right = 0;
 int command_left = 0;
@@ -60,6 +79,7 @@ bool estop_active = false;
 bool motion_inhibited = false;
 bool timed_out = false;
 uint32_t last_velocity_command_ms = 0;
+uint32_t last_bldc_command_ms = 0;
 uint32_t last_ramp_ms = 0;
 uint32_t last_telemetry_ms = 0;
 char line_buffer[80];
@@ -125,10 +145,17 @@ void writeMotorOutputs() {
 }
 
 void stopCytronOutputs() {
-  cytron_dir[0] = 0;
-  cytron_dir[1] = 0;
-  analogWrite(CYTRON_PWM[0], 0);
-  analogWrite(CYTRON_PWM[1], 0);
+  for (uint8_t i = 0; i < CYTRON_COUNT; ++i) {
+    cytron_dir[i] = 0;
+    analogWrite(CYTRON_PWM[i], 0);
+    digitalWrite(CYTRON_PWM[i], LOW);
+  }
+}
+
+void stopBldcOutput() {
+  bldc_speed = 0;
+  analogWrite(BLDC_PWM, 0);
+  digitalWrite(BLDC_EN, HIGH);
 }
 
 void hardStop() {
@@ -138,6 +165,7 @@ void hardStop() {
   command_right = 0;
   writeMotorOutputs();
   stopCytronOutputs();
+  stopBldcOutput();
 }
 
 void resetEncoders() {
@@ -231,7 +259,7 @@ void publishTelemetry(uint32_t now_ms) {
 }
 
 void printHelp() {
-  Serial.println("OK H V <left> <right> | C <d1> <d2> [duty1] [duty2] | X | E | U | R | Z");
+  Serial.println("OK H V <left> <right> | B <speed> | C <d1> <d2> [duty1] [duty2] | D <d1> <d2> [duty1] [duty2] | X | E | U | R | Z");
 }
 
 void engageEstop() {
@@ -283,8 +311,9 @@ void setVelocityTargets(char *args) {
   Serial.println(target_right);
 }
 
-void setCytronOutputs() {
-  for (uint8_t i = 0; i < 2; ++i) {
+void setCytronOutputs(uint8_t start_index) {
+  for (uint8_t offset = 0; offset < 2; ++offset) {
+    const uint8_t i = start_index + offset;
     pinMode(CYTRON_PWM[i], OUTPUT);
     pinMode(CYTRON_DIR[i], OUTPUT);
     if (cytron_dir[i] == 0) {
@@ -292,7 +321,9 @@ void setCytronOutputs() {
       digitalWrite(CYTRON_PWM[i], LOW);
       continue;
     }
-    digitalWrite(CYTRON_DIR[i], cytron_dir[i] > 0 ? HIGH : LOW);
+    const bool positive_dir = cytron_dir[i] > 0;
+    const bool output_high = CYTRON_DIR_INVERT[i] ? !positive_dir : positive_dir;
+    digitalWrite(CYTRON_DIR[i], output_high ? HIGH : LOW);
     if (cytron_duty[i] >= 255) {
       digitalWrite(CYTRON_PWM[i], HIGH);
     } else {
@@ -301,34 +332,68 @@ void setCytronOutputs() {
   }
 }
 
-void setCytronCommand(char *args) {
+void setCytronCommand(char *args, uint8_t start_index, char command_name) {
   char *dir1_text = strtok(args, " ");
   char *dir2_text = strtok(nullptr, " ");
   char *duty1_text = strtok(nullptr, " ");
   char *duty2_text = strtok(nullptr, " ");
   if (dir1_text == nullptr || dir2_text == nullptr) {
-    Serial.println("ERR C expected_dir1_dir2");
+    Serial.print("ERR ");
+    Serial.print(command_name);
+    Serial.println(" expected_dir1_dir2");
     return;
   }
 
-  cytron_dir[0] = constrain(atoi(dir1_text), -1, 1);
-  cytron_dir[1] = constrain(atoi(dir2_text), -1, 1);
-  cytron_duty[0] = duty1_text == nullptr
-                     ? CYTRON_DEFAULT_DUTY
-                     : static_cast<uint8_t>(constrain(atoi(duty1_text), 0, 255));
-  cytron_duty[1] = duty2_text == nullptr
-                     ? CYTRON_DEFAULT_DUTY
-                     : static_cast<uint8_t>(constrain(atoi(duty2_text), 0, 255));
-  setCytronOutputs();
+  cytron_dir[start_index] = constrain(atoi(dir1_text), -1, 1);
+  cytron_dir[start_index + 1] = constrain(atoi(dir2_text), -1, 1);
+  cytron_duty[start_index] = duty1_text == nullptr
+                               ? CYTRON_DEFAULT_DUTY
+                               : static_cast<uint8_t>(constrain(atoi(duty1_text), 0, 255));
+  cytron_duty[start_index + 1] = duty2_text == nullptr
+                                   ? CYTRON_DEFAULT_DUTY
+                                   : static_cast<uint8_t>(constrain(atoi(duty2_text), 0, 255));
+  setCytronOutputs(start_index);
 
-  Serial.print("OK C ");
-  Serial.print(cytron_dir[0]);
+  Serial.print("OK ");
+  Serial.print(command_name);
   Serial.print(' ');
-  Serial.print(cytron_dir[1]);
+  Serial.print(cytron_dir[start_index]);
+  Serial.print(' ');
+  Serial.print(cytron_dir[start_index + 1]);
   Serial.print(" duty ");
-  Serial.print(cytron_duty[0]);
+  Serial.print(cytron_duty[start_index]);
   Serial.print(' ');
-  Serial.println(cytron_duty[1]);
+  Serial.println(cytron_duty[start_index + 1]);
+}
+
+void setBldcCommand(char *args) {
+  if (estop_active || motion_inhibited) {
+    hardStop();
+    Serial.println("ERR B motion_inhibited");
+    return;
+  }
+
+  char *speed_text = strtok(args, " ");
+  if (speed_text == nullptr) {
+    Serial.println("ERR B expected_speed");
+    return;
+  }
+
+  bldc_speed = constrain(atoi(speed_text), -127, 127);
+  last_bldc_command_ms = millis();
+  timed_out = false;
+
+  if (bldc_speed == 0) {
+    stopBldcOutput();
+  } else {
+    const uint8_t duty = static_cast<uint8_t>((abs(bldc_speed) * 255) / 127);
+    digitalWrite(BLDC_DIR, bldc_speed > 0 ? LOW : HIGH);
+    analogWrite(BLDC_PWM, duty);
+    digitalWrite(BLDC_EN, LOW);
+  }
+
+  Serial.print("OK B ");
+  Serial.println(bldc_speed);
 }
 
 void handleLine(char *line) {
@@ -349,9 +414,17 @@ void handleLine(char *line) {
     case 'v':
       setVelocityTargets(line);
       break;
+    case 'B':
+    case 'b':
+      setBldcCommand(line);
+      break;
     case 'C':
     case 'c':
-      setCytronCommand(line);
+      setCytronCommand(line, 0, 'C');
+      break;
+    case 'D':
+    case 'd':
+      setCytronCommand(line, 2, 'D');
       break;
     case 'X':
     case 'x':
@@ -423,6 +496,18 @@ void updateWatchdog(uint32_t now_ms) {
   Serial.println("WARN command_timeout stopped");
 }
 
+void updateBldcWatchdog(uint32_t now_ms) {
+  if (estop_active || motion_inhibited || bldc_speed == 0) {
+    return;
+  }
+  if (now_ms - last_bldc_command_ms <= COMMAND_TIMEOUT_MS) {
+    return;
+  }
+  timed_out = true;
+  stopBldcOutput();
+  Serial.println("WARN bldc_timeout stopped");
+}
+
 void setup() {
   pinMode(LED_BUILTIN, OUTPUT);
   for (uint8_t i = 0; i < ENCODER_COUNT; ++i) {
@@ -440,12 +525,19 @@ void setup() {
   attachInterrupt(digitalPinToInterrupt(ENC_A[3]), updateEncoderRR, CHANGE);
   attachInterrupt(digitalPinToInterrupt(ENC_B[3]), updateEncoderRR, CHANGE);
 
-  for (uint8_t i = 0; i < 2; ++i) {
+  for (uint8_t i = 0; i < CYTRON_COUNT; ++i) {
     pinMode(CYTRON_PWM[i], OUTPUT);
     pinMode(CYTRON_DIR[i], OUTPUT);
     analogWrite(CYTRON_PWM[i], 0);
     digitalWrite(CYTRON_DIR[i], LOW);
   }
+  pinMode(BLDC_PWM, OUTPUT);
+  pinMode(BLDC_DIR, OUTPUT);
+  pinMode(BLDC_EN, OUTPUT);
+  analogWriteFrequency(BLDC_PWM, 1000);
+  analogWrite(BLDC_PWM, 0);
+  digitalWrite(BLDC_DIR, HIGH);
+  digitalWrite(BLDC_EN, HIGH);
 
   Serial.begin(USB_BAUD);
   Serial1.begin(SABER_BAUD);
@@ -471,6 +563,7 @@ void loop() {
 
   readCommands();
   updateWatchdog(now_ms);
+  updateBldcWatchdog(now_ms);
   updateRamp(now_ms);
   publishTelemetry(now_ms);
 }


### PR DESCRIPTION
## What changed
- Adds `/deposition/actuator/cmd` as the ROS topic for the deposition door Cytron pair.
- Routes that topic through `drivetrain_bridge` to the Teensy `D` serial command.
- Extends the Teensy firmware to address Cytron #2 on the live-tested pins: PWM 33/41, DIR 11/12.
- Keeps actuator 4's hardware-swapped direction convention as positive = extend, negative = retract.
- Updates hardware docs and interface contracts for the new deposition mapping.

## Validation
- `PYTHONPATH=src/lunabot_drivetrain pytest -q src/lunabot_drivetrain/test/test_sabertooth_serial.py`
- Jetson Teensy firmware compile with `arduino-cli compile --fqbn teensy:avr:teensy41`
- Live hardware smoke test via rosbridge: Windows controller script published X/B commands to `/deposition/actuator/cmd`; Jetson drivetrain bridge forwarded them and the deposition actuators moved as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR adds support for controlling the deposition door actuators through a new ROS topic `/deposition/actuator/cmd`, enabling the rover to operate its deposition mechanism remotely.

### Core Functionality
- Introduced a new ROS subscription `/deposition/actuator/cmd` (type: `Int8MultiArray`) on the `drivetrain_bridge` node to receive deposition actuator commands
- Extended the Teensy firmware's command protocol to support deposition actuator control via a new `D` serial command, alongside existing `C` commands for primary actuators
- Mapped the deposition door Cytron controller (`#2`) to Teensy PWM pins 33/41 and DIR pins 11/12 based on live hardware testing

### Hardware Documentation Updates
- Updated all hardware documentation files to reflect the final pin mappings for Cytron `#2` (250mm actuators): PWM channels moved to pins 33 and 41
- Documented the new pin assignments in the Teensy 4.1 pin map and software team notes

### Testing & Validation
- Added unit tests for deposition actuator command encoding and drivetrain bridge callback routing
- Verified the implementation through hardware smoke testing with actual deposition actuators responding correctly to ROS commands

### Behavioral Notes
- Deposition actuators retain the hardware-swapped direction convention (positive = extend, negative = retract)
- Deposition actuator commands use full duty cycle (255) by default for reliable operation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->