### PR TITLE
docs: add June 2026 drivetrain bring-up session notes

### DIFF
--- a/docs/session-2026-06-06.md
+++ b/docs/session-2026-06-06.md
@@ -1,0 +1,184 @@
+# Dev Session Notes — 2026-06-06
+
+## Summary
+
+Full drivetrain bring-up session: fixed FR/RR motors, set up Cytron MDD10A #1 actuator
+control via Xbox controller, and established arduino-cli as the standard Teensy flashing workflow.
+
+---
+
+## 1. FR + RR Motors Fixed (Teensy Firmware)
+
+**Problem:** Right-side motors (FR + RR) were not responding. The Sabertooth #2 S1 pin
+is wired to **Teensy pin 29 (Serial7 TX)**, but the firmware was using `Serial2` (pin 8).
+
+**Fix:** Updated `drivetrain_serial_firmware.ino` — replaced all `Serial2` references with
+`Serial7`. Reflashed via arduino-cli (see section 4).
+
+**Current UART assignments:**
+| Serial | Teensy TX Pin | Connected To |
+|--------|--------------|--------------|
+| Serial1 | Pin 1 | Sabertooth #1 — FL + RL motors |
+| Serial7 | Pin 29 | Sabertooth #2 — FR + RR motors |
+
+All 4 drivetrain motors now work via Xbox controller left stick (forward/back) and right
+stick (turn), with Left Bumper held as deadman.
+
+---
+
+## 2. Cytron MDD10A #1 Actuator Control
+
+Two linear actuators on Cytron MDD10A #1 are now controllable via the Xbox controller.
+Both channels move together (same direction simultaneously).
+
+### Button Mapping
+| Button | Action |
+|--------|--------|
+| **LB** (hold) | Deadman — must be held for any control |
+| **Y** | Both actuators extend |
+| **A** | Both actuators retract |
+
+### Pin Map — Cytron MDD10A #1
+| Teensy Pin | Signal | Notes |
+|-----------|--------|-------|
+| 2 | PWM ch1 | Actuator 1 speed |
+| 3 | PWM ch2 | Actuator 2 speed |
+| 9 | DIR ch1 | Actuator 1 direction |
+| 28 | DIR ch2 | Actuator 2 direction — **relocated from pin 10** (solder fault, pin dead) |
+
+### Firmware Command Added
+```
+C <dir1> <dir2>    -1=retract, 0=stop, 1=extend
+```
+Example: `C 1 1` extends both, `C -1 -1` retracts both, `C 0 0` stops both.
+
+### Software Changes Made
+- `tools/teensy/drivetrain_serial_firmware/drivetrain_serial_firmware.ino` — added
+  `CYTRON_PWM[]`, `CYTRON_DIR[]` pin definitions, `setCytronOutputs()`,
+  `setCytronCommand()`, and `C` handler in `handleLine()`
+- `src/lunabot_drivetrain/lunabot_drivetrain/teensy_serial.py` — added
+  `actuator_to_bytes()` and `send_actuator_cmd()`
+- `src/lunabot_drivetrain/lunabot_drivetrain/drivetrain_bridge.py` — added
+  `/actuator/cmd` (`std_msgs/Int8MultiArray`) subscription and
+  `_actuator_cmd_callback()`
+- `tools/teleop_roslibpy.py` — added `BTN_ACT_EXTEND` (Y) / `BTN_ACT_RETRACT` (A)
+  buttons, publishes `[dir, dir]` to `/actuator/cmd` when deadman held
+
+---
+
+## 3. Duplicate Process / Oscillating Gate Issue
+
+**Symptom:** Velocity gate oscillates OPEN/CLOSED at ~10 Hz, motors don't move.
+
+**Cause:** Two sets of `drivetrain_bridge` + `velocity_gate` processes running at the
+same time, both competing for `/dev/ttyACM0`. Each publishes alternating READY/FAULT
+status, causing the gate to flip.
+
+**Fix:**
+```bash
+# Find and kill all drivetrain/rosbridge processes
+ps aux | grep -E '(drivetrain|velocity_gate|rosbridge)' | grep -v grep | awk '{print $2}' | xargs kill -9
+# Wait, then relaunch once
+```
+
+**Root cause:** Using `nohup` over SSH — if you run the launch command twice (e.g.
+reconnect and relaunch without checking), you get duplicates. A tmux-based launch
+script would prevent this (see section 6).
+
+---
+
+## 4. Teensy Flashing — arduino-cli (Standard Workflow)
+
+Arduino IDE GUI replaced with `arduino-cli` for headless flashing.
+
+**CLI path (bundled with Arduino IDE):**
+```
+C:\Users\Proxi\AppData\Local\Programs\Arduino IDE\resources\app\lib\backend\resources\arduino-cli.exe
+```
+
+**One-time setup (already done):**
+```powershell
+$cli = "C:\Users\Proxi\AppData\Local\Programs\Arduino IDE\resources\app\lib\backend\resources\arduino-cli.exe"
+& $cli config add board_manager.additional_urls "https://www.pjrc.com/teensy/package_teensy_index.json"
+& $cli core update-index
+& $cli core install teensy:avr
+```
+
+**Flash workflow (use every time):**
+```powershell
+$cli = "C:\Users\Proxi\AppData\Local\Programs\Arduino IDE\resources\app\lib\backend\resources\arduino-cli.exe"
+$sketch = "C:\Users\Proxi\lunabotics\innex1-rover\tools\teensy\drivetrain_serial_firmware\drivetrain_serial_firmware.ino"
+
+# Compile
+& $cli compile --fqbn teensy:avr:teensy41 $sketch
+
+# Check port (Teensy should appear as teensy protocol)
+& $cli board list
+
+# Upload
+& $cli upload --fqbn teensy:avr:teensy41 -p "usb:0/140000/0/5" $sketch
+```
+
+> **Note:** Teensy must be plugged into the **laptop** for flashing, then moved back to
+> the Jetson. If the port changes after replug, run `board list` again to confirm.
+> After flashing, always replug into the **same USB port** on the Jetson to keep
+> `/dev/ttyACM0` stable.
+
+---
+
+## 5. Standard Launch Sequence (Current)
+
+Run these on the Jetson over SSH each session:
+
+```bash
+# 1. Kill any stale processes first
+ps aux | grep -E '(drivetrain|velocity_gate|rosbridge)' | grep -v grep | awk '{print $2}' | xargs kill -9 2>/dev/null
+
+# 2. Launch rosbridge
+source /opt/ros/humble/setup.bash && source ~/innex1-rover/install/setup.bash
+nohup ros2 launch rosbridge_server rosbridge_websocket_launch.xml > /tmp/rosbridge.log 2>&1 &
+
+# 3. Wait ~4s, then launch drivetrain
+sleep 4
+nohup ros2 launch lunabot_drivetrain drivetrain_bench.launch.py > /tmp/drivetrain.log 2>&1 &
+
+# 4. Verify
+tail -10 /tmp/drivetrain.log
+# Should see: "Gate OPEN — drivetrain healthy"
+```
+
+Then on Windows (PowerShell):
+```powershell
+Start-Process python -ArgumentList "C:\Users\Proxi\lunabotics\innex1-rover\tools\teleop_roslibpy.py", "--topic", "/cmd_vel_safe" -WorkingDirectory "C:\Users\Proxi\lunabotics\innex1-rover"
+```
+
+---
+
+## 6. Jetson Health Notes
+
+| Item | Status |
+|------|--------|
+| Disk usage | 79% (43 GB / 56 GB) — monitor this |
+| ROS logs (`~/.ros/log/`) | 873 MB — safe to `rm -rf ~/.ros/log/*` periodically |
+| Leo Rover packages in `src/external/` | Kept — `lunabot_description` depends on `leo_description` |
+| Tailscale IP | `100.71.241.9` (alias `innex1-jetson` in SSH config) |
+| Teensy serial port | `/dev/ttyACM0` (replug into same USB port to keep consistent) |
+
+**Recommended future improvement:** Replace `nohup` launches with a `tmux` session
+script so you can reattach and see live logs, and avoid accidental duplicate launches.
+
+---
+
+## 7. ROS2 Topic Map (Drivetrain + Actuators)
+
+```
+[teleop_roslibpy.py] ──/cmd_vel_safe──► [velocity_gate] ──/cmd_vel_gated──► [drivetrain_bridge] ──Serial──► Teensy ──► Sabertooth #1/#2
+                    └──/actuator/cmd─────────────────────────────────────────► [drivetrain_bridge] ──Serial──► Teensy ──► Cytron MDD10A #1
+```
+
+| Topic | Type | Publisher | Subscriber |
+|-------|------|-----------|------------|
+| `/cmd_vel_safe` | `geometry_msgs/Twist` | teleop | velocity_gate |
+| `/cmd_vel_gated` | `geometry_msgs/Twist` | velocity_gate | drivetrain_bridge |
+| `/actuator/cmd` | `std_msgs/Int8MultiArray` | teleop | drivetrain_bridge |
+| `/drivetrain/status` | `DrivetrainStatus` | drivetrain_bridge | velocity_gate |

--- a/docs/session-2026-06-06.md
+++ b/docs/session-2026-06-06.md
@@ -1,5 +1,9 @@
 # Dev Session Notes — 2026-06-06
 
+> **Note:** These are point-in-time notes from 2026-06-06. The firmware and software
+> have since evolved (see PR #337 and later). Treat all "current" statements as
+> "at the time of this session", not as today's runbook.
+
 ## Summary
 
 Full drivetrain bring-up session: fixed FR/RR motors, set up Cytron MDD10A #1 actuator
@@ -15,7 +19,7 @@ is wired to **Teensy pin 29 (Serial7 TX)**, but the firmware was using `Serial2`
 **Fix:** Updated `drivetrain_serial_firmware.ino` — replaced all `Serial2` references with
 `Serial7`. Reflashed via arduino-cli (see section 4).
 
-**Current UART assignments:**
+**UART assignments at the time of this session:**
 | Serial | Teensy TX Pin | Connected To |
 |--------|--------------|--------------|
 | Serial1 | Pin 1 | Sabertooth #1 — FL + RL motors |
@@ -63,6 +67,11 @@ Example: `C 1 1` extends both, `C -1 -1` retracts both, `C 0 0` stops both.
   `_actuator_cmd_callback()`
 - `tools/teleop_roslibpy.py` — added `BTN_ACT_EXTEND` (Y) / `BTN_ACT_RETRACT` (A)
   buttons, publishes `[dir, dir]` to `/actuator/cmd` when deadman held
+
+> **Post-session addition (see PR #337):** Deposition door control was added after this
+> session. Cytron MDD10A #2 (pins 33/41/11/12) drives the deposition doors via the `D`
+> firmware command and `/deposition/actuator/cmd` ROS topic. Button mapping: X = extend
+> doors `[1, 1]`, B = retract doors `[-1, -1]`.
 
 ---
 
@@ -126,7 +135,7 @@ $sketch = "C:\Users\Proxi\lunabotics\innex1-rover\tools\teensy\drivetrain_serial
 
 ---
 
-## 5. Standard Launch Sequence (Current)
+## 5. Launch Sequence (As of This Session)
 
 Run these on the Jetson over SSH each session:
 
@@ -162,23 +171,28 @@ Start-Process python -ArgumentList "C:\Users\Proxi\lunabotics\innex1-rover\tools
 | ROS logs (`~/.ros/log/`) | 873 MB — safe to `rm -rf ~/.ros/log/*` periodically |
 | Leo Rover packages in `src/external/` | Kept — `lunabot_description` depends on `leo_description` |
 | Tailscale IP | `100.71.241.9` (alias `innex1-jetson` in SSH config) |
-| Teensy serial port | `/dev/ttyACM0` (replug into same USB port to keep consistent) |
+| Teensy serial port | `/dev/ttyACM0` used during this session. Prefer the stable udev by-id path: `/dev/serial/by-id/usb-Teensyduino_USB_Serial_19852100-if00` |
 
 **Recommended future improvement:** Replace `nohup` launches with a `tmux` session
 script so you can reattach and see live logs, and avoid accidental duplicate launches.
 
 ---
 
-## 7. ROS2 Topic Map (Drivetrain + Actuators)
+## 7. ROS2 Topic Map (As of This Session + Post-Session Additions)
 
 ```
-[teleop_roslibpy.py] ──/cmd_vel_safe──► [velocity_gate] ──/cmd_vel_gated──► [drivetrain_bridge] ──Serial──► Teensy ──► Sabertooth #1/#2
-                    └──/actuator/cmd─────────────────────────────────────────► [drivetrain_bridge] ──Serial──► Teensy ──► Cytron MDD10A #1
+[teleop_roslibpy.py] ──/cmd_vel_safe──────────► [velocity_gate] ──/cmd_vel_gated──► [drivetrain_bridge] ──Serial──► Teensy ──► Sabertooth #1/#2
+                    ├──/actuator/cmd────────────────────────────────────────────────► [drivetrain_bridge] ──Serial──► Teensy ──► Cytron MDD10A #1
+                    ├──/deposition/actuator/cmd─────────────────────────────────────► [drivetrain_bridge] ──Serial──► Teensy ──► Cytron MDD10A #2
+                    └──/safety/estop────────────────────────────────────────────────► [drivetrain_bridge] (latches motors off)
 ```
 
-| Topic | Type | Publisher | Subscriber |
-|-------|------|-----------|------------|
-| `/cmd_vel_safe` | `geometry_msgs/Twist` | teleop | velocity_gate |
-| `/cmd_vel_gated` | `geometry_msgs/Twist` | velocity_gate | drivetrain_bridge |
-| `/actuator/cmd` | `std_msgs/Int8MultiArray` | teleop | drivetrain_bridge |
-| `/drivetrain/status` | `DrivetrainStatus` | drivetrain_bridge | velocity_gate |
+| Topic | Type | Publisher | Subscriber | Added |
+|-------|------|-----------|------------|-------|
+| `/cmd_vel_safe` | `geometry_msgs/Twist` | teleop | velocity_gate | this session |
+| `/cmd_vel_gated` | `geometry_msgs/Twist` | velocity_gate | drivetrain_bridge | this session |
+| `/actuator/cmd` | `std_msgs/Int8MultiArray` | teleop | drivetrain_bridge | this session |
+| `/drivetrain/status` | `DrivetrainStatus` | drivetrain_bridge | velocity_gate | this session |
+| `/deposition/actuator/cmd` | `std_msgs/Int8MultiArray` | teleop | drivetrain_bridge | post-session (PR #337) |
+| `/safety/estop` | `std_msgs/Bool` | teleop | drivetrain_bridge | post-session (PR #337) |
+| `/safety/motion_inhibit` | `std_msgs/Bool` | safety node | drivetrain_bridge | post-session (PR #337) |


### PR DESCRIPTION
## Summary

- Adds `docs/session-2026-06-06.md` — historical notes from the full drivetrain bring-up session
- Clearly scoped as point-in-time notes (top-level callout added so it doesn't read as a live runbook)
- Documents: FR/RR motor fix (Serial2 → Serial7), Cytron MDD10A #1 actuator wiring, oscillating velocity-gate diagnosis, arduino-cli flashing workflow, launch sequence, and the ROS2 topic map
- Post-session additions (PR #337) noted inline: Cytron MDD10A #2 deposition doors (`D` command, X/B buttons, `/deposition/actuator/cmd`), `/safety/estop`, `/safety/motion_inhibit`
- Serial port note updated to reference the stable udev by-id path
- Section 7 topic map expanded to include all current topics with an 'Added' column

## Test plan

- [ ] Read through and verify accuracy against current firmware and bridge code
- [ ] Confirm topic map matches `ros2 topic list` output during a live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)